### PR TITLE
PS-10899: fix Lambda EC2 cleanup with Cirrus CI auto-tagging

### DIFF
--- a/IaC/LambdaEC2Cleanup.yml
+++ b/IaC/LambdaEC2Cleanup.yml
@@ -84,6 +84,8 @@ Resources:
         clean up orphaned EKS clusters
       Runtime: python3.13
       Handler: index.lambda_handler
+      Architectures:
+        - arm64
       MemorySize: 128
       Timeout: 120
       Role: !GetAtt RoleEC2Cleanup.Arn

--- a/IaC/LambdaEC2Cleanup.yml
+++ b/IaC/LambdaEC2Cleanup.yml
@@ -82,7 +82,7 @@ Resources:
       Description: >-
         Terminate untagged EC2 instances, auto-tag Cirrus CI,
         clean up orphaned EKS clusters
-      Runtime: python3.12
+      Runtime: python3.13
       Handler: index.lambda_handler
       MemorySize: 128
       Timeout: 120

--- a/IaC/LambdaEC2Cleanup.yml
+++ b/IaC/LambdaEC2Cleanup.yml
@@ -1,27 +1,50 @@
 ---
 AWSTemplateFormatVersion: 2010-09-09
-Description: "Terminate untagged EC2 instances running for more than 10 minutes"
+Description: >-
+  Terminate untagged EC2 instances, auto-tag Cirrus CI instances,
+  and clean up orphaned EKS clusters across all AWS regions.
+
+Parameters:
+  DryRunMode:
+    Type: String
+    Default: "true"
+    AllowedValues: ["true", "false"]
+    Description: >-
+      When true, logs actions without terminating instances or tagging.
+      Set to false only after validating dry-run logs.
+  EksSkipPattern:
+    Type: String
+    Default: "pe-.*"
+    Description: >-
+      Regex pattern for EKS cluster names to skip (even without billing tag).
+  ScheduleRate:
+    Type: String
+    Default: "rate(5 minutes)"
+    Description: EventBridge schedule expression for the cleanup Lambda.
+  LogRetentionDays:
+    Type: Number
+    Default: 14
+    AllowedValues: [1, 3, 5, 7, 14, 30, 60, 90]
+
 Resources:
 
   RoleEC2Cleanup:
     Type: AWS::IAM::Role
     Properties:
+      RoleName: RoleEC2Cleanup
       AssumeRolePolicyDocument:
         Version: "2012-10-17"
         Statement:
-          - Effect: "Allow"
+          - Effect: Allow
             Principal:
               Service:
-                - "lambda.amazonaws.com"
-                - "ec2.amazonaws.com"
-                - "logs.amazonaws.com"
+                - lambda.amazonaws.com
             Action:
-              - "sts:AssumeRole"
-      Path: "/"
-      RoleName: RoleEC2Cleanup
+              - sts:AssumeRole
+      Path: /
       Tags:
         - Key: iit-billing-tag
-          Value: removeUntaggedEc2
+          Value: lambda-ec2-cleanup
 
   PolicyEC2Cleanup:
     Type: AWS::IAM::Policy
@@ -34,146 +57,361 @@ Resources:
         Statement:
           - Effect: Allow
             Action:
-              - logs:CreateLogGroup
-              - logs:CreateLogStream
-              - logs:PutLogEvents
-            Resource: !Sub 'arn:aws:logs:*:${AWS::AccountId}:log-group:/aws/lambda/LambdaEC2Cleanup:*'
-          - Effect: Allow
-            Action:
-              - sts:DecodeAuthorizationMessage
-            Resource: '*'
-          - Effect: Allow
-            Action:
               - ec2:DescribeRegions
               - ec2:DescribeInstances
               - ec2:TerminateInstances
               - ec2:CreateTags
-            Resource: '*'
+            Resource: "*"
+          - Effect: Allow
+            Action:
+              - cloudformation:DescribeStacks
+              - cloudformation:DescribeStackEvents
+              - cloudformation:DeleteStack
+            Resource: "*"
+          - Effect: Allow
+            Action:
+              - logs:CreateLogGroup
+              - logs:CreateLogStream
+              - logs:PutLogEvents
+            Resource: "*"
 
   LambdaEC2Cleanup:
     Type: AWS::Lambda::Function
     Properties:
       FunctionName: LambdaEC2Cleanup
-      Description: Terminates EC2 instances without iit-billing-tag running for more than 10 minutes, and tags CirrusCI instances
+      Description: >-
+        Terminate untagged EC2 instances, auto-tag Cirrus CI,
+        clean up orphaned EKS clusters
       Runtime: python3.12
       Handler: index.lambda_handler
       MemorySize: 128
-      Timeout: 60
+      Timeout: 120
+      Role: !GetAtt RoleEC2Cleanup.Arn
+      Environment:
+        Variables:
+          DRY_RUN: !Ref DryRunMode
+          EKS_SKIP_PATTERN: !Ref EksSkipPattern
+      Tags:
+        - Key: iit-billing-tag
+          Value: lambda-ec2-cleanup
       Code:
         ZipFile: |
           import logging
           import datetime
           import boto3
+          import os
+          import re
           from botocore.exceptions import ClientError
 
-          # Set logging level to INFO
           logger = logging.getLogger()
           logger.setLevel("INFO")
 
+          EKS_SKIP_PATTERN = os.environ.get("EKS_SKIP_PATTERN", "pe-.*")
+          DRY_RUN = os.environ.get("DRY_RUN", "true").lower() == "true"
+
+          logger.info(f"EKS_SKIP_PATTERN: {EKS_SKIP_PATTERN}")
+          logger.info(f"DRY_RUN: {DRY_RUN}")
+
+          eks_clusters_to_delete = {}
+
+
           def convert_tags_to_dict(tags):
-              return {tag['Key']: tag['Value'] for tag in tags} if tags else {}
+              return {tag["Key"]: tag["Value"] for tag in tags} if tags else {}
 
-          def is_instance_to_terminate(instance):
-              # Check if the instance has 'iit-billing-tag'
-              has_iit_billing_tag = False
-              if instance.tags is not None:
-                  for tag in instance.tags:
-                      if tag['Key'] == 'iit-billing-tag':
-                          has_iit_billing_tag = True
-                          break
 
-              # Calculate the running time of the instance
-              current_time = datetime.datetime.now(datetime.timezone.utc)
-              launch_time = instance.launch_time
-              running_time = current_time - launch_time
+          def get_eks_cluster_name(tags_dict):
+              for key in ["aws:eks:cluster-name", "eks:eks-cluster-name"]:
+                  if key in tags_dict:
+                      return tags_dict[key]
+              for key in tags_dict:
+                  if key.startswith("kubernetes.io/cluster/"):
+                      return key.replace("kubernetes.io/cluster/", "")
+              return None
 
-              # Terminate instances without 'iit-billing-tag' running for more than 10 minutes
-              if not has_iit_billing_tag and running_time.total_seconds() > 600:
+
+          def has_valid_billing_tag(tags_dict, instance_launch_time):
+              if "iit-billing-tag" not in tags_dict:
+                  return False
+              tag_value = tags_dict["iit-billing-tag"]
+              if not tag_value:
+                  return False
+              try:
+                  exp = int(tag_value)
+                  now = int(datetime.datetime.now(datetime.timezone.utc).timestamp())
+                  if exp > now:
+                      logger.info(f"Valid billing tag expiration {exp} (expires in {exp - now}s)")
+                      return True
+                  else:
+                      logger.info(f"Billing tag expired: {exp} < {now} (expired {now - exp}s ago)")
+                      return False
+              except ValueError:
+                  logger.info(f"Valid billing tag category: {tag_value}")
                   return True
-              return False
 
-          def cirrus_ci_add_iit_billing_tag(instance):
-              # Convert tags to a dictionary for easier access
+
+          def get_eks_cfn_billing_tag(cluster_name, region):
+              try:
+                  cfn = boto3.client("cloudformation", region_name=region)
+                  stack_name = f"eksctl-{cluster_name}-cluster"
+                  resp = cfn.describe_stacks(StackName=stack_name)
+                  tags = {t["Key"]: t["Value"] for t in resp["Stacks"][0].get("Tags", [])}
+                  return tags.get("iit-billing-tag")
+              except ClientError as e:
+                  if "does not exist" in str(e):
+                      return None
+                  logger.error(f"CF stack tag check error: {e}")
+                  return None
+              except Exception as e:
+                  logger.error(f"Unexpected CF error: {e}")
+                  return None
+
+
+          def is_eks_managed(instance, region):
               tags_dict = convert_tags_to_dict(instance.tags)
+              indicators = [
+                  "kubernetes.io/cluster/", "aws:eks:cluster-name",
+                  "eks:eks-cluster-name", "eks:kubernetes-node-pool-name",
+                  "aws:ec2:managed-launch",
+              ]
+              is_eks = any(ind in key for key in tags_dict for ind in indicators)
+              if not is_eks:
+                  return False
 
-              # Check if the instance has 'CIRRUS_CI' tag set to 'true' and 'iit-billing-tag' is not set
-              has_cirrus_ci_tag = tags_dict.get('CIRRUS_CI', '').lower() == 'true'
-              has_iit_billing_tag = 'iit-billing-tag' in tags_dict
+              cluster_name = get_eks_cluster_name(tags_dict)
+              if has_valid_billing_tag(tags_dict, instance.launch_time):
+                  logger.info(f"{instance.id} EKS ({cluster_name}), has billing tag, skip")
+                  return True
+              cfn_tag = get_eks_cfn_billing_tag(cluster_name, region)
+              if cfn_tag:
+                  logger.info(f"{instance.id} EKS ({cluster_name}), CF billing tag: {cfn_tag}, skip")
+                  return True
 
-              # Extract additional tag values
-              instance_name = tags_dict.get('Name')
-              cirrus_repo_full_name = tags_dict.get('CIRRUS_REPO_FULL_NAME')
-              cirrus_task_id = tags_dict.get('CIRRUS_TASK_ID')
-
-              # If 'CIRRUS_CI' tag is set to 'true' and 'iit-billing-tag' is not set, add 'iit-billing-tag' set to 'CirrusCI'
-              if has_cirrus_ci_tag and not has_iit_billing_tag:
+              if cluster_name and EKS_SKIP_PATTERN:
                   try:
-                      instance.create_tags(Tags=[{'Key': 'iit-billing-tag', 'Value': 'CirrusCI'}])
-                      logging.info(
-                          f"Instance {instance.id} ({instance_name}) tagged with 'iit-billing-tag: CirrusCI'. "
-                          f"CIRRUS_REPO_FULL_NAME: {cirrus_repo_full_name}, CIRRUS_TASK_ID: {cirrus_task_id}"
-                      )
-                  except ClientError as e:
-                      logging.error(f"Error tagging instance {instance.id}: {e}")
+                      if re.match(EKS_SKIP_PATTERN, cluster_name):
+                          logger.info(f"{instance.id} EKS ({cluster_name}), matches skip pattern, skip")
+                          return True
+                      else:
+                          logger.info(f"{instance.id} EKS ({cluster_name}), no billing tag, mark for deletion")
+                          if region not in eks_clusters_to_delete:
+                              eks_clusters_to_delete[region] = set()
+                          eks_clusters_to_delete[region].add(cluster_name)
+                          return True
+                  except re.error as e:
+                      logger.error(f"Invalid regex '{EKS_SKIP_PATTERN}': {e}, skipping all EKS")
+                      return True
 
-          def terminate_instances_in_region(region):
-              ec2 = boto3.resource('ec2', region_name=region)
-              instances = ec2.instances.filter(Filters=[{'Name': 'instance-state-name', 'Values': ['running']}])
-              terminated_instances = []
+              logger.info(f"{instance.id} EKS ({cluster_name or 'unknown'}), skip")
+              return True
+
+
+          def is_cirrus_ci(tags_dict):
+              return tags_dict.get("CIRRUS_CI", "").lower() == "true"
+
+
+          def auto_tag_cirrus_ci(instance, tags_dict, region):
+              repo = tags_dict.get("CIRRUS_REPO_FULL_NAME", "unknown")
+              task_id = tags_dict.get("CIRRUS_TASK_ID", "unknown")
+              if DRY_RUN:
+                  logger.info(
+                      f"DRY_RUN: Would auto-tag {instance.id} in {region} "
+                      f"(repo: {repo}, task: {task_id}) with iit-billing-tag=CirrusCI"
+                  )
+                  return
+              try:
+                  instance.create_tags(Tags=[{"Key": "iit-billing-tag", "Value": "CirrusCI"}])
+                  logger.info(f"Auto-tagged {instance.id} in {region} (repo: {repo}, task: {task_id})")
+              except ClientError as e:
+                  logger.error(f"Failed to auto-tag {instance.id} in {region}: {e}")
+
+
+          def should_terminate(instance):
+              tags_dict = convert_tags_to_dict(instance.tags)
+              if has_valid_billing_tag(tags_dict, instance.launch_time):
+                  return False
+              running = datetime.datetime.now(datetime.timezone.utc) - instance.launch_time
+              return running.total_seconds() > 600
+
+
+          def get_name_tag(instance):
+              tags_dict = convert_tags_to_dict(instance.tags)
+              return tags_dict.get("Name")
+
+
+          def cleanup_failed_stack(stack_name, region):
+              try:
+                  cfn = boto3.client("cloudformation", region_name=region)
+                  ec2 = boto3.client("ec2", region_name=region)
+                  events = cfn.describe_stack_events(StackName=stack_name)
+                  failed = {}
+                  for ev in events["StackEvents"]:
+                      if ev.get("ResourceStatus") == "DELETE_FAILED":
+                          lid = ev["LogicalResourceId"]
+                          if lid not in failed:
+                              failed[lid] = {"Type": ev["ResourceType"], "PhysicalId": ev.get("PhysicalResourceId")}
+                  if not failed:
+                      return True
+                  logger.info(f"Cleaning {len(failed)} failed resources for {stack_name}")
+                  for lid, res in failed.items():
+                      rtype, pid = res["Type"], res["PhysicalId"]
+                      try:
+                          if rtype == "AWS::EC2::SecurityGroupIngress" and pid:
+                              sg_id = pid.split("|")[0] if "|" in pid else None
+                              if sg_id and sg_id.startswith("sg-"):
+                                  r = ec2.describe_security_groups(GroupIds=[sg_id])
+                                  if r["SecurityGroups"] and r["SecurityGroups"][0]["IpPermissions"]:
+                                      ec2.revoke_security_group_ingress(GroupId=sg_id, IpPermissions=r["SecurityGroups"][0]["IpPermissions"])
+                          elif rtype == "AWS::EC2::SubnetRouteTableAssociation" and pid and pid.startswith("rtbassoc-"):
+                              ec2.disassociate_route_table(AssociationId=pid)
+                          elif rtype == "AWS::EC2::Route" and pid:
+                              parts = pid.split("_")
+                              if len(parts) == 2 and parts[0].startswith("rtb-"):
+                                  ec2.delete_route(RouteTableId=parts[0], DestinationCidrBlock=parts[1])
+                      except ClientError as e:
+                          code = e.response.get("Error", {}).get("Code", "")
+                          if code not in ["InvalidGroup.NotFound", "InvalidAssociationID.NotFound", "InvalidRoute.NotFound"]:
+                              logger.warning(f"Cleanup {rtype} {pid}: {e}")
+                      except Exception as e:
+                          logger.warning(f"Cleanup error {rtype} {pid}: {e}")
+                  return True
+              except Exception as e:
+                  logger.error(f"Failed stack cleanup {stack_name}: {e}")
+                  return False
+
+
+          def delete_eks_stack(cluster_name, region):
+              try:
+                  cfn = boto3.client("cloudformation", region_name=region)
+                  stack_name = f"eksctl-{cluster_name}-cluster"
+                  try:
+                      resp = cfn.describe_stacks(StackName=stack_name)
+                      status = resp["Stacks"][0]["StackStatus"]
+                  except ClientError as e:
+                      if "does not exist" in str(e):
+                          logger.warning(f"CF stack {stack_name} not found in {region}")
+                          return False
+                      raise
+                  if status == "DELETE_FAILED":
+                      if DRY_RUN:
+                          logger.info(f"DRY_RUN: Would retry deletion of {stack_name}")
+                      else:
+                          cleanup_failed_stack(stack_name, region)
+                          cfn.delete_stack(StackName=stack_name)
+                          logger.info(f"Retrying deletion of {stack_name}")
+                      return True
+                  if "DELETE" in status and status != "DELETE_COMPLETE":
+                      logger.info(f"Stack {stack_name} already deleting ({status})")
+                      return True
+                  if DRY_RUN:
+                      logger.info(f"DRY_RUN: Would delete CF stack {stack_name} for {cluster_name} in {region}")
+                  else:
+                      cfn.delete_stack(StackName=stack_name)
+                      logger.info(f"Deleted CF stack {stack_name} for {cluster_name} in {region}")
+                  return True
+              except ClientError as e:
+                  logger.error(f"CF delete failed for {cluster_name} in {region}: {e}")
+                  return False
+              except Exception as e:
+                  logger.error(f"Unexpected error deleting {cluster_name} in {region}: {e}")
+                  return False
+
+
+          def process_region(region):
+              ec2 = boto3.resource("ec2", region_name=region)
+              instances = ec2.instances.filter(Filters=[{"Name": "instance-state-name", "Values": ["running"]}])
+              terminated = []
+              skipped = []
 
               for instance in instances:
-                  cirrus_ci_add_iit_billing_tag(instance)
-                  if is_instance_to_terminate(instance):
-                      try:
-                          # Get instance details before termination
+                  try:
+                      if is_eks_managed(instance, region):
                           tags_dict = convert_tags_to_dict(instance.tags)
-                          instance_name = tags_dict.get('Name', 'N/A')
-                          ssh_key_name = instance.key_name if instance.key_name else 'N/A'
+                          cluster = get_eks_cluster_name(tags_dict)
+                          skipped.append({"id": instance.id, "reason": f"EKS ({cluster or 'unknown'})"})
+                          continue
 
-                          logger.info(f"Trying to terminate {instance.id} in {region}")
-                          response = instance.terminate()
-                          logger.info(f"Terminate response for {instance.id}: {response}")
-                          terminated_instances.append({
-                              'InstanceId': instance.id,
-                              'AvailabilityZone': instance.placement['AvailabilityZone'],
-                              'SSHKeyName': ssh_key_name,
-                              'NameTag': instance_name
-                          })
-                      except ClientError as e:
-                          logger.error(f"Failed to terminate {instance.id}: {e}")
-                          error_code = e.response['Error']['Code']
-                          error_message = e.response['Error']['Message']
-                          logger.error(f"Error Code: {error_code}")
-                          logger.error(f"Error Message: {error_message}")
-                          logger.error(f"RequestId: {e.response.get('ResponseMetadata', {}).get('RequestId')}")
-              return terminated_instances
+                      tags_dict = convert_tags_to_dict(instance.tags)
+                      if is_cirrus_ci(tags_dict) and "iit-billing-tag" not in tags_dict:
+                          auto_tag_cirrus_ci(instance, tags_dict, region)
+                          skipped.append({"id": instance.id, "reason": "Cirrus CI, auto-tagged"})
+                          continue
+
+                      if should_terminate(instance):
+                          info = {
+                              "InstanceId": instance.id,
+                              "SSHKeyName": instance.key_name,
+                              "NameTag": get_name_tag(instance),
+                              "AvailabilityZone": instance.placement["AvailabilityZone"],
+                          }
+                          if DRY_RUN:
+                              logger.info(f"DRY_RUN: Would terminate {instance.id} (Name: {info['NameTag']}, Key: {info['SSHKeyName']})")
+                              skipped.append({"id": instance.id, "reason": "DRY_RUN: would terminate"})
+                          else:
+                              try:
+                                  instance.terminate()
+                                  terminated.append(info)
+                                  logger.info(f"Terminated {instance.id} in {region}")
+                              except ClientError as e:
+                                  logger.error(f"Failed to terminate {instance.id}: {e}")
+                                  skipped.append({"id": instance.id, "reason": f"Error: {e}"})
+                  except Exception as e:
+                      logger.error(f"Error processing {instance.id} in {region}: {e}")
+                      continue
+
+              if skipped:
+                  logger.info(f"Skipped {len(skipped)} in {region}")
+                  for s in skipped[:5]:
+                      logger.info(f"  - {s['id']}: {s['reason']}")
+              return terminated
+
 
           def lambda_handler(event, context):
-              regions = [region['RegionName'] for region in boto3.client('ec2').describe_regions()['Regions']]
-              terminated_instances_all_regions = []
+              global eks_clusters_to_delete
+              eks_clusters_to_delete = {}
+
+              regions = [r["RegionName"] for r in boto3.client("ec2").describe_regions()["Regions"]]
+              all_terminated = []
+              deleted_clusters = []
 
               for region in regions:
-                  terminated_instances_region = terminate_instances_in_region(region)
-                  terminated_instances_all_regions.extend(terminated_instances_region)
+                  try:
+                      all_terminated.extend(process_region(region))
+                  except Exception as e:
+                      logger.error(f"Region {region} error: {e}")
+                      continue
 
-              if terminated_instances_all_regions:
-                  logger.info("Terminated instances:")
-                  for instance_info in terminated_instances_all_regions:
-                      logger.info(f"- Instance ID: {instance_info['InstanceId']}, SSH Key: {instance_info['SSHKeyName']}, Name Tag: {instance_info['NameTag']}, Availability Zone: {instance_info['AvailabilityZone']}")
+              for region, clusters in eks_clusters_to_delete.items():
+                  for name in clusters:
+                      try:
+                          if delete_eks_stack(name, region):
+                              deleted_clusters.append(f"{name} ({region})")
+                      except Exception as e:
+                          logger.error(f"Cluster delete {name} in {region}: {e}")
+
+              if all_terminated:
+                  logger.info("Terminated:")
+                  for t in all_terminated:
+                      logger.info(f"  {t['InstanceId']} Key={t['SSHKeyName']} Name={t['NameTag']} AZ={t['AvailabilityZone']}")
               else:
-                  logger.info("No instances were terminated.")
-      Role: !GetAtt RoleEC2Cleanup.Arn
-      Tags:
-        - Key: iit-billing-tag
-          Value: removeUntaggedEc2
+                  logger.info("No instances terminated.")
+
+              if deleted_clusters:
+                  logger.info(f"Deleted {len(deleted_clusters)} EKS clusters: {deleted_clusters}")
+              else:
+                  logger.info("No EKS clusters deleted.")
+
+              return {
+                  "statusCode": 200,
+                  "body": f"Terminated {len(all_terminated)} instances, deleted {len(deleted_clusters)} EKS clusters",
+              }
 
   EventEC2Cleanup:
     Type: AWS::Events::Rule
     Properties:
-      Description: "Executes every 15 minutes to cleanup untagged EC2 instances"
+      Description: "Trigger LambdaEC2Cleanup on schedule"
       Name: EventEC2Cleanup
-      ScheduleExpression: "rate(15 minutes)"
-      State: "ENABLED"
+      ScheduleExpression: !Ref ScheduleRate
+      State: ENABLED
       Targets:
         - Arn: !GetAtt LambdaEC2Cleanup.Arn
           Id: LambdaEC2Cleanup
@@ -182,9 +420,20 @@ Resources:
     Type: AWS::Lambda::Permission
     Properties:
       FunctionName: !Ref LambdaEC2Cleanup
-      Action: "lambda:InvokeFunction"
-      Principal: "events.amazonaws.com"
+      Action: lambda:InvokeFunction
+      Principal: events.amazonaws.com
       SourceArn: !GetAtt EventEC2Cleanup.Arn
 
-  # Note: CloudWatch LogGroup is created automatically by Lambda on first invocation
-  # Explicit creation removed to avoid IAM permission requirements
+  LambdaLogGroup:
+    Type: AWS::Logs::LogGroup
+    Properties:
+      LogGroupName: /aws/lambda/LambdaEC2Cleanup
+      RetentionInDays: !Ref LogRetentionDays
+
+Outputs:
+  LambdaArn:
+    Value: !GetAtt LambdaEC2Cleanup.Arn
+  RoleArn:
+    Value: !GetAtt RoleEC2Cleanup.Arn
+  ScheduleRule:
+    Value: !Ref EventEC2Cleanup


### PR DESCRIPTION
## What

Replace `removeUntaggedEc2` Lambda with a CF-managed `LambdaEC2Cleanup` stack. Fixes three bugs and adds Cirrus CI support.

## Why

Cirrus CI arm64 builds for `percona-server` and `percona-xtradb-cluster` were being terminated after 10 minutes because the cleanup Lambda lacked Cirrus CI awareness.

## Changes

### Bug fixes

- **Cirrus CI auto-tagging**: Cirrus CI cannot set `iit-billing-tag` at launch. The Lambda now detects instances with `CIRRUS_CI=true` and adds `iit-billing-tag=CirrusCI`, bridging them into the company-standard billing tag for cost tracking.

- **DRY_RUN guard**: `DRY_RUN` now gates all destructive actions, including EC2 termination and Cirrus CI tagging.

- **NameTag extraction**: Name tag lookup now uses a dict-based approach instead of positional index.

### Infrastructure

- Full CloudFormation IaC: IAM role, policy, EventBridge rule, CloudWatch log group.

- CF parameters: `DryRunMode`, `EksSkipPattern`, `ScheduleRate`, `LogRetentionDays`.

- Runtime: python3.13 on arm64 (Graviton).

## Deployment status

Stack deployed and verified in eu-west-1. Cirrus CI auto-tagging confirmed in CloudWatch logs: a live `percona/percona-server` build instance was detected and tagged during scheduled execution.

Fixes [PS-10899](https://perconadev.atlassian.net/browse/PS-10899).

[PS-10899]: https://perconadev.atlassian.net/browse/PS-10899?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ