### PR TITLE
Adding Debian-13 (Trixie) as a supported platform in ppg test workflows.

### DIFF
--- a/ppg/component-generic-parallel.groovy
+++ b/ppg/component-generic-parallel.groovy
@@ -46,7 +46,7 @@ pipeline {
             name: 'COMPONENT_VERSION'
         )
         string(
-            defaultValue: 'ppg-17.6',
+            defaultValue: 'ppg-18.0',
             description: 'PPG version for test',
             name: 'VERSION'
         )

--- a/ppg/component-generic.groovy
+++ b/ppg/component-generic.groovy
@@ -51,7 +51,7 @@ pipeline {
             name: 'COMPONENT_VERSION'
         )
         string(
-            defaultValue: 'ppg-17.6',
+            defaultValue: 'ppg-18.0',
             description: 'PPG version for test',
             name: 'VERSION'
         )

--- a/ppg/component-multi-parallel.groovy
+++ b/ppg/component-multi-parallel.groovy
@@ -17,7 +17,7 @@ pipeline {
             choices: repoList()
         )
         string(
-            defaultValue: 'ppg-17.6',
+            defaultValue: 'ppg-18.0',
             description: 'PPG version for test',
             name: 'VERSION'
          )
@@ -26,19 +26,19 @@ pipeline {
             description: 'Base branch for ppg-testing repo',
             name: 'TESTING_BRANCH')
         string(
-            defaultValue: '2.2.0',
+            defaultValue: '2.3.0',
             description: 'PGSM version',
             name: 'PGSM_VERSION')
         string(
-            defaultValue: '4.6.2',
+            defaultValue: '4.6.3',
             description: 'pgpool version',
             name: 'PGPOOL_VERSION')
         string(
-            defaultValue: '3.3.8',
+            defaultValue: '3.5.3',
             description: 'postgis version',
             name: 'POSTGIS_VERSION')
         string(
-            defaultValue: '17.1',
+            defaultValue: '18.0',
             description: ' version',
             name: 'PGAUDIT_VERSION')
         string(
@@ -46,7 +46,7 @@ pipeline {
             description: 'PG_REPACK version',
             name: 'PG_REPACK_VERSION')
         string(
-            defaultValue: 'v4.0.6',
+            defaultValue: 'v4.1.0',
             description: 'Patroni version',
             name: 'PATRONI_VERSION')
         string(
@@ -54,7 +54,7 @@ pipeline {
             description: 'pgbackrest version',
             name: 'PGBACKREST_VERSION')
         string(
-            defaultValue: 'REL4_1_0',
+            defaultValue: 'REL4_2_0',
             description: 'pgaudit13_set_user version',
             name: 'SETUSER_VERSION')
         string(
@@ -70,7 +70,7 @@ pipeline {
             description: 'wal2json version',
             name: 'WAL2JSON_VERSION')
         string(
-            defaultValue: 'v0.8.0',
+            defaultValue: 'v0.8.1',
             description: 'pgvector version',
             name: 'PGVECTOR_VERSION')
         string(

--- a/ppg/docker-parallel.groovy
+++ b/ppg/docker-parallel.groovy
@@ -21,12 +21,12 @@ pipeline {
   }
   parameters {
         string(
-            defaultValue: '17.6',
+            defaultValue: '18.0',
             description: 'TAG of the docker to test. For example, 16, 16.1, 16.1-multi.',
             name: 'DOCKER_TAG'
         )
         string(
-            defaultValue: '17.6',
+            defaultValue: '18.0',
             description: 'Docker PG version to test, including both major and minor version. For example, 15.4.',
             name: 'SERVER_VERSION'
         )
@@ -80,7 +80,7 @@ pipeline {
         stage('Test') {
           steps {
                 script {
-                    moleculeParallelTestPPG(['rocky-9', 'debian-12', 'ubuntu-jammy', 'rocky-9-arm64', 'debian-12-arm64', 'ubuntu-jammy-arm64'], env.MOLECULE_DIR)
+                    moleculeParallelTestPPG(['rocky-9', 'rhel-10', 'debian-12', 'debian-13', 'ubuntu-jammy', 'rocky-9-arm64', 'rhel-10-arm64', 'debian-12-arm64', 'debian-13-arm64', 'ubuntu-jammy-arm64'], env.MOLECULE_DIR)
                 }
             }
          }
@@ -89,7 +89,7 @@ pipeline {
         always {
           script {
               if (env.DESTROY_ENV == "yes") {
-                    moleculeParallelPostDestroyPPG(['rocky-9', 'debian-12', 'ubuntu-jammy', 'rocky-9-arm64', 'debian-12-arm64', 'ubuntu-jammy-arm64'], env.MOLECULE_DIR)
+                    moleculeParallelPostDestroyPPG(['rocky-9', 'rhel-10', 'debian-12', 'debian-13', 'ubuntu-jammy', 'rocky-9-arm64', 'rhel-10-arm64', 'debian-12-arm64', 'debian-13-arm64', 'ubuntu-jammy-arm64'], env.MOLECULE_DIR)
               }
               sendSlackNotification(env.REPOSITORY, env.SERVER_VERSION, env.DOCKER_TAG)
          }

--- a/ppg/docker.groovy
+++ b/ppg/docker.groovy
@@ -16,18 +16,22 @@ pipeline {
                 'debian-12',
                 'rocky-9',
                 'ubuntu-jammy',
+                'rhel-10',
+                'debian-13',
                 'debian-12-arm64',
                 'rocky-9-arm64',
                 'ubuntu-jammy-arm64'
+                'rhel-10-arm64',
+                'debian-13-arm64',
             ]
         )
         string(
-            defaultValue: '17.6',
+            defaultValue: '18.0',
             description: 'TAG of the docker to test. For example, 16, 16.1, 16.1-multi.',
             name: 'DOCKER_TAG'
         )
         string(
-            defaultValue: '17.6',
+            defaultValue: '18.0',
             description: 'Docker PG version to test, including both major and minor version. For example, 15.4.',
             name: 'SERVER_VERSION'
         )

--- a/ppg/pgsm-parallel.groovy
+++ b/ppg/pgsm-parallel.groovy
@@ -35,12 +35,12 @@ pipeline {
             name: 'PGSM_REPO'
         )
         string(
-            defaultValue: '2.2.0',
+            defaultValue: '2.3.0',
             description: 'PGSM repo version/branch/tag to use; e.g main, 2.0.5',
             name: 'PGSM_BRANCH'
         )
         string(
-            defaultValue: 'ppg-17.6',
+            defaultValue: 'ppg-18.0',
             description: 'Server PG version for test, including major and minor version, e.g ppg-16.2, ppg-15.5',
             name: 'VERSION'
         )

--- a/ppg/pgsm.groovy
+++ b/ppg/pgsm.groovy
@@ -34,7 +34,7 @@ pipeline {
             name: 'PGSM_BRANCH'
         )
         string(
-            defaultValue: 'ppg-17.6',
+            defaultValue: 'ppg-18.0',
             description: 'Server PG version for test, including major and minor version, e.g ppg-16.2, ppg-15.5',
             name: 'VERSION'
         )

--- a/ppg/ppg-parallel.groovy
+++ b/ppg/ppg-parallel.groovy
@@ -31,7 +31,7 @@ pipeline {
             ]
         )
         string(
-            defaultValue: 'ppg-17.6',
+            defaultValue: 'ppg-18.0',
             description: 'PG version for test',
             name: 'VERSION'
         )

--- a/ppg/ppg.groovy
+++ b/ppg/ppg.groovy
@@ -24,7 +24,7 @@ pipeline {
             ]
         )
         string(
-            defaultValue: 'ppg-17.6',
+            defaultValue: 'ppg-18.0',
             description: 'PG version for test',
             name: 'VERSION'
          )

--- a/ppg/psp-installcheck-world-parallel.groovy
+++ b/ppg/psp-installcheck-world-parallel.groovy
@@ -21,12 +21,12 @@ pipeline {
   }
   parameters {
         string(
-            defaultValue: '17.6',
+            defaultValue: '18.0',
             description: 'Server PG version for test, including major and minor version, e.g 17.4, 17.3',
             name: 'VERSION'
         )
         string(
-            defaultValue: '17.6.1',
+            defaultValue: '18.0.1',
             description: 'Server PG version for test, including major and minor version, e.g 17.6.1',
             name: 'PERCONA_SERVER_VERSION'
         )
@@ -36,7 +36,7 @@ pipeline {
             name: 'PSP_REPO'
         )
         string(
-            defaultValue: 'TDE_REL_17_STABLE',
+            defaultValue: 'TDE_REL_18_STABLE',
             description: 'PSP repo version/branch/tag to use; e.g main, TDE_REL_17_STABLE',
             name: 'PSP_BRANCH'
         )

--- a/ppg/psp-installcheck-world.groovy
+++ b/ppg/psp-installcheck-world.groovy
@@ -15,12 +15,12 @@ pipeline {
             choices: ppgOperatingSystemsALL()
         )
         string(
-            defaultValue: '17.6',
+            defaultValue: '18.0',
             description: 'Server PG version for test, including major and minor version, e.g 17.4, 17.3',
             name: 'VERSION'
         )
         string(
-            defaultValue: '17.6.1',
+            defaultValue: '18.0.1',
             description: 'Server PG version for test, including major and minor version, e.g 17.6.1',
             name: 'PERCONA_SERVER_VERSION'
         )
@@ -30,7 +30,7 @@ pipeline {
             name: 'PSP_REPO'
         )
         string(
-            defaultValue: 'TDE_REL_17_STABLE',
+            defaultValue: 'TDE_REL_18_STABLE',
             description: 'PSP repo version/branch/tag to use; e.g main, TDE_REL_17_STABLE',
             name: 'PSP_BRANCH'
         )

--- a/ppg/tarball-parallel-ssl1.groovy
+++ b/ppg/tarball-parallel-ssl1.groovy
@@ -29,7 +29,7 @@ pipeline {
             ]
         )
         string(
-            defaultValue: 'ppg-17.6',
+            defaultValue: 'ppg-18.0',
             description: 'PG version for test',
             name: 'VERSION'
         )

--- a/ppg/tarball-parallel-ssl3.groovy
+++ b/ppg/tarball-parallel-ssl3.groovy
@@ -29,7 +29,7 @@ pipeline {
             ]
         )
         string(
-            defaultValue: 'ppg-17.6',
+            defaultValue: 'ppg-18.0',
             description: 'PG version for test',
             name: 'VERSION'
         )

--- a/ppg/tarball.groovy
+++ b/ppg/tarball.groovy
@@ -23,7 +23,7 @@ pipeline {
             ]
         )
         string(
-            defaultValue: 'ppg-17.6',
+            defaultValue: 'ppg-18.0',
             description: 'PG version for test',
             name: 'VERSION'
         )

--- a/ppg/tde-parallel.groovy
+++ b/ppg/tde-parallel.groovy
@@ -35,12 +35,12 @@ pipeline {
             name: 'PSP_REPO'
         )
         string(
-            defaultValue: 'TDE_REL_17_STABLE',
+            defaultValue: 'TDE_REL_18_STABLE',
             description: 'PSP repo version/branch/tag to use; e.g main, TDE_REL_17_STABLE',
             name: 'PSP_BRANCH'
         )
         string(
-            defaultValue: 'ppg-17.6',
+            defaultValue: 'ppg-18.0',
             description: 'Server PG version for test, including major and minor version, e.g ppg-17.4, ppg-17.3',
             name: 'VERSION'
         )

--- a/ppg/tde.groovy
+++ b/ppg/tde.groovy
@@ -29,12 +29,12 @@ pipeline {
             name: 'PSP_REPO'
         )
         string(
-            defaultValue: 'TDE_REL_17_STABLE',
+            defaultValue: 'TDE_REL_18_STABLE',
             description: 'PSP repo version/branch/tag to use; e.g main, TDE_REL_17_STABLE',
             name: 'PSP_BRANCH'
         )
         string(
-            defaultValue: 'ppg-17.6',
+            defaultValue: 'ppg-18.0',
             description: 'Server PG version for test, including major and minor version, e.g ppg-17.4, ppg-17.3',
             name: 'VERSION'
         )

--- a/vars/ppgOperatingSystemsALL.groovy
+++ b/vars/ppgOperatingSystemsALL.groovy
@@ -1,3 +1,3 @@
 def call() {
-  return ['ol-8', 'ol-9', 'rocky-8', 'rocky-9', 'rocky-10', 'rhel-8', 'rhel-9', 'rhel-10', 'debian-11', 'debian-12', 'ubuntu-jammy', 'ubuntu-noble', 'ol-8-arm', 'ol-9-arm', 'rocky-8-arm', 'rocky-9-arm', 'rocky-10-arm', 'rhel-8-arm', 'rhel-9-arm', 'rhel-10-arm', 'debian-11-arm', 'debian-12-arm', 'ubuntu-jammy-arm', 'ubuntu-noble-arm']
+  return ['ol-8', 'ol-9', 'rocky-8', 'rocky-9', 'rocky-10', 'rhel-8', 'rhel-9', 'rhel-10', 'debian-11', 'debian-12', 'debian-13', 'ubuntu-jammy', 'ubuntu-noble', 'ol-8-arm', 'ol-9-arm', 'rocky-8-arm', 'rocky-9-arm', 'rocky-10-arm', 'rhel-8-arm', 'rhel-9-arm', 'rhel-10-arm', 'debian-11-arm', 'debian-12-arm', 'debian-13-arm', 'ubuntu-jammy-arm', 'ubuntu-noble-arm']
 }

--- a/vars/ppgOperatingSystemsAMD.groovy
+++ b/vars/ppgOperatingSystemsAMD.groovy
@@ -1,3 +1,3 @@
 def call() {
-  return ['ol-8', 'ol-9', 'rocky-8', 'rocky-9', 'rocky-10', 'rhel-8', 'rhel-9', 'rhel-10', 'debian-11', 'debian-12', 'ubuntu-jammy', 'ubuntu-noble']
+  return ['ol-8', 'ol-9', 'rocky-8', 'rocky-9', 'rocky-10', 'rhel-8', 'rhel-9', 'rhel-10', 'debian-11', 'debian-12', 'debian-13', 'ubuntu-jammy', 'ubuntu-noble']
 }

--- a/vars/ppgOperatingSystemsARM.groovy
+++ b/vars/ppgOperatingSystemsARM.groovy
@@ -1,3 +1,3 @@
 def call() {
-  return ['ol-8-arm', 'ol-9-arm', 'rocky-8-arm', 'rocky-9-arm', 'rocky-10-arm', 'rhel-8-arm', 'rhel-9-arm', 'rhel-10-arm', 'debian-11-arm', 'debian-12-arm', 'ubuntu-jammy-arm', 'ubuntu-noble-arm']
+  return ['ol-8-arm', 'ol-9-arm', 'rocky-8-arm', 'rocky-9-arm', 'rocky-10-arm', 'rhel-8-arm', 'rhel-9-arm', 'rhel-10-arm', 'debian-11-arm', 'debian-12-arm', 'debian-13-arm', 'ubuntu-jammy-arm', 'ubuntu-noble-arm']
 }

--- a/vars/ppgOperatingSystemsSSL35.groovy
+++ b/vars/ppgOperatingSystemsSSL35.groovy
@@ -1,0 +1,3 @@
+def call() {
+  return ['debian-13', 'debian-13-arm']
+}

--- a/vars/ppgScenarios.groovy
+++ b/vars/ppgScenarios.groovy
@@ -1,11 +1,9 @@
 def call() {
   return [
-  'pg-13', 'pg-14', 'pg-15', 'pg-16', 'pg-17',
-  'pg-13-meta-ha', 'pg-14-meta-ha', 'pg-15-meta-ha', 'pg-16-meta-ha', 'pg-17-meta-ha',
-  'pg-13-meta-server', 'pg-14-meta-server', 'pg-15-meta-server', 'pg-16-meta-server', 'pg-17-meta-server',
-  'pg-13-setup', 'pg-14-setup', 'pg-15-setup',
-  'pg-13-with-vanila-components', 'pg-14-with-vanila-components',
-  'pg-15-with-vanila-components', 'pg-13-components-with-vanila',
-  'pg-14-components-with-vanila', 'pg-15-components-with-vanila'
+  'pg-13', 'pg-14', 'pg-15', 'pg-16', 'pg-17', 'pg-18',
+  'pg-13-meta-ha', 'pg-14-meta-ha', 'pg-15-meta-ha', 'pg-16-meta-ha',
+  'pg-17-meta-ha', 'pg-18-meta-ha','pg-13-meta-server', 'pg-14-meta-server',
+  'pg-15-meta-server', 'pg-16-meta-server', 'pg-17-meta-server',
+  'pg-18-meta-server'
   ]
 }

--- a/vars/ppgUpgradeScenarios.groovy
+++ b/vars/ppgUpgradeScenarios.groovy
@@ -1,7 +1,8 @@
 def call() {
   return [
-  'pg-13-minor-upgrade', 'pg-14-minor-upgrade', 'pg-15-minor-upgrade', 'pg-16-minor-upgrade', 'pg-17-minor-upgrade',
-  'pg-13-major-upgrade', 'pg-14-major-upgrade', 'pg-15-major-upgrade', 'pg-16-major-upgrade', 'pg-17-major-upgrade',
-  'pg-13-vanila-upgrade', 'pg-14-vanila-upgrade', 'pg-15-vanila-upgrade'
+  'pg-13-minor-upgrade', 'pg-14-minor-upgrade', 'pg-15-minor-upgrade',
+  'pg-16-minor-upgrade', 'pg-17-minor-upgrade', 'pg-18-minor-upgrade',
+  'pg-13-major-upgrade', 'pg-14-major-upgrade', 'pg-15-major-upgrade',
+  'pg-16-major-upgrade', 'pg-17-major-upgrade', 'pg-18-major-upgrade'
   ]
 }


### PR DESCRIPTION
 Adding Debian-13 (Trixie) as a supported platform in ppg test workflows.. Clean up and update versions for pg-18.