### PR TITLE
CLOUD-888 Fix failing EKS pipelines because of a change how latest version is detected

### DIFF
--- a/cloud/jenkins/ps_operator_eks_latest.groovy
+++ b/cloud/jenkins/ps_operator_eks_latest.groovy
@@ -29,7 +29,7 @@ void prepareNode() {
 
 void prepareSources() {
     if ("$PLATFORM_VER" == "latest") {
-        USED_PLATFORM_VER = sh(script: "eksctl version -ojson | jq -r '.EKSServerSupportedVersions | max'", , returnStdout: true).trim()
+        USED_PLATFORM_VER = sh(script: "aws eks describe-addon-versions --query 'addons[].addonVersions[].compatibilities[].clusterVersion' --output json | jq -r 'flatten | unique | sort | reverse | .[0]'", , returnStdout: true).trim()
     } else {
         USED_PLATFORM_VER="$PLATFORM_VER"
     }

--- a/cloud/jenkins/ps_operator_eks_version.groovy
+++ b/cloud/jenkins/ps_operator_eks_version.groovy
@@ -29,7 +29,7 @@ void prepareNode() {
 
 void prepareSources() {
     if ("$PLATFORM_VER" == "latest") {
-        USED_PLATFORM_VER = sh(script: "eksctl version -ojson | jq -r '.EKSServerSupportedVersions | max'", , returnStdout: true).trim()
+        USED_PLATFORM_VER = sh(script: "aws eks describe-addon-versions --query 'addons[].addonVersions[].compatibilities[].clusterVersion' --output json | jq -r 'flatten | unique | sort | reverse | .[0]'", , returnStdout: true).trim()
     } else {
         USED_PLATFORM_VER="$PLATFORM_VER"
     }


### PR DESCRIPTION
Newer versions of `eksctl` don’t include `EKSServerSupportedVersions` in the version output, do we have to use smt. else, for example the aws tool itself:
`aws eks describe-addon-versions --query 'addons[].addonVersions[].compatibilities[].clusterVersion' --output json | jq -r 'flatten | unique | sort | reverse | .[0]'
`