### PR TITLE
PXB-2627 - Remove debian Stretch from jenkins axis

### DIFF
--- a/pxb/v2/jenkins/percona-xtrabackup-8.0-compile-param.yml
+++ b/pxb/v2/jenkins/percona-xtrabackup-8.0-compile-param.yml
@@ -52,7 +52,6 @@
          - centos:8
          - ubuntu:bionic
          - ubuntu:focal
-         - debian:stretch
          - debian:buster
          - asan
     builders:

--- a/pxb/v2/jenkins/percona-xtrabackup-8.0-compile-pipeline.groovy
+++ b/pxb/v2/jenkins/percona-xtrabackup-8.0-compile-pipeline.groovy
@@ -13,7 +13,7 @@ pipeline {
             name: 'BRANCH',
             trim: true)
         choice(
-            choices: 'centos:7\ncentos:8\nubuntu:bionic\nubuntu:focal\ndebian:stretch\ndebian:buster\nasan',
+            choices: 'centos:7\ncentos:8\nubuntu:bionic\nubuntu:focal\ndebian:buster\nasan',
             description: 'OS version for compilation',
             name: 'DOCKER_OS')
         choice(

--- a/pxb/v2/jenkins/percona-xtrabackup-8.0-compile-pipeline.yml
+++ b/pxb/v2/jenkins/percona-xtrabackup-8.0-compile-pipeline.yml
@@ -29,7 +29,6 @@
         - centos:8
         - ubuntu:bionic
         - ubuntu:focal
-        - debian:stretch
         - debian:buster
         - asan
         description: OS version for compilation

--- a/pxb/v2/jenkins/percona-xtrabackup-8.0-test-param.yml
+++ b/pxb/v2/jenkins/percona-xtrabackup-8.0-test-param.yml
@@ -58,7 +58,6 @@
         - centos:8
         - ubuntu:bionic
         - ubuntu:focal
-        - debian:stretch
         - debian:buster
         - asan
     - axis:

--- a/pxb/v2/jenkins/percona-xtrabackup-8.0-test-pipeline.groovy
+++ b/pxb/v2/jenkins/percona-xtrabackup-8.0-test-pipeline.groovy
@@ -3,7 +3,7 @@ pipeline_timeout = 10
 pipeline {
     parameters {
         choice(
-            choices: 'centos:7\ncentos:8\nubuntu:bionic\nubuntu:focal\ndebian:stretch\ndebian:buster\nasan',
+            choices: 'centos:7\ncentos:8\nubuntu:bionic\nubuntu:focal\ndebian:buster\nasan',
             description: 'OS version for compilation',
             name: 'DOCKER_OS')
         choice(

--- a/pxb/v2/jenkins/percona-xtrabackup-8.0-test-pipeline.yml
+++ b/pxb/v2/jenkins/percona-xtrabackup-8.0-test-pipeline.yml
@@ -21,7 +21,6 @@
           - centos:8
           - ubuntu:bionic
           - ubuntu:focal
-          - debian:stretch
           - debian:buster
           - asan
         description: OS version for compilation


### PR DESCRIPTION
Removed debian Stretch from Jenkins axis since upstream doesn't support
it anymore.