### PR TITLE
PKG-1307: inject /etc/hosts for repo.ci.percona.com on Hetzner workers

### DIFF
--- a/IaC/cloud.cd/init.groovy.d/htz.cloud.groovy
+++ b/IaC/cloud.cd/init.groovy.d/htz.cloud.groovy
@@ -79,6 +79,7 @@ initMap = [:]
 initMap['fedora-docker'] = '''#!/bin/bash -x
     set -o xtrace
     echo -e "nameserver 9.9.9.9\nnameserver 1.1.1.1" | sudo tee /etc/resolv.conf
+    echo '10.30.6.9 repo.ci.percona.com' | sudo tee -a /etc/hosts
     ( sudo systemctl stop sshd; sleep 300; sudo systemctl start sshd ) &
     sudo install -o $(id -u -n) -g $(id -g -n) -d /mnt/jenkins
     sudo fallocate -l 32G /swapfile

--- a/IaC/pg.cd/init.groovy.d/htz.cloud.groovy
+++ b/IaC/pg.cd/init.groovy.d/htz.cloud.groovy
@@ -79,6 +79,7 @@ initMap = [:]
 initMap['deb-docker'] = '''#!/bin/bash -x
     set -o xtrace
     echo -e "nameserver 9.9.9.9\nnameserver 1.1.1.1" | sudo tee /etc/resolv.conf
+    echo '10.30.6.9 repo.ci.percona.com' | sudo tee -a /etc/hosts
     sudo install -o $(id -u -n) -g $(id -g -n) -d /mnt/jenkins
     sudo fallocate -l 32G /swapfile
     sudo chmod 600 /swapfile

--- a/IaC/pmm.cd/init.groovy.d/htz.cloud.groovy
+++ b/IaC/pmm.cd/init.groovy.d/htz.cloud.groovy
@@ -79,6 +79,7 @@ initMap = [:]
 initMap['deb-docker'] = '''#!/bin/bash -x
     set -o xtrace
     echo -e "nameserver 9.9.9.9\nnameserver 1.1.1.1" | sudo tee /etc/resolv.conf
+    echo '10.30.6.9 repo.ci.percona.com' | sudo tee -a /etc/hosts
     sudo install -o $(id -u -n) -g $(id -g -n) -d /mnt/jenkins
     sudo fallocate -l 32G /swapfile
     sudo chmod 600 /swapfile

--- a/IaC/ps3.cd/init.groovy.d/htz.cloud.groovy
+++ b/IaC/ps3.cd/init.groovy.d/htz.cloud.groovy
@@ -79,6 +79,7 @@ initMap = [:]
 initMap['deb-docker'] = '''#!/bin/bash -x
     set -o xtrace
     echo -e "nameserver 9.9.9.9\nnameserver 1.1.1.1" | sudo tee /etc/resolv.conf
+    echo '10.30.6.9 repo.ci.percona.com' | sudo tee -a /etc/hosts
     sudo install -o $(id -u -n) -g $(id -g -n) -d /mnt/jenkins
     sudo fallocate -l 32G /swapfile
     sudo chmod 600 /swapfile

--- a/IaC/ps57.cd/init.groovy.d/htz.cloud.groovy
+++ b/IaC/ps57.cd/init.groovy.d/htz.cloud.groovy
@@ -79,6 +79,7 @@ initMap = [:]
 initMap['deb-docker'] = '''#!/bin/bash -x
     set -o xtrace
     echo -e "nameserver 9.9.9.9\nnameserver 1.1.1.1" | sudo tee /etc/resolv.conf
+    echo '10.30.6.9 repo.ci.percona.com' | sudo tee -a /etc/hosts
     sudo install -o $(id -u -n) -g $(id -g -n) -d /mnt/jenkins
     sudo fallocate -l 32G /swapfile
     sudo chmod 600 /swapfile

--- a/IaC/ps80.cd/init.groovy.d/htz.cloud.groovy
+++ b/IaC/ps80.cd/init.groovy.d/htz.cloud.groovy
@@ -79,6 +79,7 @@ initMap = [:]
 initMap['deb-docker'] = '''#!/bin/bash -x
     set -o xtrace
     echo -e "nameserver 9.9.9.9\nnameserver 1.1.1.1" | sudo tee /etc/resolv.conf
+    echo '10.30.6.9 repo.ci.percona.com' | sudo tee -a /etc/hosts
     sudo install -o $(id -u -n) -g $(id -g -n) -d /mnt/jenkins
     sudo fallocate -l 32G /swapfile
     sudo chmod 600 /swapfile

--- a/IaC/psmdb.cd/init.groovy.d/htz.cloud.groovy
+++ b/IaC/psmdb.cd/init.groovy.d/htz.cloud.groovy
@@ -79,6 +79,7 @@ initMap = [:]
 initMap['deb-docker'] = '''#!/bin/bash -x
     set -o xtrace
     echo -e "nameserver 9.9.9.9\nnameserver 1.1.1.1" | sudo tee /etc/resolv.conf
+    echo '10.30.6.9 repo.ci.percona.com' | sudo tee -a /etc/hosts
     ( sudo systemctl stop sshd; sleep 300; sudo systemctl start sshd ) &
     sudo install -o $(id -u -n) -g $(id -g -n) -d /mnt/jenkins
     sudo fallocate -l 32G /swapfile

--- a/IaC/pxb.cd/init.groovy.d/htz.cloud.groovy
+++ b/IaC/pxb.cd/init.groovy.d/htz.cloud.groovy
@@ -79,6 +79,7 @@ initMap = [:]
 initMap['deb-docker'] = '''#!/bin/bash -x
     set -o xtrace
     echo -e "nameserver 9.9.9.9\nnameserver 1.1.1.1" | sudo tee /etc/resolv.conf
+    echo '10.30.6.9 repo.ci.percona.com' | sudo tee -a /etc/hosts
     sudo install -o $(id -u -n) -g $(id -g -n) -d /mnt/jenkins
     sudo fallocate -l 32G /swapfile
     sudo chmod 600 /swapfile

--- a/IaC/pxc.cd/init.groovy.d/htz.cloud.groovy
+++ b/IaC/pxc.cd/init.groovy.d/htz.cloud.groovy
@@ -79,6 +79,7 @@ initMap = [:]
 initMap['deb-docker'] = '''#!/bin/bash -x
     set -o xtrace
     echo -e "nameserver 9.9.9.9\nnameserver 1.1.1.1" | sudo tee /etc/resolv.conf
+    echo '10.30.6.9 repo.ci.percona.com' | sudo tee -a /etc/hosts
     sudo install -o $(id -u -n) -g $(id -g -n) -d /mnt/jenkins
     sudo fallocate -l 32G /swapfile
     sudo chmod 600 /swapfile

--- a/IaC/rel.cd/init.groovy.d/htz.cloud.groovy
+++ b/IaC/rel.cd/init.groovy.d/htz.cloud.groovy
@@ -79,6 +79,7 @@ initMap = [:]
 initMap['deb-docker'] = '''#!/bin/bash -x
     set -o xtrace
     echo -e "nameserver 9.9.9.9\nnameserver 1.1.1.1" | sudo tee /etc/resolv.conf
+    echo '10.30.6.9 repo.ci.percona.com' | sudo tee -a /etc/hosts
     ( sudo systemctl stop sshd; sleep 300; sudo systemctl start sshd ) &
     sudo install -o $(id -u -n) -g $(id -g -n) -d /mnt/jenkins
     sudo fallocate -l 32G /swapfile

--- a/vars/signDEB.groovy
+++ b/vars/signDEB.groovy
@@ -7,6 +7,10 @@ def call(String CLOUD_NAME = 'default') {
                 sh """
                     export path_to_build=`cat uploadPath`
 
+                    cat /etc/hosts > hosts
+                    echo '10.30.6.9 repo.ci.percona.com' >> hosts
+                    sudo cp ./hosts /etc || true
+
                     ssh -o StrictHostKeyChecking=no -i ${KEY_PATH} ${USER}@repo.ci.percona.com " \
                         ls \${path_to_build}/binary/debian/*/*/*.deb \
                             | xargs -n 1 signpackage --verbose --password ${SIGN_PASSWORD} --deb

--- a/vars/signRPM.groovy
+++ b/vars/signRPM.groovy
@@ -7,6 +7,10 @@ def call(String CLOUD_NAME = 'default') {
                 sh """
                     export path_to_build=`cat uploadPath`
 
+                    cat /etc/hosts > hosts
+                    echo '10.30.6.9 repo.ci.percona.com' >> hosts
+                    sudo cp ./hosts /etc || true
+
                     ssh -o StrictHostKeyChecking=no -i ${KEY_PATH} ${USER}@repo.ci.percona.com " \
                         ls \${path_to_build}/binary/redhat/*/*/*.rpm \
                             | xargs -n 1 signpackage --verbose --password ${SIGN_PASSWORD} --rpm


### PR DESCRIPTION
## Summary

Fixes [PKG-1307](https://perconadev.atlassian.net/browse/PKG-1307). Hetzner Jenkins workers fail to resolve `repo.ci.percona.com` during package signing, breaking RPM/DEB release jobs with `ssh: Could not resolve hostname repo.ci.percona.com: Temporary failure in name resolution`. Reproduced on `hetzner-pg_cron-RELEASE` build 19 and `hetzner-percona-telemetry-agent-RELEASE` build 48 on `rel.cd.percona.com`.

## Root cause

Two compounding gaps on the `hetzner` branch:

1. `vars/signRPM.groovy` and `vars/signDEB.groovy` were moved off `node('master')` to dispatch on `launcher-x64` (Hetzner) or `micro-amazon` (EC2) based on `params.CLOUD`. The Hetzner branch never had the `/etc/hosts` injection that sibling helpers (`vars/sync2web.groovy`, `vars/uploadTarballfromAWS.groovy`) carry inline.

2. `IaC/<inst>.cd/init.groovy.d/htz.cloud.groovy` does not bake `10.30.6.9 repo.ci.percona.com` into `/etc/hosts` at provisioning time, unlike the EC2 equivalent `cloud.groovy` which has carried that line for years. Newly provisioned `hcloud-*` workers therefore have no way to resolve the host.

`repo.ci.percona.com` is an internal ITOps host with no public DNS record. The IP `10.30.6.9` is reachable from Hetzner workers via `percona-vpc-eu` routing through the Ashburn VPC gateway, so a hosts entry alone is sufficient.

## Scope

Two distinct release jobs / 3 builds were affected on `rel.cd.percona.com` within a ~46-minute window on 2026-04-07. Other release helpers that already inject `/etc/hosts` inline (`sync2web`, `uploadTarballfromAWS`, etc.) are unaffected. Not a fleet-wide DNS or network outage.


[PKG-1307]: https://perconadev.atlassian.net/browse/PKG-1307?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ