### PR TITLE
Replace personal GitHub URLs with official repository URL

### DIFF
--- a/cloud/jenkins/openshift-cluster-create.yml
+++ b/cloud/jenkins/openshift-cluster-create.yml
@@ -1,174 +1,166 @@
 - job:
-      name: openshift-cluster-create
-      project-type: pipeline
-      description: |
-          Create OpenShift clusters on AWS with configurable parameters.
+    name: openshift-cluster-create
+    project-type: pipeline
+    description: |
+      Create OpenShift clusters on AWS with configurable parameters.
 
-          This job creates production-ready OpenShift clusters with:
-          - Multiple OpenShift versions (4.16-4.19)
-          - Standard x86_64 instance types (m5, m6i, c5)
-          - Automatic cluster state backup to S3
-          - Billing tags for cost tracking
-          - Optional PMM deployment
+      This job creates production-ready OpenShift clusters with:
+      - Multiple OpenShift versions (4.16-4.19)
+      - Standard x86_64 instance types (m5, m6i, c5)
+      - Automatic cluster state backup to S3
+      - Billing tags for cost tracking
+      - Optional PMM deployment
 
-          Note: Uses AMD64 (x86_64) architecture for PMM compatibility.
-          The cluster state is saved to S3 for later destruction.
-
-      parameters:
-          # === Basic Cluster Configuration ===
-          - string:
-                name: CLUSTER_NAME
-                default: test-cluster
-                description: "Name for the OpenShift cluster (lowercase, alphanumeric, hyphens only, max 20 chars)"
-                trim: true
-          - choice:
-                name: OPENSHIFT_VERSION
-                choices:
-                    # Dynamic list - Last 5 patches from each minor version (4.16-4.19)
-                    # Updated: 2025-08-07 via show-last-5-patches.sh
-                    - "latest"
-                    # --- OpenShift 4.19 (Latest 5 stable patches) ---
-                    - "4.19.6"
-                    - "4.19.5"
-                    - "4.19.4"
-                    - "4.19.3"
-                    - "4.19.2"
-                    # --- OpenShift 4.18 (Latest 5 stable patches) ---
-                    - "4.18.9"
-                    - "4.18.8"
-                    - "4.18.7"
-                    - "4.18.6"
-                    - "4.18.5"
-                    # --- OpenShift 4.17 (Latest 5 stable patches) ---
-                    - "4.17.9"
-                    - "4.17.8"
-                    - "4.17.7"
-                    - "4.17.6"
-                    - "4.17.5"
-                    # --- OpenShift 4.16 (Latest 5 stable patches) ---
-                    - "4.16.9"
-                    - "4.16.8"
-                    - "4.16.7"
-                    - "4.16.6"
-                    - "4.16.5"
-                    # --- Release Channels (Always Latest) ---
-                    - "stable-4.19"
-                    - "stable-4.18"
-                    - "stable-4.17"
-                    - "stable-4.16"
-                    # --- Fast Channels (Newer releases) ---
-                    - "fast-4.19"
-                    - "fast-4.18"
-                    - "fast-4.17"
-                    - "fast-4.16"
-                    # --- Candidate Channels (Pre-release) ---
-                    - "candidate-4.19"
-                    - "candidate-4.18"
-                    - "candidate-4.17"
-                    - "candidate-4.16"
-                description: "OpenShift version to install (specific version or channel)"
-          - choice:
-                name: AWS_REGION
-                choices:
-                    - "us-east-2"
-                description: "AWS region for the cluster (currently limited to us-east-2)"
-
-          # === Compute Resources ===
-          - choice:
-                name: WORKER_COUNT
-                choices:
-                    - "3"
-                    - "2"
-                    - "4"
-                    - "5"
-                    - "6"
-                description: "Number of worker nodes"
-          - choice:
-                name: WORKER_INSTANCE_TYPE
-                choices:
-                    - "m5.large"
-                    - "m5.xlarge"
-                    - "m5.2xlarge"
-                    - "m6i.large"
-                    - "m6i.xlarge"
-                description: "EC2 instance type for worker nodes (x86_64)"
-          - choice:
-                name: MASTER_INSTANCE_TYPE
-                choices:
-                    - "m5.xlarge"
-                    - "m5.2xlarge"
-                    - "m6i.xlarge"
-                    - "m6i.2xlarge"
-                    - "c5.2xlarge"
-                description: "EC2 instance type for master nodes (x86_64)"
-
-          # === PMM Configuration ===
-          - bool:
-                name: DEPLOY_PMM
-                default: true
-                description: "Deploy Percona Monitoring and Management (PMM) after cluster creation"
-          - string:
-                name: PMM_IMAGE_TAG
-                default: "3.3.1"
-                description: "Docker image tag for PMM server (e.g., 3.3.1, 3.3.1-rc, 3-dev-latest, 202508040905, PR-1234)"
-                trim: true
-          - string:
-                name: PMM_HELM_CHART_VERSION
-                default: "1.4.7"
-                description: "Helm chart version for PMM deployment (default: 1.4.7 for PMM 3.x)"
-                trim: true
-          - string:
-                name: PMM_IMAGE_REPOSITORY
-                default: "percona/pmm-server"
-                description: "Docker image repository (e.g., percona/pmm-server, perconalab/pmm-server)"
-                trim: true
-          - string:
-                name: PMM_ADMIN_PASSWORD
-                default: "<GENERATED>"
-                description: "Admin password for PMM web interface (if deployed, use '<GENERATED>' or leave empty for auto-generated password)"
-                trim: true
-
-          # === Resource Tags & Lifecycle ===
-          - string:
-                name: DELETE_AFTER_HOURS
-                default: "8"
-                description: "Auto-delete cluster after this many hours (1-168, for cost control)"
-                trim: true
-          - string:
-                name: TEAM_NAME
-                default: "cloud"
-                description: "Team name for resource tracking and billing"
-                trim: true
-          - string:
-                name: PRODUCT_TAG
-                default: "pg-operator"
-                description: "Product/project tag for billing allocation"
-                trim: true
-
-          # === Advanced Options ===
-          - string:
-                name: BASE_DOMAIN
-                default: "cd.percona.com"
-                description: "Base domain for cluster URLs (rarely changed)"
-                trim: true
-          - bool:
-                name: DEBUG_MODE
-                default: false
-                description: "Enable debug logging for troubleshooting cluster creation issues"
-
-      pipeline-scm:
-          scm:
-              - git:
-                    url: https://github.com/Percona-Lab/jenkins-pipelines.git
-                    branches:
-                        - "master"
-                    wipe-workspace: false
-          lightweight-checkout: true
-          script-path: cloud/jenkins/openshift_cluster_create.groovy
-
-      concurrent: true
-
-      properties:
-          - build-discarder:
-                days-to-keep: 30
-                num-to-keep: 100
+      Note: Uses AMD64 (x86_64) architecture for PMM compatibility.
+      The cluster state is saved to S3 for later destruction.
+    parameters:
+      # === Basic Cluster Configuration ===
+      - string:
+          name: CLUSTER_NAME
+          default: test-cluster
+          description: "Name for the OpenShift cluster (lowercase, alphanumeric, hyphens only, max 20 chars)"
+          trim: true
+      - choice:
+          name: OPENSHIFT_VERSION
+          choices:
+            # Dynamic list - Last 5 patches from each minor version (4.16-4.19)
+            # Updated: 2025-08-07 via show-last-5-patches.sh
+            - "latest"
+            # --- OpenShift 4.19 (Latest 5 stable patches) ---
+            - "4.19.6"
+            - "4.19.5"
+            - "4.19.4"
+            - "4.19.3"
+            - "4.19.2"
+            # --- OpenShift 4.18 (Latest 5 stable patches) ---
+            - "4.18.9"
+            - "4.18.8"
+            - "4.18.7"
+            - "4.18.6"
+            - "4.18.5"
+            # --- OpenShift 4.17 (Latest 5 stable patches) ---
+            - "4.17.9"
+            - "4.17.8"
+            - "4.17.7"
+            - "4.17.6"
+            - "4.17.5"
+            # --- OpenShift 4.16 (Latest 5 stable patches) ---
+            - "4.16.9"
+            - "4.16.8"
+            - "4.16.7"
+            - "4.16.6"
+            - "4.16.5"
+            # --- Release Channels (Always Latest) ---
+            - "stable-4.19"
+            - "stable-4.18"
+            - "stable-4.17"
+            - "stable-4.16"
+            # --- Fast Channels (Newer releases) ---
+            - "fast-4.19"
+            - "fast-4.18"
+            - "fast-4.17"
+            - "fast-4.16"
+            # --- Candidate Channels (Pre-release) ---
+            - "candidate-4.19"
+            - "candidate-4.18"
+            - "candidate-4.17"
+            - "candidate-4.16"
+          description: "OpenShift version to install (specific version or channel)"
+      - choice:
+          name: AWS_REGION
+          choices:
+            - "us-east-2"
+          description: "AWS region for the cluster (currently limited to us-east-2)"
+      # === Compute Resources ===
+      - choice:
+          name: WORKER_COUNT
+          choices:
+            - "3"
+            - "2"
+            - "4"
+            - "5"
+            - "6"
+          description: "Number of worker nodes"
+      - choice:
+          name: WORKER_INSTANCE_TYPE
+          choices:
+            - "m5.large"
+            - "m5.xlarge"
+            - "m5.2xlarge"
+            - "m6i.large"
+            - "m6i.xlarge"
+          description: "EC2 instance type for worker nodes (x86_64)"
+      - choice:
+          name: MASTER_INSTANCE_TYPE
+          choices:
+            - "m5.xlarge"
+            - "m5.2xlarge"
+            - "m6i.xlarge"
+            - "m6i.2xlarge"
+            - "c5.2xlarge"
+          description: "EC2 instance type for master nodes (x86_64)"
+      # === PMM Configuration ===
+      - bool:
+          name: DEPLOY_PMM
+          default: true
+          description: "Deploy Percona Monitoring and Management (PMM) after cluster creation"
+      - string:
+          name: PMM_IMAGE_TAG
+          default: "3.3.1"
+          description: "Docker image tag for PMM server (e.g., 3.3.1, 3.3.1-rc, 3-dev-latest, 202508040905, PR-1234)"
+          trim: true
+      - string:
+          name: PMM_HELM_CHART_VERSION
+          default: "1.4.7"
+          description: "Helm chart version for PMM deployment (default: 1.4.7 for PMM 3.x)"
+          trim: true
+      - string:
+          name: PMM_IMAGE_REPOSITORY
+          default: "percona/pmm-server"
+          description: "Docker image repository (e.g., percona/pmm-server, perconalab/pmm-server)"
+          trim: true
+      - string:
+          name: PMM_ADMIN_PASSWORD
+          default: "<GENERATED>"
+          description: "Admin password for PMM web interface (if deployed, use '<GENERATED>' or leave empty for auto-generated password)"
+          trim: true
+      # === Resource Tags & Lifecycle ===
+      - string:
+          name: DELETE_AFTER_HOURS
+          default: "8"
+          description: "Auto-delete cluster after this many hours (1-168, for cost control)"
+          trim: true
+      - string:
+          name: TEAM_NAME
+          default: "cloud"
+          description: "Team name for resource tracking and billing"
+          trim: true
+      - string:
+          name: PRODUCT_TAG
+          default: "pg-operator"
+          description: "Product/project tag for billing allocation"
+          trim: true
+      # === Advanced Options ===
+      - string:
+          name: BASE_DOMAIN
+          default: "cd.percona.com"
+          description: "Base domain for cluster URLs (rarely changed)"
+          trim: true
+      - bool:
+          name: DEBUG_MODE
+          default: false
+          description: "Enable debug logging for troubleshooting cluster creation issues"
+    pipeline-scm:
+      scm:
+        - git:
+            url: https://github.com/Percona-Lab/jenkins-pipelines.git
+            branches:
+              - "master"
+            wipe-workspace: false
+      lightweight-checkout: true
+      script-path: cloud/jenkins/openshift_cluster_create.groovy
+    concurrent: true
+    properties:
+      - build-discarder:
+          days-to-keep: 30
+          num-to-keep: 100

--- a/cloud/jenkins/openshift-cluster-destroy.yml
+++ b/cloud/jenkins/openshift-cluster-destroy.yml
@@ -2,16 +2,15 @@
     name: openshift-cluster-destroy
     project-type: pipeline
     description: |
-        Destroy OpenShift clusters on AWS.
+      Destroy OpenShift clusters on AWS.
 
-        This job:
-        - Downloads cluster state from S3
-        - Destroys all cluster resources
-        - Cleans up S3 backup (optional)
-        - Verifies resource cleanup
+      This job:
+      - Downloads cluster state from S3
+      - Destroys all cluster resources
+      - Cleans up S3 backup (optional)
+      - Verifies resource cleanup
 
-        WARNING: This operation is irreversible!
-
+      WARNING: This operation is irreversible!
     parameters:
       - string:
           name: CLUSTER_NAME
@@ -37,19 +36,16 @@
             - 'error-cleanup'
             - 'other'
           description: 'Reason for cluster destruction'
-
     pipeline-scm:
       scm:
         - git:
             url: https://github.com/Percona-Lab/jenkins-pipelines.git
             branches:
-            - 'master'
+              - 'master'
             wipe-workspace: false
       lightweight-checkout: true
       script-path: cloud/jenkins/openshift_cluster_destroy.groovy
-
     concurrent: true
-
     properties:
       - build-discarder:
           days-to-keep: 30

--- a/cloud/jenkins/openshift-cluster-list.yml
+++ b/cloud/jenkins/openshift-cluster-list.yml
@@ -4,7 +4,6 @@
     description: |
       List all OpenShift clusters deployed via Jenkins.
       Shows cluster name, version, region, creator, and deployment time.
-
     parameters:
       - string:
           name: AWS_REGION
@@ -16,7 +15,6 @@
           choices:
             - table
             - json
-
     pipeline-scm:
       scm:
         - git:
@@ -25,9 +23,7 @@
               - master
       script-path: cloud/jenkins/openshift_cluster_list.groovy
       lightweight-checkout: true
-
     concurrent: true
-
     properties:
       - build-discarder:
           days-to-keep: 7


### PR DESCRIPTION
## Summary

Replace personal GitHub repository URLs with the official Percona-Lab repository URL in Jenkins job configurations.