### PR TITLE
PKG-685 : jenkins-job-builder unable to publish if there is xml binar…

### DIFF
--- a/pxb/v2/jenkins/percona-xtrabackup-8.0-compile-param.yml
+++ b/pxb/v2/jenkins/percona-xtrabackup-8.0-compile-param.yml
@@ -81,29 +81,38 @@
         gunzip build.log.gz
     publishers:
     - raw:
-        xml: !!binary |
-          PGlvLmplbmtpbnMucGx1Z2lucy5hbmFseXNpcy5jb3JlLnN0ZXBzLklzc3Vlc1JlY29yZGVyIHBs
-          dWdpbj0id2FybmluZ3MtbmdAOS4wLjEiPgogICAgICA8YW5hbHlzaXNUb29scz4KICAgICAgICA8
-          aW8uamVua2lucy5wbHVnaW5zLmFuYWx5c2lzLndhcm5pbmdzLkdjYzQ+CiAgICAgICAgICA8aWQg
-          Lz4KICAgICAgICAgIDxuYW1lIC8+CiAgICAgICAgICA8cGF0dGVybj4qKi9idWlsZC5sb2c8L3Bh
-          dHRlcm4+CiAgICAgICAgICA8cmVwb3J0RW5jb2RpbmcgLz4KICAgICAgICAgIDxza2lwU3ltYm9s
-          aWNMaW5rcz5mYWxzZTwvc2tpcFN5bWJvbGljTGlua3M+CiAgICAgICAgPC9pby5qZW5raW5zLnBs
-          dWdpbnMuYW5hbHlzaXMud2FybmluZ3MuR2NjND4KICAgICAgPC9hbmFseXNpc1Rvb2xzPgogICAg
-          ICA8c291cmNlQ29kZUVuY29kaW5nIC8+CiAgICAgIDxzb3VyY2VEaXJlY3RvcnkgLz4KICAgICAg
-          PGlnbm9yZVF1YWxpdHlHYXRlPmZhbHNlPC9pZ25vcmVRdWFsaXR5R2F0ZT4KICAgICAgPGlnbm9y
-          ZUZhaWxlZEJ1aWxkcz50cnVlPC9pZ25vcmVGYWlsZWRCdWlsZHM+CiAgICAgIDxmYWlsT25FcnJv
-          cj5mYWxzZTwvZmFpbE9uRXJyb3I+CiAgICAgIDxoZWFsdGh5PjA8L2hlYWx0aHk+CiAgICAgIDx1
-          bmhlYWx0aHk+MDwvdW5oZWFsdGh5PgogICAgICA8bWluaW11bVNldmVyaXR5IHBsdWdpbj0iYW5h
-          bHlzaXMtbW9kZWwtYXBpQDEwLjAuMCI+CiAgICAgICAgPG5hbWU+TE9XPC9uYW1lPgogICAgICA8
-          L21pbmltdW1TZXZlcml0eT4KICAgICAgPGZpbHRlcnMgLz4KICAgICAgPGlzRW5hYmxlZEZvckZh
-          aWx1cmU+dHJ1ZTwvaXNFbmFibGVkRm9yRmFpbHVyZT4KICAgICAgPGlzQWdncmVnYXRpbmdSZXN1
-          bHRzPmZhbHNlPC9pc0FnZ3JlZ2F0aW5nUmVzdWx0cz4KICAgICAgPGlzQmxhbWVEaXNhYmxlZD5m
-          YWxzZTwvaXNCbGFtZURpc2FibGVkPgogICAgICA8c2tpcFB1Ymxpc2hpbmdDaGVja3M+ZmFsc2U8
-          L3NraXBQdWJsaXNoaW5nQ2hlY2tzPgogICAgICA8cHVibGlzaEFsbElzc3Vlcz5mYWxzZTwvcHVi
-          bGlzaEFsbElzc3Vlcz4KICAgICAgPHF1YWxpdHlHYXRlcyAvPgogICAgICA8dHJlbmRDaGFydFR5
-          cGU+QUdHUkVHQVRJT05fVE9PTFM8L3RyZW5kQ2hhcnRUeXBlPgogICAgICA8c2NtIC8+CiAgICA8
-          L2lvLmplbmtpbnMucGx1Z2lucy5hbmFseXNpcy5jb3JlLnN0ZXBzLklzc3Vlc1JlY29yZGVyPgog
-          IA==
+        xml: |
+          <?xml version="1.0"?>
+          <io.jenkins.plugins.analysis.core.steps.IssuesRecorder plugin="warnings-ng@9.0.1">
+            <analysisTools>
+              <io.jenkins.plugins.analysis.warnings.Gcc4>
+                <id/>
+                <name/>
+                <pattern>**/build.log</pattern>
+                <reportEncoding/>
+                <skipSymbolicLinks>false</skipSymbolicLinks>
+              </io.jenkins.plugins.analysis.warnings.Gcc4>
+            </analysisTools>
+            <sourceCodeEncoding/>
+            <sourceDirectory/>
+            <ignoreQualityGate>false</ignoreQualityGate>
+            <ignoreFailedBuilds>true</ignoreFailedBuilds>
+            <failOnError>false</failOnError>
+            <healthy>0</healthy>
+            <unhealthy>0</unhealthy>
+            <minimumSeverity plugin="analysis-model-api@10.0.0">
+              <name>LOW</name>
+            </minimumSeverity>
+            <filters/>
+            <isEnabledForFailure>true</isEnabledForFailure>
+            <isAggregatingResults>false</isAggregatingResults>
+            <isBlameDisabled>false</isBlameDisabled>
+            <skipPublishingChecks>false</skipPublishingChecks>
+            <publishAllIssues>false</publishAllIssues>
+            <qualityGates/>
+            <trendChartType>AGGREGATION_TOOLS</trendChartType>
+            <scm/>
+          </io.jenkins.plugins.analysis.core.steps.IssuesRecorder>
     - archive:
         artifacts: 'PIPELINE_BUILD_NUMBER'
     - archive:

--- a/pxb/v2/jenkins/percona-xtrabackup-8.0-trunk.yml
+++ b/pxb/v2/jenkins/percona-xtrabackup-8.0-trunk.yml
@@ -51,29 +51,38 @@
         echo "${TRIGGERED_BUILD_NUMBERS_percona_xtrabackup_8_0_test_param}" > TEST_PIPELINE_BUILD_NUMBER
     publishers:
     - raw:
-        xml: !!binary |
-          PGlvLmplbmtpbnMucGx1Z2lucy5hbmFseXNpcy5jb3JlLnN0ZXBzLklzc3Vlc1JlY29yZGVyIHBs
-          dWdpbj0id2FybmluZ3MtbmdAOS4wLjEiPgogICAgICA8YW5hbHlzaXNUb29scz4KICAgICAgICA8
-          aW8uamVua2lucy5wbHVnaW5zLmFuYWx5c2lzLndhcm5pbmdzLkdjYzQ+CiAgICAgICAgICA8aWQg
-          Lz4KICAgICAgICAgIDxuYW1lIC8+CiAgICAgICAgICA8cGF0dGVybj4qKi9idWlsZC5sb2c8L3Bh
-          dHRlcm4+CiAgICAgICAgICA8cmVwb3J0RW5jb2RpbmcgLz4KICAgICAgICAgIDxza2lwU3ltYm9s
-          aWNMaW5rcz5mYWxzZTwvc2tpcFN5bWJvbGljTGlua3M+CiAgICAgICAgPC9pby5qZW5raW5zLnBs
-          dWdpbnMuYW5hbHlzaXMud2FybmluZ3MuR2NjND4KICAgICAgPC9hbmFseXNpc1Rvb2xzPgogICAg
-          ICA8c291cmNlQ29kZUVuY29kaW5nIC8+CiAgICAgIDxzb3VyY2VEaXJlY3RvcnkgLz4KICAgICAg
-          PGlnbm9yZVF1YWxpdHlHYXRlPmZhbHNlPC9pZ25vcmVRdWFsaXR5R2F0ZT4KICAgICAgPGlnbm9y
-          ZUZhaWxlZEJ1aWxkcz50cnVlPC9pZ25vcmVGYWlsZWRCdWlsZHM+CiAgICAgIDxmYWlsT25FcnJv
-          cj5mYWxzZTwvZmFpbE9uRXJyb3I+CiAgICAgIDxoZWFsdGh5PjA8L2hlYWx0aHk+CiAgICAgIDx1
-          bmhlYWx0aHk+MDwvdW5oZWFsdGh5PgogICAgICA8bWluaW11bVNldmVyaXR5IHBsdWdpbj0iYW5h
-          bHlzaXMtbW9kZWwtYXBpQDEwLjAuMCI+CiAgICAgICAgPG5hbWU+TE9XPC9uYW1lPgogICAgICA8
-          L21pbmltdW1TZXZlcml0eT4KICAgICAgPGZpbHRlcnMgLz4KICAgICAgPGlzRW5hYmxlZEZvckZh
-          aWx1cmU+dHJ1ZTwvaXNFbmFibGVkRm9yRmFpbHVyZT4KICAgICAgPGlzQWdncmVnYXRpbmdSZXN1
-          bHRzPmZhbHNlPC9pc0FnZ3JlZ2F0aW5nUmVzdWx0cz4KICAgICAgPGlzQmxhbWVEaXNhYmxlZD5m
-          YWxzZTwvaXNCbGFtZURpc2FibGVkPgogICAgICA8c2tpcFB1Ymxpc2hpbmdDaGVja3M+ZmFsc2U8
-          L3NraXBQdWJsaXNoaW5nQ2hlY2tzPgogICAgICA8cHVibGlzaEFsbElzc3Vlcz5mYWxzZTwvcHVi
-          bGlzaEFsbElzc3Vlcz4KICAgICAgPHF1YWxpdHlHYXRlcyAvPgogICAgICA8dHJlbmRDaGFydFR5
-          cGU+QUdHUkVHQVRJT05fVE9PTFM8L3RyZW5kQ2hhcnRUeXBlPgogICAgICA8c2NtIC8+CiAgICA8
-          L2lvLmplbmtpbnMucGx1Z2lucy5hbmFseXNpcy5jb3JlLnN0ZXBzLklzc3Vlc1JlY29yZGVyPgog
-          IA==
+        xml: |
+          <?xml version="1.0"?>
+          <io.jenkins.plugins.analysis.core.steps.IssuesRecorder plugin="warnings-ng@9.0.1">
+            <analysisTools>
+              <io.jenkins.plugins.analysis.warnings.Gcc4>
+                <id/>
+                <name/>
+                <pattern>**/build.log</pattern>
+                <reportEncoding/>
+                <skipSymbolicLinks>false</skipSymbolicLinks>
+              </io.jenkins.plugins.analysis.warnings.Gcc4>
+            </analysisTools>
+            <sourceCodeEncoding/>
+            <sourceDirectory/>
+            <ignoreQualityGate>false</ignoreQualityGate>
+            <ignoreFailedBuilds>true</ignoreFailedBuilds>
+            <failOnError>false</failOnError>
+            <healthy>0</healthy>
+            <unhealthy>0</unhealthy>
+            <minimumSeverity plugin="analysis-model-api@10.0.0">
+              <name>LOW</name>
+            </minimumSeverity>
+            <filters/>
+            <isEnabledForFailure>true</isEnabledForFailure>
+            <isAggregatingResults>false</isAggregatingResults>
+            <isBlameDisabled>false</isBlameDisabled>
+            <skipPublishingChecks>false</skipPublishingChecks>
+            <publishAllIssues>false</publishAllIssues>
+            <qualityGates/>
+            <trendChartType>AGGREGATION_TOOLS</trendChartType>
+            <scm/>
+          </io.jenkins.plugins.analysis.core.steps.IssuesRecorder>
     - junit:
         results: "**/junit.xml"
         keep-long-stdio: true


### PR DESCRIPTION
…y data in the YML file

Key Points:
JJB ≥ 4.0.0 switched from PyYAML to ruamel.yaml for parsing, which treats !!binary differently JJB 3.x and earlier used PyYAML, which allowed !!binary for Base64-encoded data JJB 4.0.0+ no longer supports !!binary out-of-the-box with ruamel.yaml

Fix:
Convert Base64 decoded string to regular string and remove the !!binary