### PR TITLE
K8SPS-520: add hetzner worker for PSO openshift job

### DIFF
--- a/cloud/jenkins/pso_openshift.groovy
+++ b/cloud/jenkins/pso_openshift.groovy
@@ -453,7 +453,7 @@ pipeline {
         }
         stage('Run Tests') {
             options {
-                timeout(time: 4, unit: 'HOURS')
+                timeout(time: 210, unit: 'MINUTES')
             }
             parallel {
                 stage('cluster1') {


### PR DESCRIPTION
Jenkins supports two clouds for agents: hetzner and aws. AWS uses spot instances that causes jobs interruption from time to time. Hetzner does not have spots thus is more stable (can need more time to start worker).
This PR: 
- adds new param to job that allows to select hetzner or AWS for jenkins agent for job.
- adds one more node for tests
- increases stages timeout (hetzner needs more time to start thus test stage will take more time)