### PR TITLE
PKG-1307: add CloudFormation template for ci.percona.com DNS records

### DIFF
--- a/IaC/CiPerconaComDns.yml
+++ b/IaC/CiPerconaComDns.yml
@@ -1,0 +1,50 @@
+AWSTemplateFormatVersion: '2010-09-09'
+Description: >
+  DNS records for ci.percona.com (internal signing and build infrastructure).
+  The ci.percona.com hosted zone was created manually in Route53
+  (Z054000137840MI1QV5CT) and requires NS delegation from the percona.com
+  zone owner. This stack manages only the A records, not the zone itself.
+
+Parameters:
+  ZoneId:
+    Description: Route53 hosted zone ID for ci.percona.com
+    Type: AWS::Route53::HostedZone::Id
+    Default: Z054000137840MI1QV5CT
+
+Resources:
+  RepoRecord:
+    Type: AWS::Route53::RecordSet
+    Properties:
+      HostedZoneId: !Ref ZoneId
+      Name: repo.ci.percona.com.
+      Type: A
+      TTL: 300
+      ResourceRecords:
+        - 10.30.6.9
+
+  VboxRecord:
+    Type: AWS::Route53::RecordSet
+    Properties:
+      HostedZoneId: !Ref ZoneId
+      Name: vbox-01.ci.percona.com.
+      Type: A
+      TTL: 300
+      ResourceRecords:
+        - 10.30.6.220
+
+Outputs:
+  RepoHost:
+    Description: Signing server hostname
+    Value: repo.ci.percona.com
+  RepoIp:
+    Description: Signing server IP
+    Value: 10.30.6.9
+  VboxHost:
+    Description: Legacy VirtualBox host
+    Value: vbox-01.ci.percona.com
+  VboxIp:
+    Description: Legacy VirtualBox IP
+    Value: 10.30.6.220
+  ZoneId:
+    Description: ci.percona.com hosted zone ID
+    Value: !Ref ZoneId


### PR DESCRIPTION
## Summary

Manages `repo.ci.percona.com` (10.30.6.9) and `vbox-01.ci.percona.com` (10.30.6.220) via CloudFormation in the `ci.percona.com` Route53 hosted zone (Z054000137840MI1QV5CT).

During investigation of PKG-1307 (merged in [PR #3946](https://github.com/Percona-Lab/jenkins-pipelines/pull/3946)), discovered that `ci.percona.com` has a broken NS delegation in `percona.com` — the delegated nameservers (`ns1ci.percona.com`, `ns2ci.percona.com`) have no A records and are unreachable. This is why every Jenkins instance relies on `/etc/hosts` injection (~20 IaC files, 200+ pipeline references).

Created a Route53 zone with the correct records and filed an IT Help Desk request to re-point the dead NS delegation to our nameservers. This CF template manages the records via IaC so future changes go through PR review.

Stack `ci-percona-com-dns` is already deployed (us-east-1, CREATE_COMPLETE).

[PKG-1307](https://perconadev.atlassian.net/browse/PKG-1307)

[PKG-1307]: https://perconadev.atlassian.net/browse/PKG-1307?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ