### PR TITLE
Fix Blue Ocean readability for OpenShift cluster creation job

### DIFF
--- a/pmm/openshift/openshift-cluster-create.yml
+++ b/pmm/openshift/openshift-cluster-create.yml
@@ -192,7 +192,7 @@
               - git:
                     url: https://github.com/Percona-Lab/jenkins-pipelines.git
                     branches:
-                        - "feature/clean-blue-ocean-formatting"
+                        - "master"
                     wipe-workspace: false
           lightweight-checkout: true
           script-path: pmm/openshift/openshift_cluster_create.groovy

--- a/pmm/openshift/openshift-cluster-destroy.yml
+++ b/pmm/openshift/openshift-cluster-destroy.yml
@@ -43,7 +43,7 @@
         - git:
             url: https://github.com/Percona-Lab/jenkins-pipelines.git
             branches:
-              - 'feature/clean-blue-ocean-formatting'
+              - 'master'
             wipe-workspace: false
       lightweight-checkout: true
       script-path: pmm/openshift/openshift_cluster_destroy.groovy

--- a/pmm/openshift/openshift-cluster-list.yml
+++ b/pmm/openshift/openshift-cluster-list.yml
@@ -22,7 +22,7 @@
         - git:
             url: https://github.com/Percona-Lab/jenkins-pipelines.git
             branches:
-              - feature/clean-blue-ocean-formatting
+              - master
       script-path: pmm/openshift/openshift_cluster_list.groovy
       lightweight-checkout: true
 

--- a/pmm/openshift/openshift_cluster_list.groovy
+++ b/pmm/openshift/openshift_cluster_list.groovy
@@ -38,7 +38,7 @@ pipeline {
                         def clusterCount = clusters.size()
                         def clustersText = clusterCount == 1 ? "1 cluster" : "${clusterCount} clusters"
                         currentBuild.description = "${clustersText} | ${env.OPENSHIFT_AWS_REGION} | ${params.OUTPUT_FORMAT ?: 'table'}"
-                        
+
                         if (params.OUTPUT_FORMAT == 'json') {
                             // For JSON output, just print the raw JSON
                             def json = new groovy.json.JsonBuilder(clusters)

--- a/vars/openshiftS3.groovy
+++ b/vars/openshiftS3.groovy
@@ -161,7 +161,7 @@ def downloadState(Map config) {
  *
  * Stores metadata separately from the main state file for quick access
  * without downloading the full cluster state tarball.
- * 
+ *
  * NOTE: Changed from metadata.json to cluster-metadata.json to avoid
  * overwriting the OpenShift installer's metadata.json file which is
  * required for openshift-install destroy operations.
@@ -200,7 +200,7 @@ EOF
  *
  * Fetches and parses the cluster-metadata.json file for a specific cluster.
  * Returns null if not found rather than throwing an error.
- * 
+ *
  * NOTE: Changed from metadata.json to cluster-metadata.json to avoid
  * conflicts with the OpenShift installer's metadata.json file which is
  * required for openshift-install destroy operations.
@@ -228,7 +228,7 @@ EOF
 def getMetadata(Map params) {
     // Use cluster-metadata.json - metadata.json is reserved for OpenShift installer
     def s3Uri = "s3://${params.bucket}/${params.clusterName}/cluster-metadata.json"
-    
+
     // Check if metadata exists
     def existsResult = sh(
         script: "aws s3 ls '${s3Uri}' --region ${params.region} 2>/dev/null | wc -l",

--- a/vars/openshiftTools.groovy
+++ b/vars/openshiftTools.groovy
@@ -541,22 +541,22 @@ def formatClustersSummary(List clusters, String title = "OPENSHIFT CLUSTERS") {
         clusters.each { cluster ->
             // Primary info (most important)
             summary.append("Cluster Name:        ${cluster.name}\n")
-            
+
             // Version and status info
             summary.append("OpenShift Version:   ${cluster.version}\n")
             summary.append("Status:              ${getClusterStatus(cluster)}\n")
             summary.append("PMM Deployed:        ${cluster.pmm_deployed}\n")
-            
+
             // Metadata
             summary.append("AWS Region:          ${cluster.region}\n")
             summary.append("Created:             ${cluster.created_at}\n")
             summary.append("Created By:          ${cluster.created_by}\n")
-            
+
             // Technical details
             summary.append("Data Source:         ${cluster.source}\n")
             summary.append("S3 Backup:           ${cluster.has_backup}\n")
             summary.append("Resource Types:      ${cluster.resource_count}\n")
-            
+
             // Show base name only if it differs (for clusters with random suffixes)
             if (cluster.baseName && cluster.baseName != cluster.name) {
                 summary.append("S3 Base Name:        ${cluster.baseName}\n")


### PR DESCRIPTION
## Summary

Fix Blue Ocean readability by removing HTML from build descriptions and reorganizing console output by priority.

## Problem

Blue Ocean shows raw HTML tags instead of rendering them, making cluster info hard to read.

## Solution

- Replace HTML with pipe-separated format: `cluster | OCP 4.16.9 | us-east-2 | Active | Console: https://...`
- Reorder output by QA priority: URLs → Credentials → Versions → Technical details → Admin info
- Align all fields consistently with colons

## Example

**Before:** `<b>Cluster:</b> test<br/><b>Status:</b> Active<br/>...` (shows as raw HTML in Blue Ocean)

**After:** `test | OCP 4.16.9 | us-east-2 | Active | Console: https://... | PMM: https://...`