### PR TITLE
PMM-7 Remove unnecessary GitHub workflow triggers

### DIFF
--- a/pmm/pmm2-submodules.groovy
+++ b/pmm/pmm2-submodules.groovy
@@ -334,25 +334,9 @@ pipeline {
                                 -d "{\\"body\\":\\"server docker - ${IMAGE}\\nclient docker - ${CLIENT_IMAGE}\\nclient - ${CLIENT_URL}\\nCreate Staging Instance: https://pmm.cd.percona.com/job/aws-staging-start/parambuild/?DOCKER_VERSION=${IMAGE}&CLIENT_VERSION=${CLIENT_URL}\\"}" \
                                 "https://api.github.com/repos/\$(echo $CHANGE_URL | cut -d '/' -f 4-5)/issues/${CHANGE_ID}/comments"
                         """
-                        // trigger workflow in GH to run some test there as well, pass server and client images as parameters
                         def FB_COMMIT_HASH = sh(returnStdout: true, script: "cat fbCommitSha").trim()
-                        sh """
-                            curl -v -X POST \
-                                -H "Accept: application/vnd.github.v3+json" \
-                                -H "Authorization: token ${GITHUB_API_TOKEN}" \
-                                "https://api.github.com/repos/\$(echo $CHANGE_URL | cut -d '/' -f 4-5)/actions/workflows/jenkins-dispatch.yml/dispatches" \
-                                -d '{"ref":"${CHANGE_BRANCH}","inputs":{"server_image":"${IMAGE}","client_image":"${CLIENT_IMAGE}","sha":"${FB_COMMIT_HASH}"}}'
-                        """
-                        // trigger workflow in GH to run PMM binary cli tests
-                        sh """
-                            curl -v -X POST \
-                                -H "Accept: application/vnd.github.v3+json" \
-                                -H "Authorization: token ${GITHUB_API_TOKEN}" \
-                                "https://api.github.com/repos/\$(echo $CHANGE_URL | cut -d '/' -f 4-5)/actions/workflows/pmm-cli.yml/dispatches" \
-                                -d '{"ref":"${CHANGE_BRANCH}","inputs":{"client_tar_url":"${CLIENT_URL}","sha":"${FB_COMMIT_HASH}"}}'
-                        """
-                        // trigger workflow in GH to run testsuite tests
                         def PMM_QA_GIT_BRANCH = sh(returnStdout: true, script: "cat pmmQABranch").trim()
+                        // trigger workflow in GH to run testsuite tests
                         sh """
                             curl -v -X POST \
                                 -H "Accept: application/vnd.github.v3+json" \


### PR DESCRIPTION
The update removes several GitHub workflow triggers from the 'pmm2-submodules.groovy' file. This simplifies the code by getting rid of the commands used to trigger some tests and workflows in GitHub. The changes aim to streamline the testing process and eliminate redundancy in action calls.