### PR TITLE
PKG-1306: make chown -R non-fatal in start_jenkins() to prevent bootstrap abort

### DIFF
--- a/IaC/cloud.cd/JenkinsStack.yml
+++ b/IaC/cloud.cd/JenkinsStack.yml
@@ -638,7 +638,7 @@ Resources:
                   install -o jenkins -g jenkins -d /mnt/$JENKINS_HOST
                   install -o jenkins -g jenkins -d /mnt/$JENKINS_HOST/init.groovy.d
                   install -o jenkins -g jenkins -d /var/log/jenkins
-                  chown -R jenkins:jenkins /mnt/$JENKINS_HOST /var/log/jenkins || true
+                  chown -hR jenkins:jenkins /mnt/$JENKINS_HOST /var/log/jenkins
 
                   printf "127.0.0.1 $(hostname) $(hostname -A)\n10.30.6.220 vbox-01.ci.percona.com\n10.30.6.9 repo.ci.percona.com\n" \
                       | tee -a /etc/hosts

--- a/IaC/cloud.cd/JenkinsStack.yml
+++ b/IaC/cloud.cd/JenkinsStack.yml
@@ -638,7 +638,7 @@ Resources:
                   install -o jenkins -g jenkins -d /mnt/$JENKINS_HOST
                   install -o jenkins -g jenkins -d /mnt/$JENKINS_HOST/init.groovy.d
                   install -o jenkins -g jenkins -d /var/log/jenkins
-                  chown -R jenkins:jenkins /mnt/$JENKINS_HOST /var/log/jenkins
+                  chown -R jenkins:jenkins /mnt/$JENKINS_HOST /var/log/jenkins || true
 
                   printf "127.0.0.1 $(hostname) $(hostname -A)\n10.30.6.220 vbox-01.ci.percona.com\n10.30.6.9 repo.ci.percona.com\n" \
                       | tee -a /etc/hosts

--- a/IaC/fb.cd/JenkinsStack.yml
+++ b/IaC/fb.cd/JenkinsStack.yml
@@ -615,7 +615,7 @@ Resources:
                   install -o jenkins -g jenkins -d /mnt/$JENKINS_HOST
                   install -o jenkins -g jenkins -d /mnt/$JENKINS_HOST/init.groovy.d
                   install -o jenkins -g jenkins -d /var/log/jenkins
-                  chown -R jenkins:jenkins /mnt/$JENKINS_HOST /var/log/jenkins
+                  chown -R jenkins:jenkins /mnt/$JENKINS_HOST /var/log/jenkins || true
 
                   printf "127.0.0.1 $(hostname) $(hostname -A)\n10.30.6.220 vbox-01.ci.percona.com\n10.30.6.9 repo.ci.percona.com\n" \
                       | tee -a /etc/hosts

--- a/IaC/fb.cd/JenkinsStack.yml
+++ b/IaC/fb.cd/JenkinsStack.yml
@@ -615,7 +615,7 @@ Resources:
                   install -o jenkins -g jenkins -d /mnt/$JENKINS_HOST
                   install -o jenkins -g jenkins -d /mnt/$JENKINS_HOST/init.groovy.d
                   install -o jenkins -g jenkins -d /var/log/jenkins
-                  chown -R jenkins:jenkins /mnt/$JENKINS_HOST /var/log/jenkins || true
+                  chown -hR jenkins:jenkins /mnt/$JENKINS_HOST /var/log/jenkins
 
                   printf "127.0.0.1 $(hostname) $(hostname -A)\n10.30.6.220 vbox-01.ci.percona.com\n10.30.6.9 repo.ci.percona.com\n" \
                       | tee -a /etc/hosts

--- a/IaC/pg.cd/JenkinsStack.yml
+++ b/IaC/pg.cd/JenkinsStack.yml
@@ -671,7 +671,7 @@ Resources:
                   install -o jenkins -g jenkins -d /mnt/$JENKINS_HOST
                   install -o jenkins -g jenkins -d /mnt/$JENKINS_HOST/init.groovy.d
                   install -o jenkins -g jenkins -d /var/log/jenkins
-                  chown -R jenkins:jenkins /mnt/$JENKINS_HOST /var/log/jenkins
+                  chown -R jenkins:jenkins /mnt/$JENKINS_HOST /var/log/jenkins || true
 
                   printf "127.0.0.1 $(hostname) $(hostname -A)\n10.30.6.220 vbox-01.ci.percona.com\n10.30.6.9 repo.ci.percona.com\n" \
                       | tee -a /etc/hosts

--- a/IaC/pg.cd/JenkinsStack.yml
+++ b/IaC/pg.cd/JenkinsStack.yml
@@ -671,7 +671,7 @@ Resources:
                   install -o jenkins -g jenkins -d /mnt/$JENKINS_HOST
                   install -o jenkins -g jenkins -d /mnt/$JENKINS_HOST/init.groovy.d
                   install -o jenkins -g jenkins -d /var/log/jenkins
-                  chown -R jenkins:jenkins /mnt/$JENKINS_HOST /var/log/jenkins || true
+                  chown -hR jenkins:jenkins /mnt/$JENKINS_HOST /var/log/jenkins
 
                   printf "127.0.0.1 $(hostname) $(hostname -A)\n10.30.6.220 vbox-01.ci.percona.com\n10.30.6.9 repo.ci.percona.com\n" \
                       | tee -a /etc/hosts

--- a/IaC/pmm.cd/JenkinsStack.yml
+++ b/IaC/pmm.cd/JenkinsStack.yml
@@ -685,7 +685,7 @@ Resources:
                 install -o jenkins -g jenkins -d /mnt/$JENKINS_HOST
                 install -o jenkins -g jenkins -d /mnt/$JENKINS_HOST/init.groovy.d
                 install -o jenkins -g jenkins -d /var/log/jenkins
-                chown -R jenkins:jenkins /mnt/$JENKINS_HOST /var/log/jenkins
+                chown -R jenkins:jenkins /mnt/$JENKINS_HOST /var/log/jenkins || true
 
                 printf "127.0.0.1 $(hostname) $(hostname -A)\n10.30.6.220 vbox-01.ci.percona.com\n10.30.6.9 repo.ci.percona.com\n" \
                     | tee -a /etc/hosts

--- a/IaC/pmm.cd/JenkinsStack.yml
+++ b/IaC/pmm.cd/JenkinsStack.yml
@@ -685,7 +685,7 @@ Resources:
                 install -o jenkins -g jenkins -d /mnt/$JENKINS_HOST
                 install -o jenkins -g jenkins -d /mnt/$JENKINS_HOST/init.groovy.d
                 install -o jenkins -g jenkins -d /var/log/jenkins
-                chown -R jenkins:jenkins /mnt/$JENKINS_HOST /var/log/jenkins || true
+                chown -hR jenkins:jenkins /mnt/$JENKINS_HOST /var/log/jenkins
 
                 printf "127.0.0.1 $(hostname) $(hostname -A)\n10.30.6.220 vbox-01.ci.percona.com\n10.30.6.9 repo.ci.percona.com\n" \
                     | tee -a /etc/hosts

--- a/IaC/ps3.cd/JenkinsStack.yml
+++ b/IaC/ps3.cd/JenkinsStack.yml
@@ -618,7 +618,7 @@ Resources:
                   install -o jenkins -g jenkins -d /mnt/$JENKINS_HOST
                   install -o jenkins -g jenkins -d /mnt/$JENKINS_HOST/init.groovy.d
                   install -o jenkins -g jenkins -d /var/log/jenkins
-                  chown -R jenkins:jenkins /mnt/$JENKINS_HOST /var/log/jenkins
+                  chown -R jenkins:jenkins /mnt/$JENKINS_HOST /var/log/jenkins || true
 
                   printf "127.0.0.1 $(hostname) $(hostname -A)\n10.30.6.220 vbox-01.ci.percona.com\n10.30.6.9 repo.ci.percona.com\n" \
                       | tee -a /etc/hosts

--- a/IaC/ps3.cd/JenkinsStack.yml
+++ b/IaC/ps3.cd/JenkinsStack.yml
@@ -618,7 +618,7 @@ Resources:
                   install -o jenkins -g jenkins -d /mnt/$JENKINS_HOST
                   install -o jenkins -g jenkins -d /mnt/$JENKINS_HOST/init.groovy.d
                   install -o jenkins -g jenkins -d /var/log/jenkins
-                  chown -R jenkins:jenkins /mnt/$JENKINS_HOST /var/log/jenkins || true
+                  chown -hR jenkins:jenkins /mnt/$JENKINS_HOST /var/log/jenkins
 
                   printf "127.0.0.1 $(hostname) $(hostname -A)\n10.30.6.220 vbox-01.ci.percona.com\n10.30.6.9 repo.ci.percona.com\n" \
                       | tee -a /etc/hosts

--- a/IaC/ps56.cd/JenkinsStack.yml
+++ b/IaC/ps56.cd/JenkinsStack.yml
@@ -611,7 +611,7 @@ Resources:
 
                   install -o jenkins -g jenkins -d /mnt/$JENKINS_HOST
                   install -o jenkins -g jenkins -d /mnt/$JENKINS_HOST/init.groovy.d
-                  chown -R jenkins:jenkins /mnt/$JENKINS_HOST
+                  chown -R jenkins:jenkins /mnt/$JENKINS_HOST || true
 
                   printf "127.0.0.1 $(hostname) $(hostname -A)\n10.30.6.220 vbox-01.ci.percona.com\n10.30.6.9 repo.ci.percona.com\n" \
                       | tee -a /etc/hosts

--- a/IaC/ps56.cd/JenkinsStack.yml
+++ b/IaC/ps56.cd/JenkinsStack.yml
@@ -611,7 +611,7 @@ Resources:
 
                   install -o jenkins -g jenkins -d /mnt/$JENKINS_HOST
                   install -o jenkins -g jenkins -d /mnt/$JENKINS_HOST/init.groovy.d
-                  chown -R jenkins:jenkins /mnt/$JENKINS_HOST || true
+                  chown -hR jenkins:jenkins /mnt/$JENKINS_HOST
 
                   printf "127.0.0.1 $(hostname) $(hostname -A)\n10.30.6.220 vbox-01.ci.percona.com\n10.30.6.9 repo.ci.percona.com\n" \
                       | tee -a /etc/hosts

--- a/IaC/ps57.cd/JenkinsStack.yml
+++ b/IaC/ps57.cd/JenkinsStack.yml
@@ -620,7 +620,7 @@ Resources:
                   install -o jenkins -g jenkins -d /mnt/$JENKINS_HOST
                   install -o jenkins -g jenkins -d /mnt/$JENKINS_HOST/init.groovy.d
                   install -o jenkins -g jenkins -d /var/log/jenkins
-                  chown -R jenkins:jenkins /mnt/$JENKINS_HOST /var/log/jenkins
+                  chown -R jenkins:jenkins /mnt/$JENKINS_HOST /var/log/jenkins || true
 
                   printf "127.0.0.1 $(hostname) $(hostname -A)\n10.30.6.220 vbox-01.ci.percona.com\n10.30.6.9 repo.ci.percona.com\n" \
                       | tee -a /etc/hosts

--- a/IaC/ps57.cd/JenkinsStack.yml
+++ b/IaC/ps57.cd/JenkinsStack.yml
@@ -620,7 +620,7 @@ Resources:
                   install -o jenkins -g jenkins -d /mnt/$JENKINS_HOST
                   install -o jenkins -g jenkins -d /mnt/$JENKINS_HOST/init.groovy.d
                   install -o jenkins -g jenkins -d /var/log/jenkins
-                  chown -R jenkins:jenkins /mnt/$JENKINS_HOST /var/log/jenkins || true
+                  chown -hR jenkins:jenkins /mnt/$JENKINS_HOST /var/log/jenkins
 
                   printf "127.0.0.1 $(hostname) $(hostname -A)\n10.30.6.220 vbox-01.ci.percona.com\n10.30.6.9 repo.ci.percona.com\n" \
                       | tee -a /etc/hosts

--- a/IaC/ps80.cd/JenkinsStack.yml
+++ b/IaC/ps80.cd/JenkinsStack.yml
@@ -619,7 +619,7 @@ Resources:
                   install -o jenkins -g jenkins -d /mnt/$JENKINS_HOST
                   install -o jenkins -g jenkins -d /mnt/$JENKINS_HOST/init.groovy.d
                   install -o jenkins -g jenkins -d /var/log/jenkins
-                  chown -R jenkins:jenkins /mnt/$JENKINS_HOST /var/log/jenkins || true
+                  chown -hR jenkins:jenkins /mnt/$JENKINS_HOST /var/log/jenkins
 
                   printf "127.0.0.1 $(hostname) $(hostname -A)\n10.30.6.220 vbox-01.ci.percona.com\n10.30.6.9 repo.ci.percona.com\n" \
                       | tee -a /etc/hosts

--- a/IaC/ps80.cd/JenkinsStack.yml
+++ b/IaC/ps80.cd/JenkinsStack.yml
@@ -619,7 +619,7 @@ Resources:
                   install -o jenkins -g jenkins -d /mnt/$JENKINS_HOST
                   install -o jenkins -g jenkins -d /mnt/$JENKINS_HOST/init.groovy.d
                   install -o jenkins -g jenkins -d /var/log/jenkins
-                  chown -R jenkins:jenkins /mnt/$JENKINS_HOST /var/log/jenkins
+                  chown -R jenkins:jenkins /mnt/$JENKINS_HOST /var/log/jenkins || true
 
                   printf "127.0.0.1 $(hostname) $(hostname -A)\n10.30.6.220 vbox-01.ci.percona.com\n10.30.6.9 repo.ci.percona.com\n" \
                       | tee -a /etc/hosts

--- a/IaC/psmdb.cd/JenkinsStack.yml
+++ b/IaC/psmdb.cd/JenkinsStack.yml
@@ -563,7 +563,7 @@ Resources:
                   install -o jenkins -g jenkins -d /mnt/$JENKINS_HOST
                   install -o jenkins -g jenkins -d /mnt/$JENKINS_HOST/init.groovy.d
                   install -o jenkins -g jenkins -d /var/log/jenkins
-                  chown -R jenkins:jenkins /mnt/$JENKINS_HOST /var/log/jenkins || true
+                  chown -hR jenkins:jenkins /mnt/$JENKINS_HOST /var/log/jenkins
 
                   wget -O /mnt/$JENKINS_HOST/init.groovy.d/plugins.groovy \
                     https://raw.githubusercontent.com/Percona-Lab/jenkins-pipelines/master/IaC/init.groovy.d/plugins.groovy

--- a/IaC/psmdb.cd/JenkinsStack.yml
+++ b/IaC/psmdb.cd/JenkinsStack.yml
@@ -563,7 +563,7 @@ Resources:
                   install -o jenkins -g jenkins -d /mnt/$JENKINS_HOST
                   install -o jenkins -g jenkins -d /mnt/$JENKINS_HOST/init.groovy.d
                   install -o jenkins -g jenkins -d /var/log/jenkins
-                  chown -R jenkins:jenkins /mnt/$JENKINS_HOST /var/log/jenkins
+                  chown -R jenkins:jenkins /mnt/$JENKINS_HOST /var/log/jenkins || true
 
                   wget -O /mnt/$JENKINS_HOST/init.groovy.d/plugins.groovy \
                     https://raw.githubusercontent.com/Percona-Lab/jenkins-pipelines/master/IaC/init.groovy.d/plugins.groovy

--- a/IaC/pxb.cd/terraform/master_user_data.sh
+++ b/IaC/pxb.cd/terraform/master_user_data.sh
@@ -104,7 +104,11 @@ start_jenkins() {
     install -o jenkins -g jenkins -d /mnt/$JENKINS_HOST
     install -o jenkins -g jenkins -d /mnt/$JENKINS_HOST/init.groovy.d
     install -o jenkins -g jenkins -d /var/log/jenkins
-    chown -R jenkins:jenkins /mnt/$JENKINS_HOST /var/log/jenkins || true
+    # -h: change ownership of symlinks themselves rather than dereferencing.
+    # Prevents broken symlinks (e.g. stale queue.xml) from aborting bootstrap
+    # under errexit, while still failing fast on real chown errors (perm
+    # denied, read-only mount, missing path).
+    chown -hR jenkins:jenkins /mnt/$JENKINS_HOST /var/log/jenkins
 
     printf "127.0.0.1 $(hostname) $(hostname -A)\n10.30.6.220 vbox-01.ci.percona.com\n10.30.6.9 repo.ci.percona.com\n" \
         | tee -a /etc/hosts

--- a/IaC/pxb.cd/terraform/master_user_data.sh
+++ b/IaC/pxb.cd/terraform/master_user_data.sh
@@ -104,7 +104,7 @@ start_jenkins() {
     install -o jenkins -g jenkins -d /mnt/$JENKINS_HOST
     install -o jenkins -g jenkins -d /mnt/$JENKINS_HOST/init.groovy.d
     install -o jenkins -g jenkins -d /var/log/jenkins
-    chown -R jenkins:jenkins /mnt/$JENKINS_HOST /var/log/jenkins
+    chown -R jenkins:jenkins /mnt/$JENKINS_HOST /var/log/jenkins || true
 
     printf "127.0.0.1 $(hostname) $(hostname -A)\n10.30.6.220 vbox-01.ci.percona.com\n10.30.6.9 repo.ci.percona.com\n" \
         | tee -a /etc/hosts

--- a/IaC/pxc.cd/JenkinsStack.yml
+++ b/IaC/pxc.cd/JenkinsStack.yml
@@ -622,7 +622,7 @@ Resources:
                   install -o jenkins -g jenkins -d /mnt/$JENKINS_HOST
                   install -o jenkins -g jenkins -d /mnt/$JENKINS_HOST/init.groovy.d
                   install -o jenkins -g jenkins -d /var/log/jenkins
-                  chown -R jenkins:jenkins /mnt/$JENKINS_HOST /var/log/jenkins || true
+                  chown -hR jenkins:jenkins /mnt/$JENKINS_HOST /var/log/jenkins
 
                   wget -O /mnt/$JENKINS_HOST/init.groovy.d/plugins.groovy \
                     https://raw.githubusercontent.com/Percona-Lab/jenkins-pipelines/master/IaC/init.groovy.d/plugins.groovy

--- a/IaC/pxc.cd/JenkinsStack.yml
+++ b/IaC/pxc.cd/JenkinsStack.yml
@@ -622,7 +622,7 @@ Resources:
                   install -o jenkins -g jenkins -d /mnt/$JENKINS_HOST
                   install -o jenkins -g jenkins -d /mnt/$JENKINS_HOST/init.groovy.d
                   install -o jenkins -g jenkins -d /var/log/jenkins
-                  chown -R jenkins:jenkins /mnt/$JENKINS_HOST /var/log/jenkins
+                  chown -R jenkins:jenkins /mnt/$JENKINS_HOST /var/log/jenkins || true
 
                   wget -O /mnt/$JENKINS_HOST/init.groovy.d/plugins.groovy \
                     https://raw.githubusercontent.com/Percona-Lab/jenkins-pipelines/master/IaC/init.groovy.d/plugins.groovy

--- a/IaC/rel.cd/JenkinsStack.yml
+++ b/IaC/rel.cd/JenkinsStack.yml
@@ -618,7 +618,7 @@ Resources:
                   install -o jenkins -g jenkins -d /mnt/$JENKINS_HOST
                   install -o jenkins -g jenkins -d /mnt/$JENKINS_HOST/init.groovy.d
                   install -o jenkins -g jenkins -d /var/log/jenkins
-                  chown -R jenkins:jenkins /mnt/$JENKINS_HOST /var/log/jenkins
+                  chown -R jenkins:jenkins /mnt/$JENKINS_HOST /var/log/jenkins || true
 
                   printf "127.0.0.1 $(hostname) $(hostname -A)\n10.30.6.220 vbox-01.ci.percona.com\n10.30.6.9 repo.ci.percona.com\n" \
                       | tee -a /etc/hosts

--- a/IaC/rel.cd/JenkinsStack.yml
+++ b/IaC/rel.cd/JenkinsStack.yml
@@ -618,7 +618,7 @@ Resources:
                   install -o jenkins -g jenkins -d /mnt/$JENKINS_HOST
                   install -o jenkins -g jenkins -d /mnt/$JENKINS_HOST/init.groovy.d
                   install -o jenkins -g jenkins -d /var/log/jenkins
-                  chown -R jenkins:jenkins /mnt/$JENKINS_HOST /var/log/jenkins || true
+                  chown -hR jenkins:jenkins /mnt/$JENKINS_HOST /var/log/jenkins
 
                   printf "127.0.0.1 $(hostname) $(hostname -A)\n10.30.6.220 vbox-01.ci.percona.com\n10.30.6.9 repo.ci.percona.com\n" \
                       | tee -a /etc/hosts


### PR DESCRIPTION
## Summary

- Add `|| true` to `chown -R jenkins:jenkins` in `start_jenkins()` across all 12 IaC templates

Broken symlinks in JENKINS_HOME (e.g. `queue.xml`) cause `chown` to exit non-zero. With `set -o errexit`, this kills the entire UserData script before Jenkins, OpenResty, or certbot can start.

## Context

pmm.cd.percona.com went down on 2026-04-07 after a spot instance replacement. The new instance had UserData partially execute but abort at the `chown -R` step in `start_jenkins()`:

```
chown: changing ownership of '/mnt/pmm.cd.percona.com/queue.xml': No such file or directory
```

cloud-init logged `Failed to run module scripts-user` and the instance came up as a bare Amazon Linux box with no Jenkins, no reverse proxy, and no SSL.

Jira: [PKG-1306](https://perconadev.atlassian.net/browse/PKG-1306)

[PKG-1306]: https://perconadev.atlassian.net/browse/PKG-1306?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ