### PR TITLE
fix(pxc): add boost 1.87.0 for PXC 9.6 Docker images

### DIFF
--- a/pxc/docker/install-deps
+++ b/pxc/docker/install-deps
@@ -554,8 +554,11 @@ wget_loop 'boost_1_77_0.tar.bz2' 'https://archives.boost.io/release/1.77.0/sourc
 # boost 1.84.0 needed for percona-server 8.4
 wget_loop 'boost_1_84_0.tar.bz2' 'https://archives.boost.io/release/1.84.0/source/boost_1_84_0.tar.bz2'
 
-# boost 1.85.0 needed for percona-server 9.x
+# boost 1.85.0 needed for percona-server 9.0-9.2
 wget_loop 'boost_1_85_0.tar.bz2' 'https://archives.boost.io/release/1.85.0/source/boost_1_85_0.tar.bz2'
+
+# boost 1.87.0 needed for percona-server 9.6
+wget_loop 'boost_1_87_0.tar.bz2' 'https://archives.boost.io/release/1.87.0/source/boost_1_87_0.tar.bz2'
 
 # googletest 1.8.0 needed for percona-server versions 5.6 to 8.0
 wget_loop 'googletest-release-1.8.0.zip' 'https://github.com/google/googletest/archive/release-1.8.0.zip'

--- a/pxc/jenkins/prepare-pxc-build-docker.yml
+++ b/pxc/jenkins/prepare-pxc-build-docker.yml
@@ -41,7 +41,7 @@
             stages {
                 stage('Prepare') {
                     steps {
-                        git poll: true, branch: 'fix/pxc-docker-ol8-boost187', url: 'https://github.com/Percona-Lab/jenkins-pipelines'
+                        git poll: true, branch: 'master', url: 'https://github.com/Percona-Lab/jenkins-pipelines'
                         sh '''
                             git reset --hard
                             git clean -xdf

--- a/pxc/jenkins/prepare-pxc-build-docker.yml
+++ b/pxc/jenkins/prepare-pxc-build-docker.yml
@@ -41,7 +41,7 @@
             stages {
                 stage('Prepare') {
                     steps {
-                        git poll: true, branch: 'master', url: 'https://github.com/Percona-Lab/jenkins-pipelines'
+                        git poll: true, branch: 'fix/pxc-docker-ol8-boost187', url: 'https://github.com/Percona-Lab/jenkins-pipelines'
                         sh '''
                             git reset --hard
                             git clean -xdf


### PR DESCRIPTION
## Summary

- Add boost_1_87_0.tar.bz2 pre-download to `pxc/docker/install-deps` for PXC 9.6 builds
- Narrow boost 1.85.0 comment from "9.x" to "9.0-9.2" for clarity

Tested on ps80 build 16 (SUCCESS, 19m20s). All 10 OS variants built and pushed to ECR.

Requested by @kamil-holubicki.