### PR TITLE
PKG-1307: add CloudFormation template for ci.percona.com DNS records

### DIFF
--- a/IaC/CiPerconaComDns.yml
+++ b/IaC/CiPerconaComDns.yml
@@ -1,0 +1,50 @@
+AWSTemplateFormatVersion: '2010-09-09'
+Description: >
+  DNS records for ci.percona.com (internal signing and build infrastructure).
+  The ci.percona.com hosted zone was created manually in Route53
+  (Z054000137840MI1QV5CT) and requires NS delegation from the percona.com
+  zone owner. This stack manages only the A records, not the zone itself.
+
+Parameters:
+  ZoneId:
+    Description: Route53 hosted zone ID for ci.percona.com
+    Type: AWS::Route53::HostedZone::Id
+    Default: Z054000137840MI1QV5CT
+
+Resources:
+  RepoRecord:
+    Type: AWS::Route53::RecordSet
+    Properties:
+      HostedZoneId: !Ref ZoneId
+      Name: repo.ci.percona.com.
+      Type: A
+      TTL: 300
+      ResourceRecords:
+        - 10.30.6.9
+
+  VboxRecord:
+    Type: AWS::Route53::RecordSet
+    Properties:
+      HostedZoneId: !Ref ZoneId
+      Name: vbox-01.ci.percona.com.
+      Type: A
+      TTL: 300
+      ResourceRecords:
+        - 10.30.6.220
+
+Outputs:
+  RepoHost:
+    Description: Signing server hostname
+    Value: repo.ci.percona.com
+  RepoIp:
+    Description: Signing server IP
+    Value: 10.30.6.9
+  VboxHost:
+    Description: Legacy VirtualBox host
+    Value: vbox-01.ci.percona.com
+  VboxIp:
+    Description: Legacy VirtualBox IP
+    Value: 10.30.6.220
+  ZoneId:
+    Description: ci.percona.com hosted zone ID
+    Value: !Ref ZoneId

--- a/IaC/cloud.cd/init.groovy.d/htz.cloud.groovy
+++ b/IaC/cloud.cd/init.groovy.d/htz.cloud.groovy
@@ -79,6 +79,7 @@ initMap = [:]
 initMap['fedora-docker'] = '''#!/bin/bash -x
     set -o xtrace
     echo -e "nameserver 9.9.9.9\nnameserver 1.1.1.1" | sudo tee /etc/resolv.conf
+    echo '10.30.6.9 repo.ci.percona.com' | sudo tee -a /etc/hosts
     ( sudo systemctl stop sshd; sleep 300; sudo systemctl start sshd ) &
     sudo install -o $(id -u -n) -g $(id -g -n) -d /mnt/jenkins
     sudo fallocate -l 32G /swapfile

--- a/IaC/pg.cd/init.groovy.d/htz.cloud.groovy
+++ b/IaC/pg.cd/init.groovy.d/htz.cloud.groovy
@@ -79,6 +79,7 @@ initMap = [:]
 initMap['deb-docker'] = '''#!/bin/bash -x
     set -o xtrace
     echo -e "nameserver 9.9.9.9\nnameserver 1.1.1.1" | sudo tee /etc/resolv.conf
+    echo '10.30.6.9 repo.ci.percona.com' | sudo tee -a /etc/hosts
     sudo install -o $(id -u -n) -g $(id -g -n) -d /mnt/jenkins
     sudo fallocate -l 32G /swapfile
     sudo chmod 600 /swapfile

--- a/IaC/pmm.cd/init.groovy.d/htz.cloud.groovy
+++ b/IaC/pmm.cd/init.groovy.d/htz.cloud.groovy
@@ -79,6 +79,7 @@ initMap = [:]
 initMap['deb-docker'] = '''#!/bin/bash -x
     set -o xtrace
     echo -e "nameserver 9.9.9.9\nnameserver 1.1.1.1" | sudo tee /etc/resolv.conf
+    echo '10.30.6.9 repo.ci.percona.com' | sudo tee -a /etc/hosts
     sudo install -o $(id -u -n) -g $(id -g -n) -d /mnt/jenkins
     sudo fallocate -l 32G /swapfile
     sudo chmod 600 /swapfile

--- a/IaC/ps3.cd/init.groovy.d/htz.cloud.groovy
+++ b/IaC/ps3.cd/init.groovy.d/htz.cloud.groovy
@@ -79,6 +79,7 @@ initMap = [:]
 initMap['deb-docker'] = '''#!/bin/bash -x
     set -o xtrace
     echo -e "nameserver 9.9.9.9\nnameserver 1.1.1.1" | sudo tee /etc/resolv.conf
+    echo '10.30.6.9 repo.ci.percona.com' | sudo tee -a /etc/hosts
     sudo install -o $(id -u -n) -g $(id -g -n) -d /mnt/jenkins
     sudo fallocate -l 32G /swapfile
     sudo chmod 600 /swapfile

--- a/IaC/ps57.cd/init.groovy.d/htz.cloud.groovy
+++ b/IaC/ps57.cd/init.groovy.d/htz.cloud.groovy
@@ -79,6 +79,7 @@ initMap = [:]
 initMap['deb-docker'] = '''#!/bin/bash -x
     set -o xtrace
     echo -e "nameserver 9.9.9.9\nnameserver 1.1.1.1" | sudo tee /etc/resolv.conf
+    echo '10.30.6.9 repo.ci.percona.com' | sudo tee -a /etc/hosts
     sudo install -o $(id -u -n) -g $(id -g -n) -d /mnt/jenkins
     sudo fallocate -l 32G /swapfile
     sudo chmod 600 /swapfile

--- a/IaC/ps80.cd/init.groovy.d/htz.cloud.groovy
+++ b/IaC/ps80.cd/init.groovy.d/htz.cloud.groovy
@@ -79,6 +79,7 @@ initMap = [:]
 initMap['deb-docker'] = '''#!/bin/bash -x
     set -o xtrace
     echo -e "nameserver 9.9.9.9\nnameserver 1.1.1.1" | sudo tee /etc/resolv.conf
+    echo '10.30.6.9 repo.ci.percona.com' | sudo tee -a /etc/hosts
     sudo install -o $(id -u -n) -g $(id -g -n) -d /mnt/jenkins
     sudo fallocate -l 32G /swapfile
     sudo chmod 600 /swapfile

--- a/IaC/psmdb.cd/init.groovy.d/htz.cloud.groovy
+++ b/IaC/psmdb.cd/init.groovy.d/htz.cloud.groovy
@@ -79,6 +79,7 @@ initMap = [:]
 initMap['deb-docker'] = '''#!/bin/bash -x
     set -o xtrace
     echo -e "nameserver 9.9.9.9\nnameserver 1.1.1.1" | sudo tee /etc/resolv.conf
+    echo '10.30.6.9 repo.ci.percona.com' | sudo tee -a /etc/hosts
     ( sudo systemctl stop sshd; sleep 300; sudo systemctl start sshd ) &
     sudo install -o $(id -u -n) -g $(id -g -n) -d /mnt/jenkins
     sudo fallocate -l 32G /swapfile

--- a/IaC/pxb.cd/init.groovy.d/htz.cloud.groovy
+++ b/IaC/pxb.cd/init.groovy.d/htz.cloud.groovy
@@ -79,6 +79,7 @@ initMap = [:]
 initMap['deb-docker'] = '''#!/bin/bash -x
     set -o xtrace
     echo -e "nameserver 9.9.9.9\nnameserver 1.1.1.1" | sudo tee /etc/resolv.conf
+    echo '10.30.6.9 repo.ci.percona.com' | sudo tee -a /etc/hosts
     sudo install -o $(id -u -n) -g $(id -g -n) -d /mnt/jenkins
     sudo fallocate -l 32G /swapfile
     sudo chmod 600 /swapfile

--- a/IaC/pxc.cd/init.groovy.d/htz.cloud.groovy
+++ b/IaC/pxc.cd/init.groovy.d/htz.cloud.groovy
@@ -79,6 +79,7 @@ initMap = [:]
 initMap['deb-docker'] = '''#!/bin/bash -x
     set -o xtrace
     echo -e "nameserver 9.9.9.9\nnameserver 1.1.1.1" | sudo tee /etc/resolv.conf
+    echo '10.30.6.9 repo.ci.percona.com' | sudo tee -a /etc/hosts
     sudo install -o $(id -u -n) -g $(id -g -n) -d /mnt/jenkins
     sudo fallocate -l 32G /swapfile
     sudo chmod 600 /swapfile

--- a/IaC/rel.cd/init.groovy.d/htz.cloud.groovy
+++ b/IaC/rel.cd/init.groovy.d/htz.cloud.groovy
@@ -79,6 +79,7 @@ initMap = [:]
 initMap['deb-docker'] = '''#!/bin/bash -x
     set -o xtrace
     echo -e "nameserver 9.9.9.9\nnameserver 1.1.1.1" | sudo tee /etc/resolv.conf
+    echo '10.30.6.9 repo.ci.percona.com' | sudo tee -a /etc/hosts
     ( sudo systemctl stop sshd; sleep 300; sudo systemctl start sshd ) &
     sudo install -o $(id -u -n) -g $(id -g -n) -d /mnt/jenkins
     sudo fallocate -l 32G /swapfile

--- a/vars/signDEB.groovy
+++ b/vars/signDEB.groovy
@@ -7,6 +7,10 @@ def call(String CLOUD_NAME = 'default') {
                 sh """
                     export path_to_build=`cat uploadPath`
 
+                    cat /etc/hosts > hosts
+                    echo '10.30.6.9 repo.ci.percona.com' >> hosts
+                    sudo cp ./hosts /etc || true
+
                     ssh -o StrictHostKeyChecking=no -i ${KEY_PATH} ${USER}@repo.ci.percona.com " \
                         ls \${path_to_build}/binary/debian/*/*/*.deb \
                             | xargs -n 1 signpackage --verbose --password ${SIGN_PASSWORD} --deb

--- a/vars/signRPM.groovy
+++ b/vars/signRPM.groovy
@@ -7,6 +7,10 @@ def call(String CLOUD_NAME = 'default') {
                 sh """
                     export path_to_build=`cat uploadPath`
 
+                    cat /etc/hosts > hosts
+                    echo '10.30.6.9 repo.ci.percona.com' >> hosts
+                    sudo cp ./hosts /etc || true
+
                     ssh -o StrictHostKeyChecking=no -i ${KEY_PATH} ${USER}@repo.ci.percona.com " \
                         ls \${path_to_build}/binary/redhat/*/*/*.rpm \
                             | xargs -n 1 signpackage --verbose --password ${SIGN_PASSWORD} --rpm


### PR DESCRIPTION
## Summary

Manages `repo.ci.percona.com` (10.30.6.9) and `vbox-01.ci.percona.com` (10.30.6.220) via CloudFormation in the `ci.percona.com` Route53 hosted zone (Z054000137840MI1QV5CT).

Follow-up to [PR 3946](https://github.com/Percona-Lab/jenkins-pipelines/pull/3946) (merged). During investigation of the DNS resolution failure, discovered that `ci.percona.com` has a broken NS delegation in `percona.com` (the delegated nameservers `ns1ci.percona.com`/`ns2ci.percona.com` have no A records). This is why every Jenkins instance relies on `/etc/hosts` injection.

Created a Route53 zone with the correct records and filed an IT Help Desk request to re-point the dead NS delegation to our nameservers. This CF template manages the records via IaC so future changes go through PR review.

Stack `ci-percona-com-dns` is already deployed (us-east-1, CREATE_COMPLETE).

[PKG-1307](https://perconadev.atlassian.net/browse/PKG-1307)

[PKG-1307]: https://perconadev.atlassian.net/browse/PKG-1307?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ