### PR TITLE
PXB-3752 : Create Jenkins pipelines for testing PXB 9.x versions

### DIFF
--- a/pxb/v2/docker/run-build
+++ b/pxb/v2/docker/run-build
@@ -5,10 +5,10 @@ set -o xtrace
 
 ROOT_DIR=$(cd $(dirname $0)/../sources; pwd -P)
 SCRIPTS_DIR=$(cd $(dirname $0)/../local; pwd -P)
-SOURCE_IMAGE=${1:-centos:8}
+SOURCE_IMAGE=${1:-oraclelinux:9}
 
 if [[ ${SOURCE_IMAGE} == 'asan' ]]; then
-    SOURCE_IMAGE='centos:8'
+    SOURCE_IMAGE='oraclelinux:9'
     ASAN_SWITCH=ON
 fi
 

--- a/pxb/v2/docker/run-test
+++ b/pxb/v2/docker/run-test
@@ -9,10 +9,10 @@ function cleanup (){
 }
 ROOT_DIR=$(cd $(dirname $0)/../sources; pwd -P)
 SCRIPTS_DIR=$(cd $(dirname $0)/../local; pwd -P)
-SOURCE_IMAGE=${1:-centos:7}
+SOURCE_IMAGE=${1:-oraclelinux:9}
 
 if [[ ${SOURCE_IMAGE} == 'asan' ]]; then
-    SOURCE_IMAGE='centos:8'
+    SOURCE_IMAGE='oraclelinux:9'
 fi
 
 function check_pxb_network() {

--- a/pxb/v2/jenkins/percona-xtrabackup-9.x-compile-param.yml
+++ b/pxb/v2/jenkins/percona-xtrabackup-9.x-compile-param.yml
@@ -1,0 +1,125 @@
+- job:
+    name: percona-xtrabackup-9.x-compile-param
+    project-type: matrix
+    defaults: global
+    description: |
+        Do not edit this job through the web!
+    disabled: false
+    concurrent: true
+    auth-token: xbparam24
+    node: launcher-x64
+    properties:
+    - groovy-label:
+        script: |
+            return (CLOUD == 'AWS') ? 'micro-amazon' : 'launcher-x64'
+        sandbox: true
+    - build-discarder:
+        days-to-keep: -1
+        num-to-keep: 50
+        artifact-days-to-keep: -1
+        artifact-num-to-keep: 50
+    parameters:
+    - string:
+        name: GIT_REPO
+        default: "https://github.com/percona/percona-xtrabackup"
+        description: URL to percona-xtrabackup repository
+    - string:
+        name: BRANCH
+        default: "trunk"
+        description: Tag/Branch for percona-xtrabackup repository
+    - string:
+        name: CMAKE_OPTS
+        default:
+        description: cmake options
+    - string:
+        name: MAKE_OPTS
+        default:
+        description: make options, like VERBOSE=1
+    - choice:
+        name: CLOUD
+        choices:
+        - "Hetzner"
+        - "AWS"
+        description: "Host provider for Jenkins workers"
+    axes:
+      - axis:
+         type: user-defined
+         name: CMAKE_BUILD_TYPE
+         values:
+          - RelWithDebInfo
+          - Debug
+      - axis:
+         type: user-defined
+         name: DOCKER_OS
+         values:
+         - oraclelinux:9
+         - ubuntu:jammy
+         - ubuntu:noble
+         - debian:bookworm
+         - debian:trixie
+         - asan
+    builders:
+    - trigger-builds:
+      - project: percona-xtrabackup-9.x-compile-pipeline
+        current-parameters: true
+        predefined-parameters: |
+          DOCKER_OS=${{DOCKER_OS}}
+          CMAKE_BUILD_TYPE=${{CMAKE_BUILD_TYPE}}
+          CLOUD=${{CLOUD}}
+        block: true
+        block-thresholds:
+          build-step-failure-threshold: FAILURE
+          unstable-threshold: never
+          failure-threshold: FAILURE
+    - shell: |
+        sudo find . -name "*.xml" -o -name "*.log" -delete
+    - copyartifact:
+        project: percona-xtrabackup-9.x-compile-pipeline
+        which-build: specific-build
+        build-number: "${{TRIGGERED_BUILD_NUMBERS_percona_xtrabackup_9_x_compile_pipeline}}"
+        do-not-fingerprint: true
+    - shell: |
+        echo "${{TRIGGERED_BUILD_NUMBERS_percona_xtrabackup_9_x_compile_pipeline}}" > PIPELINE_BUILD_NUMBER
+        gunzip build.log.gz
+    publishers:
+    - raw:
+        xml: |
+          <io.jenkins.plugins.analysis.core.steps.IssuesRecorder plugin="warnings-ng@11.4.1">
+            <analysisTools>
+              <io.jenkins.plugins.analysis.warnings.Gcc4>
+                <id></id>
+                <name></name>
+                <jenkins plugin="plugin-util-api@4.1.0"/>
+                <pattern>build.log</pattern>
+                <reportEncoding></reportEncoding>
+                <skipSymbolicLinks>false</skipSymbolicLinks>
+              </io.jenkins.plugins.analysis.warnings.Gcc4>
+            </analysisTools>
+            <sourceCodeEncoding></sourceCodeEncoding>
+            <sourceDirectories/>
+            <sourceCodeRetention>EVERY_BUILD</sourceCodeRetention>
+            <ignoreQualityGate>false</ignoreQualityGate>
+            <failOnError>false</failOnError>
+            <healthy>0</healthy>
+            <unhealthy>0</unhealthy>
+            <minimumSeverity plugin="analysis-model-api@12.4.0">
+              <name>LOW</name>
+            </minimumSeverity>
+            <filters/>
+            <isEnabledForFailure>true</isEnabledForFailure>
+            <isAggregatingResults>false</isAggregatingResults>
+            <quiet>false</quiet>
+            <isBlameDisabled>false</isBlameDisabled>
+            <skipPublishingChecks>false</skipPublishingChecks>
+            <checksAnnotationScope>NEW</checksAnnotationScope>
+            <skipPostProcessing>false</skipPostProcessing>
+            <qualityGates/>
+            <trendChartType>AGGREGATION_TOOLS</trendChartType>
+            <scm></scm>
+          </io.jenkins.plugins.analysis.core.steps.IssuesRecorder>
+    - archive:
+        artifacts: 'PIPELINE_BUILD_NUMBER'
+    - archive:
+        artifacts: 'COMPILE_BUILD_TAG'
+    - archive:
+        artifacts: 'build.log'

--- a/pxb/v2/jenkins/percona-xtrabackup-9.x-compile-pipeline.groovy
+++ b/pxb/v2/jenkins/percona-xtrabackup-9.x-compile-pipeline.groovy
@@ -1,0 +1,154 @@
+// Default to Hetzner
+String LABEL = 'docker-x64'
+String MICRO_LABEL = 'launcher-x64'
+
+if (params.CLOUD == 'AWS') {
+    LABEL = 'docker-32gb'
+    MICRO_LABEL = 'micro-amazon'
+}
+
+pipeline {
+    parameters {
+        string(
+            defaultValue: 'https://github.com/percona/percona-xtrabackup',
+            description: 'URL to percona-xtrabackup repository',
+            name: 'GIT_REPO',
+            trim: true)
+        string(
+            defaultValue: 'trunk',
+            description: 'Tag/Branch for percona-xtrabackup repository',
+            name: 'BRANCH',
+            trim: true)
+        choice(
+            choices: 'oraclelinux:9\nubuntu:jammy\nubuntu:noble\ndebian:bookworm\ndebian:trixie\nasan',
+            description: 'OS version for compilation',
+            name: 'DOCKER_OS')
+        choice(
+            choices: 'RelWithDebInfo\nDebug',
+            description: 'Type of build to produce',
+            name: 'CMAKE_BUILD_TYPE')
+        string(
+            defaultValue: '',
+            description: 'cmake options',
+            name: 'CMAKE_OPTS')
+        string(
+            defaultValue: '',
+            description: 'make options, like VERBOSE=1',
+            name: 'MAKE_OPTS')
+        choice(
+            choices: 'Hetzner\nAWS',
+            description: 'Host provider for Jenkins workers',
+            name: 'CLOUD')
+    }
+    agent {
+        label MICRO_LABEL
+    }
+    options {
+        skipDefaultCheckout()
+        skipStagesAfterUnstable()
+        timeout(time: 180, unit: 'MINUTES')
+        buildDiscarder(logRotator(numToKeepStr: '200', artifactNumToKeepStr: '200'))
+    }
+    stages {
+        stage('Build') {
+            agent { label LABEL }
+            steps {
+                timeout(time: 60, unit: 'MINUTES')  {
+                    script {
+                        currentBuild.displayName = "${BUILD_NUMBER} ${CMAKE_BUILD_TYPE}/${DOCKER_OS}"
+                    }
+                    sh 'echo Prepare: \$(date -u "+%s")'
+                    echo 'Checking Percona XtraBackup branch version'
+                    sh '''#!/bin/bash
+                        MY_BRANCH_BASE_MAJOR=9
+                        MY_BRANCH_BASE_MINOR=0
+                        RAW_VERSION_LINK=$(echo ${GIT_REPO%.git} | sed -e "s:github.com:raw.githubusercontent.com:g")
+                        curl ${RAW_VERSION_LINK}/${BRANCH}/XB_VERSION --output ${WORKSPACE}/XB_VERSION-${BUILD_NUMBER}
+                        source ${WORKSPACE}/XB_VERSION-${BUILD_NUMBER}
+                        if [[ ${XB_VERSION_MAJOR} -lt ${MY_BRANCH_BASE_MAJOR} ]]; then
+                            echo "Are you trying to build wrong branch?"
+                            echo "You are trying to build ${XB_VERSION_MAJOR}.${XB_VERSION_MINOR} instead of ${MY_BRANCH_BASE_MAJOR}.x!"
+                            rm -f ${WORKSPACE}/XB_VERSION-${BUILD_NUMBER}
+                            exit 1
+                        fi
+                        rm -f ${WORKSPACE}/XB_VERSION-${BUILD_NUMBER}
+                    '''
+                    git branch: 'master', url: 'https://github.com/Percona-Lab/jenkins-pipelines'
+                    withCredentials([[$class: 'AmazonWebServicesCredentialsBinding', accessKeyVariable: 'AWS_ACCESS_KEY_ID', credentialsId: '24e68886-c552-4033-8503-ed85bbaa31f3', secretKeyVariable: 'AWS_SECRET_ACCESS_KEY']]) {
+                        sh '''#!/bin/bash
+                            # sudo is needed for better node recovery after compilation failure
+                            # if building failed on compilation stage directory will have files owned by docker user
+                            sudo git reset --hard
+                            sudo git clean -xdf
+                            cd pxb/v2
+                            sudo rm -rf sources
+                            ./local/checkout
+
+                            aws ecr-public get-login-password --region us-east-1 | docker login -u AWS --password-stdin public.ecr.aws/e7j3v3n0
+                            echo Build: \$(date -u "+%s")
+                            sg docker -c "
+                                if [ \$(docker ps -q | wc -l) -ne 0 ]; then
+                                    docker ps -q | xargs docker stop --time 1 || :
+                                fi
+                                ./docker/run-build ${DOCKER_OS}
+                            " 2>&1 | tee build.log
+
+                            echo Archive build: \$(date -u "+%s")
+                            sed -i -e '
+                                s^/tmp/pxb/^sources/^;
+                                s^/tmp/results/^sources/^;
+                            ' build.log
+                            gzip build.log
+
+                            if [[ -f build.log.gz ]]; then
+                                until aws s3 cp --no-progress --acl public-read build.log.gz s3://pxb-build-cache/${BUILD_TAG}/build.log.gz; do
+                                    sleep 5
+                                done
+                            fi
+
+                            if [[ -f \$(ls sources/results/*.tar.gz | head -1) ]]; then
+                                until aws s3 cp --no-progress --acl public-read sources/results/*.tar.gz s3://pxb-build-cache/${BUILD_TAG}/; do
+                                    sleep 5
+                                done
+                            else
+                                echo cannot find compiled archive
+                                exit 1
+                            fi
+                            echo ${BUILD_TAG} > ${WORKSPACE}/COMPILE_BUILD_TAG
+                        '''
+                        archiveArtifacts artifacts: 'COMPILE_BUILD_TAG', followSymlinks: false, onlyIfSuccessful: true
+                    }
+                }
+            }
+        }
+        stage('Archive Build') {
+            agent { label MICRO_LABEL }
+            steps {
+                timeout(time: 60, unit: 'MINUTES')  {
+                    retry(3) {
+                        deleteDir()
+                        withCredentials([[$class: 'AmazonWebServicesCredentialsBinding', accessKeyVariable: 'AWS_ACCESS_KEY_ID', credentialsId: '24e68886-c552-4033-8503-ed85bbaa31f3', secretKeyVariable: 'AWS_SECRET_ACCESS_KEY']]) {
+                            sh '''
+                                aws s3 cp --no-progress s3://pxb-build-cache/${BUILD_TAG}/build.log.gz ./build.log.gz
+                                gunzip < build.log.gz > build.log
+                                echo "
+                                    binary    - https://s3.us-east-2.amazonaws.com/pxb-build-cache/${BUILD_TAG}/binary.tar.gz
+                                    build log - https://s3.us-east-2.amazonaws.com/pxb-build-cache/${BUILD_TAG}/build.log.gz
+                                " > public_url
+                            '''
+                        }
+                        recordIssues enabledForFailure: true, tools: [gcc(pattern: 'build.log')]
+                        archiveArtifacts 'build.log.gz,public_url'
+                    }
+                }
+            }
+        }
+    }
+    post {
+        always {
+            sh '''
+                echo Finish: \$(date -u "+%s")
+            '''
+        }
+    }
+}

--- a/pxb/v2/jenkins/percona-xtrabackup-9.x-compile-pipeline.yml
+++ b/pxb/v2/jenkins/percona-xtrabackup-9.x-compile-pipeline.yml
@@ -1,0 +1,54 @@
+- job:
+    name: percona-xtrabackup-9.x-compile-pipeline
+    project-type: pipeline
+    description: |
+        Do not edit this job through the web!
+    concurrent: true
+    pipeline-scm:
+      scm:
+        - git:
+            url: https://github.com/Percona-Lab/jenkins-pipelines
+            branches:
+            - "master"
+            wipe-workspace: false
+      lightweight-checkout: true
+      script-path: pxb/v2/jenkins/percona-xtrabackup-9.x-compile-pipeline.groovy
+    parameters:
+    - string:
+        name: GIT_REPO
+        default: "https://github.com/percona/percona-xtrabackup"
+        description: URL to percona-xtrabackup repository
+    - string:
+        name: BRANCH
+        default: "trunk"
+        description: Tag/Branch for percona-xtrabackup repository
+    - choice:
+        name: DOCKER_OS
+        choices:
+        - oraclelinux:9
+        - ubuntu:jammy
+        - ubuntu:noble
+        - debian:bookworm
+        - debian:trixie
+        - asan
+        description: OS version for compilation
+    - choice:
+        name: CMAKE_BUILD_TYPE
+        choices:
+          - RelWithDebInfo
+          - Debug
+        description: Type of build to produce
+    - string:
+        name: CMAKE_OPTS
+        default:
+        description: cmake options
+    - string:
+        name: MAKE_OPTS
+        default:
+        description: make options, like VERBOSE=1
+    - choice:
+        name: CLOUD
+        choices:
+        - "Hetzner"
+        - "AWS"
+        description: "Host provider for Jenkins workers"

--- a/pxb/v2/jenkins/percona-xtrabackup-9.x-single-platform.groovy
+++ b/pxb/v2/jenkins/percona-xtrabackup-9.x-single-platform.groovy
@@ -1,0 +1,215 @@
+// Default to Hetzner
+String LABEL = 'docker-x64'
+String MICRO_LABEL = 'launcher-x64'
+
+if (params.CLOUD == 'AWS') {
+    LABEL = 'docker-32gb'
+    MICRO_LABEL = 'micro-amazon'
+}
+
+pipeline {
+    parameters {
+        string(
+            defaultValue: 'https://github.com/percona/percona-xtrabackup',
+            description: 'URL to PXB repository',
+            name: 'GIT_REPO',
+            trim: true)
+        string(
+            defaultValue: 'trunk',
+            description: 'Tag/Branch for PXB repository',
+            name: 'BRANCH',
+            trim: true)
+        choice(
+            choices: 'oraclelinux:9\nubuntu:jammy\nubuntu:noble\ndebian:bookworm\ndebian:trixie',
+            description: 'OS version for compilation and testing',
+            name: 'DOCKER_OS')
+        choice(
+            choices: 'both\ninnodb9x\nxtradb9x',
+            description: 'MySQL server flavour for QA run (both runs innodb9x then xtradb9x)',
+            name: 'XTRABACKUP_TARGET')
+        string(
+            defaultValue: '9.6.0',
+            description: 'Version of MySQL InnoDB which will be used for bootstrap.sh script',
+            name: 'INNODB9X_VERSION')
+        string(
+            defaultValue: '9.6.0-1',
+            description: 'Version of Percona XtraDB which will be used for bootstrap.sh script',
+            name: 'XTRADB9X_VERSION')
+        string(
+            defaultValue: '',
+            description: 'Pass an URL for downloading bootstrap.sh, If empty will use from repository you specified',
+            name: 'BOOTSTRAP_URL')
+        choice(
+            choices: 'RelWithDebInfo\nDebug',
+            description: 'Type of build to produce',
+            name: 'CMAKE_BUILD_TYPE')
+        string(
+            defaultValue: '',
+            description: 'cmake options',
+            name: 'CMAKE_OPTS')
+        string(
+            defaultValue: '',
+            description: 'make options, like VERBOSE=1',
+            name: 'MAKE_OPTS')
+        string(
+            defaultValue: '-j 2',
+            description: './run.sh options, for options like: -j N Run tests in N parallel processes, -T seconds, -x options  Extra options to pass to xtrabackup',
+            name: 'XBTR_ARGS')
+        booleanParam(
+            defaultValue: false,
+            description: 'Starts Microsoft Azurite emulator and tests xbcloud against it',
+            name: 'WITH_AZURITE')
+        booleanParam(
+            name: 'WITH_XBCLOUD_TESTS',
+            defaultValue: false,
+            description: 'Run xbcloud tests')
+        booleanParam(
+            name: 'WITH_VAULT_TESTS',
+            defaultValue: false,
+            description: 'Run vault tests')
+        booleanParam(
+            name: 'WITH_KMIP_TESTS',
+            defaultValue: false,
+            description: 'Run kmip tests')
+        choice(
+            choices: 'Hetzner\nAWS',
+            description: 'Host provider for Jenkins workers',
+            name: 'CLOUD')
+    }
+    agent {
+        label MICRO_LABEL
+    }
+    options {
+        skipDefaultCheckout()
+        skipStagesAfterUnstable()
+        timeout(time: 6, unit: 'DAYS')
+        buildDiscarder(logRotator(numToKeepStr: '200', artifactNumToKeepStr: '200'))
+    }
+    stages {
+        stage('Build PXB 9.x') {
+            agent { label LABEL }
+            steps {
+                timeout(time: 60, unit: 'MINUTES') {
+                    script {
+                        currentBuild.displayName = "${BUILD_NUMBER} ${CMAKE_BUILD_TYPE}/${DOCKER_OS}"
+                    }
+                    sh 'echo Prepare: \$(date -u "+%s")'
+                    echo 'Checking Percona XtraBackup branch version'
+                    sh '''#!/bin/bash
+                        MY_BRANCH_BASE_MAJOR=9
+                        RAW_VERSION_LINK=$(echo ${GIT_REPO%.git} | sed -e "s:github.com:raw.githubusercontent.com:g")
+                        curl ${RAW_VERSION_LINK}/${BRANCH}/XB_VERSION --output ${WORKSPACE}/XB_VERSION-${BUILD_NUMBER}
+                        source ${WORKSPACE}/XB_VERSION-${BUILD_NUMBER}
+                        if [[ ${XB_VERSION_MAJOR} -lt ${MY_BRANCH_BASE_MAJOR} ]]; then
+                            echo "Are you trying to build wrong branch?"
+                            echo "You are trying to build ${XB_VERSION_MAJOR}.${XB_VERSION_MINOR} instead of ${MY_BRANCH_BASE_MAJOR}.x!"
+                            rm -f ${WORKSPACE}/XB_VERSION-${BUILD_NUMBER}
+                            exit 1
+                        fi
+                        rm -f ${WORKSPACE}/XB_VERSION-${BUILD_NUMBER}
+                    '''
+                    git branch: 'master', url: 'https://github.com/Percona-Lab/jenkins-pipelines'
+                    withCredentials([[$class: 'AmazonWebServicesCredentialsBinding', accessKeyVariable: 'AWS_ACCESS_KEY_ID', credentialsId: '24e68886-c552-4033-8503-ed85bbaa31f3', secretKeyVariable: 'AWS_SECRET_ACCESS_KEY']]) {
+                        sh '''#!/bin/bash
+                            sudo git reset --hard
+                            sudo git clean -xdf
+                            cd pxb/v2
+                            sudo rm -rf sources
+                            ./local/checkout
+
+                            aws ecr-public get-login-password --region us-east-1 | docker login -u AWS --password-stdin public.ecr.aws/e7j3v3n0
+                            echo Build: \$(date -u "+%s")
+                            sg docker -c "
+                                if [ \$(docker ps -q | wc -l) -ne 0 ]; then
+                                    docker ps -q | xargs docker stop --time 1 || :
+                                fi
+                                ./docker/run-build ${DOCKER_OS}
+                            " 2>&1 | tee build.log
+
+                            if [[ -f \$(ls sources/results/*.tar.gz | head -1) ]]; then
+                                until aws s3 cp --no-progress --acl public-read sources/results/*.tar.gz s3://pxb-build-cache/${BUILD_TAG}/pxb9x.tar.gz; do
+                                    sleep 5
+                                done
+                            else
+                                echo cannot find compiled archive
+                                exit 1
+                            fi
+                        '''
+                    }
+                }
+            }
+        }
+        stage('Test PXB 9.x') {
+            agent { label LABEL }
+            steps {
+                timeout(time: 480, unit: 'MINUTES') {
+                    git branch: 'master', url: 'https://github.com/Percona-Lab/jenkins-pipelines'
+                    withCredentials([[$class: 'AmazonWebServicesCredentialsBinding', accessKeyVariable: 'AWS_ACCESS_KEY_ID', credentialsId: '24e68886-c552-4033-8503-ed85bbaa31f3', secretKeyVariable: 'AWS_SECRET_ACCESS_KEY']]) {
+                        sh '''#!/bin/bash
+                            sudo git reset --hard
+                            sudo git clean -xdf
+                            cd pxb/v2
+                            sudo rm -rf sources/results
+                            mkdir -p sources/results
+
+                            until aws s3 cp --no-progress s3://pxb-build-cache/${BUILD_TAG}/pxb9x.tar.gz ./sources/results/binary.tar.gz; do
+                                sleep 5
+                            done
+
+                            aws ecr-public get-login-password --region us-east-1 | docker login -u AWS --password-stdin public.ecr.aws/e7j3v3n0
+
+                            run_test_for_target() {
+                                local target=$1
+                                echo "Testing target: ${target} at $(date -u '+%s')"
+                                export XTRABACKUP_TARGET="${target}"
+                                sg docker -c "
+                                    if [ \$(docker ps -q | wc -l) -ne 0 ]; then
+                                        docker ps -q | xargs docker stop --time 1 || :
+                                        docker rm --force azurite || :
+                                    fi
+                                    ulimit -a
+                                    ./docker/run-test ${DOCKER_OS}
+                                "
+                            }
+
+                            if [[ "${XTRABACKUP_TARGET}" == "both" ]]; then
+                                run_test_for_target innodb9x
+                                run_test_for_target xtradb9x
+                            else
+                                run_test_for_target "${XTRABACKUP_TARGET}"
+                            fi
+
+                            echo Archive test: \$(date -u "+%s")
+                            gzip sources/results/* || true
+                            if [[ -d sources/results/results/ ]]; then
+                                tar -zcvf results.tar.gz sources/results/results/
+                                mv results.tar.gz sources/results/
+                            fi
+                        '''
+                    }
+                }
+            }
+            post {
+                always {
+                    sh '''
+                        cd pxb/v2
+                        if [[ -f sources/results/junit.xml.gz ]]; then
+                            gunzip < sources/results/junit.xml.gz > ${WORKSPACE}/junit.xml || true
+                        elif [[ -f sources/results/junit.xml ]]; then
+                            cp sources/results/junit.xml ${WORKSPACE}/junit.xml || true
+                        fi
+                    '''
+                    step([$class: 'JUnitResultArchiver', testResults: 'junit.xml', healthScaleFactor: 1.0])
+                    archiveArtifacts allowEmptyArchive: true, artifacts: 'junit.xml'
+                }
+            }
+        }
+    }
+    post {
+        always {
+            sh '''
+                echo Finish: \$(date -u "+%s")
+            '''
+        }
+    }
+}

--- a/pxb/v2/jenkins/percona-xtrabackup-9.x-single-platform.yml
+++ b/pxb/v2/jenkins/percona-xtrabackup-9.x-single-platform.yml
@@ -1,0 +1,93 @@
+- job:
+    name: pxb9x-single-platform-run
+    project-type: pipeline
+    description: |
+        Do not edit this job through the web!
+        Ad-hoc single-platform compile and test for PXB 9.x.
+    concurrent: true
+    pipeline-scm:
+      scm:
+        - git:
+            url: https://github.com/Percona-Lab/jenkins-pipelines
+            branches:
+            - "master"
+            wipe-workspace: false
+      lightweight-checkout: true
+      script-path: pxb/v2/jenkins/pxb9x-single-platform-run.groovy
+    parameters:
+    - string:
+        name: GIT_REPO
+        default: "https://github.com/percona/percona-xtrabackup"
+        description: URL to PXB repository
+    - string:
+        name: BRANCH
+        default: "trunk"
+        description: Tag/Branch for PXB repository
+    - choice:
+        name: DOCKER_OS
+        choices:
+        - oraclelinux:9
+        - ubuntu:jammy
+        - ubuntu:noble
+        - debian:bookworm
+        - debian:trixie
+        description: OS version for compilation and testing
+    - choice:
+        name: XTRABACKUP_TARGET
+        choices:
+        - "both"
+        - "innodb9x"
+        - "xtradb9x"
+        description: MySQL server flavour for QA run (both runs innodb9x then xtradb9x)
+    - string:
+        name: INNODB9X_VERSION
+        default: "9.6.0"
+        description: Version of MySQL InnoDB which will be used for bootstrap.sh script
+    - string:
+        name: XTRADB9X_VERSION
+        default: "9.6.0-1"
+        description: Version of Percona XtraDB which will be used for bootstrap.sh script
+    - string:
+        name: BOOTSTRAP_URL
+        default: ""
+        description: "Pass an URL for downloading bootstrap.sh, If empty will use from repository"
+    - choice:
+        name: CMAKE_BUILD_TYPE
+        choices:
+        - RelWithDebInfo
+        - Debug
+        description: Type of build to produce
+    - string:
+        name: CMAKE_OPTS
+        default:
+        description: cmake options
+    - string:
+        name: MAKE_OPTS
+        default:
+        description: make options, like VERBOSE=1
+    - string:
+        name: XBTR_ARGS
+        default: "-j 2"
+        description: "./run.sh options, for options like: -j N Run tests in N parallel processes, -T seconds, -x options Extra options to pass to xtrabackup"
+    - bool:
+        name: WITH_AZURITE
+        default: false
+        description: "Starts Microsoft Azurite emulator and tests xbcloud against it"
+    - bool:
+        name: WITH_XBCLOUD_TESTS
+        default: false
+        description: "Run xbcloud tests"
+    - bool:
+        name: WITH_VAULT_TESTS
+        default: false
+        description: "Run vault tests"
+    - bool:
+        name: WITH_KMIP_TESTS
+        default: false
+        description: "Run kmip tests"
+    - choice:
+        name: CLOUD
+        choices:
+        - "Hetzner"
+        - "AWS"
+        description: "Host provider for Jenkins workers"

--- a/pxb/v2/jenkins/percona-xtrabackup-9.x-test-param.yml
+++ b/pxb/v2/jenkins/percona-xtrabackup-9.x-test-param.yml
@@ -1,0 +1,119 @@
+- job:
+    name: percona-xtrabackup-9.x-test-param
+    project-type: matrix
+    defaults: global
+    description: |
+        Do not edit this job through the web!
+    disabled: false
+    concurrent: true
+    auth-token: xbparam24
+    node: launcher-x64
+    properties:
+    - groovy-label:
+        script: |
+            return (CLOUD == 'AWS') ? 'micro-amazon' : 'launcher-x64'
+        sandbox: true
+    - build-discarder:
+        days-to-keep: -1
+        num-to-keep: 30
+        artifact-days-to-keep: -1
+        artifact-num-to-keep: 30
+    parameters:
+    - string:
+        name: BOOTSTRAP_URL
+        default: ""
+        description:
+    - string:
+        name: USE_BINARIES_FROM_BUILD_ID
+        default: "lastSuccessfulBuild"
+        description: Specific percona-xtrabackup-9.x-compile-param build id to use binaries from.
+    - string:
+        name: INNODB9X_VERSION
+        default: "9.6.0"
+        description: Version of MySQL InnoDB which will be used for bootstrap.sh script
+    - string:
+        name: XTRADB9X_VERSION
+        default: "9.6.0-1"
+        description: Version of Percona XtraDB which will be used for bootstrap.sh script
+    - string:
+        name: XBTR_ARGS
+        default: ""
+        description: "./run.sh options, for options like: -j N Run tests in N parallel processes, -T seconds, -x options Extra options to pass to xtrabackup"
+    - bool:
+        name: WITH_AZURITE
+        default: false
+        description: "Starts Microsoft Azurite emulator and tests xbcloud against it"
+    - bool:
+        name: WITH_XBCLOUD_TESTS
+        default: true
+        description: "Run xbcloud tests"
+    - bool:
+        name: WITH_VAULT_TESTS
+        default: true
+        description: "Run vault tests"
+    - bool:
+        name: WITH_KMIP_TESTS
+        default: true
+        description: "Run kmip tests"
+    - choice:
+        name: CLOUD
+        choices:
+        - "Hetzner"
+        - "AWS"
+        description: "Host provider for Jenkins workers"
+    axes:
+    - axis:
+        name: CMAKE_BUILD_TYPE
+        type: user-defined
+        values:
+          - RelWithDebInfo
+          - Debug
+    - axis:
+        type: user-defined
+        name: DOCKER_OS
+        values:
+        - oraclelinux:9
+        - ubuntu:jammy
+        - ubuntu:noble
+        - debian:bookworm
+        - debian:trixie
+        - asan
+    - axis:
+        name: XTRABACKUP_TARGET
+        type: user-defined
+        values:
+        - innodb9x
+        - xtradb9x
+    builders:
+    - trigger-builds:
+      - project: percona-xtrabackup-9.x-test-pipeline
+        current-parameters: true
+        predefined-parameters: |
+          DOCKER_OS=${{DOCKER_OS}}
+          CMAKE_BUILD_TYPE=${{CMAKE_BUILD_TYPE}}
+          XTRABACKUP_TARGET=${{XTRABACKUP_TARGET}}
+          CLOUD=${{CLOUD}}
+        block: true
+        block-thresholds:
+          build-step-failure-threshold: FAILURE
+          unstable-threshold: never
+          failure-threshold: FAILURE
+    - shell: |
+        sudo find . -name "*.xml" -o -name "*.log" -delete
+    - copyartifact:
+        project: percona-xtrabackup-9.x-test-pipeline
+        which-build: specific-build
+        build-number: "${{TRIGGERED_BUILD_NUMBERS_percona_xtrabackup_9_x_test_pipeline}}"
+        do-not-fingerprint: true
+    - shell: |
+        echo "${{TRIGGERED_BUILD_NUMBERS_percona_xtrabackup_9_x_test_pipeline}}" > PIPELINE_BUILD_NUMBER
+    publishers:
+    - junit:
+        results: "**/junit.xml"
+        keep-long-stdio: true
+    - archive:
+        artifacts: 'PIPELINE_BUILD_NUMBER'
+    - archive:
+        artifacts: 'junit.xml'
+    - archive:
+        artifacts: 'results.tar.gz'

--- a/pxb/v2/jenkins/percona-xtrabackup-9.x-test-pipeline.groovy
+++ b/pxb/v2/jenkins/percona-xtrabackup-9.x-test-pipeline.groovy
@@ -1,0 +1,180 @@
+// Default to Hetzner
+String LABEL = 'docker-x64'
+String MICRO_LABEL = 'launcher-x64'
+
+if (params.CLOUD == 'AWS') {
+    LABEL = 'docker-32gb'
+    MICRO_LABEL = 'micro-amazon'
+}
+
+pipeline {
+    parameters {
+        choice(
+            choices: 'oraclelinux:9\nubuntu:jammy\nubuntu:noble\ndebian:bookworm\ndebian:trixie\nasan',
+            description: 'OS version for compilation',
+            name: 'DOCKER_OS')
+        choice(
+            choices: 'RelWithDebInfo\nDebug',
+            description: 'Type of build to produce',
+            name: 'CMAKE_BUILD_TYPE')
+        choice(
+            choices: 'innodb9x\nxtradb9x',
+            description: 'MySQL server flavour for QA run',
+            name: 'XTRABACKUP_TARGET')
+        string(
+            defaultValue: '9.6.0',
+            description: 'Version of MySQL InnoDB which will be used for bootstrap.sh script',
+            name: 'INNODB9X_VERSION')
+        string(
+            defaultValue: '9.6.0-1',
+            description: 'Version of Percona XtraDB which will be used for bootstrap.sh script',
+            name: 'XTRADB9X_VERSION')
+        string(
+            defaultValue: '',
+            description: './run.sh options, for options like: -j N Run tests in N parallel processes, -T seconds, -x options  Extra options to pass to xtrabackup',
+            name: 'XBTR_ARGS')
+        string(
+            defaultValue: '',
+            description: 'Pass an URL for downloading bootstrap.sh, If empty will use from repository you specified',
+            name: 'BOOTSTRAP_URL')
+        booleanParam(
+            defaultValue: false,
+            description: 'Starts Microsoft Azurite emulator and tests xbcloud against it',
+            name: 'WITH_AZURITE')
+        booleanParam(
+            name: 'WITH_XBCLOUD_TESTS',
+            defaultValue: true,
+            description: 'Run xbcloud tests')
+        booleanParam(
+            name: 'WITH_VAULT_TESTS',
+            defaultValue: true,
+            description: 'Run vault tests')
+        booleanParam(
+            name: 'WITH_KMIP_TESTS',
+            defaultValue: true,
+            description: 'Run kmip tests')
+        choice(
+            choices: 'Hetzner\nAWS',
+            description: 'Host provider for Jenkins workers',
+            name: 'CLOUD')
+    }
+    agent {
+        label MICRO_LABEL
+    }
+    options {
+        skipDefaultCheckout()
+        skipStagesAfterUnstable()
+        timeout(time: 10, unit: 'HOURS')
+        buildDiscarder(logRotator(numToKeepStr: '200', artifactNumToKeepStr: '200'))
+    }
+    stages {
+        stage('Test') {
+            agent { label LABEL }
+            steps {
+                timeout(time: 240, unit: 'MINUTES')  {
+                    script {
+                        currentBuild.displayName = "${BUILD_NUMBER} ${CMAKE_BUILD_TYPE}/${DOCKER_OS}"
+                    }
+                    sh 'echo Prepare: \$(date -u "+%s")'
+                    git branch: 'master', url: 'https://github.com/Percona-Lab/jenkins-pipelines'
+                    sh '''#!/bin/bash
+                        # sudo is needed for better node recovery after compilation failure
+                        # if building failed on compilation stage directory will have files owned by docker user
+                        sudo git reset --hard
+                        sudo git clean -xdf
+                        cd pxb/v2
+                        rm -rf sources/results
+                        sudo git -C sources reset --hard || :
+                        sudo git -C sources clean -xdf   || :
+                        '''
+                    copyArtifacts filter: 'COMPILE_BUILD_TAG', projectName: 'percona-xtrabackup-9.x-compile-param', selector: specific("${USE_BINARIES_FROM_BUILD_ID}")
+                    withCredentials([[$class: 'AmazonWebServicesCredentialsBinding', accessKeyVariable: 'AWS_ACCESS_KEY_ID', credentialsId: '24e68886-c552-4033-8503-ed85bbaa31f3', secretKeyVariable: 'AWS_SECRET_ACCESS_KEY']]) {
+                        sh '''#!/bin/bash
+                            for file in $(find . -name "COMPILE_BUILD_TAG"); do
+                                COMPILE_BUILD_TAG_VAR+=" $(cat $file)"
+                            done
+
+                            for tarball in $(echo $COMPILE_BUILD_TAG_VAR); do
+                                if [[ $CMAKE_BUILD_TYPE == "Debug" ]] && [[ ${DOCKER_OS} != "asan" ]]; then
+                                    TARBALL=$(aws s3 ls pxb-build-cache/$tarball/ | grep x86_64-${DOCKER_OS//:/-}-debug | awk {'print $4'})
+                                    if [[ ! -z $TARBALL ]]; then
+                                        break
+                                    fi
+                                elif [[ $CMAKE_BUILD_TYPE == "RelWithDebInfo" ]] && [[ ${DOCKER_OS} != "asan" ]]; then
+                                    TARBALL+=$(aws s3 ls pxb-build-cache/$tarball/ | grep x86_64-${DOCKER_OS//:/-}.tar.gz | awk {'print $4'})
+                                    if [[ ! -z $TARBALL ]]; then
+                                        break
+                                    fi
+                                elif [[ $CMAKE_BUILD_TYPE == "Debug" ]] && [[ ${DOCKER_OS} == "asan" ]]; then
+                                    TARBALL+=$(aws s3 ls pxb-build-cache/$tarball/ | grep x86_64-${DOCKER_OS//:/-}-asan-debug | awk {'print $4'})
+                                    if [[ ! -z $TARBALL ]]; then
+                                        break
+                                    fi
+                                elif [[ $CMAKE_BUILD_TYPE == "RelWithDebInfo" ]] && [[ ${DOCKER_OS} == "asan" ]]; then
+                                    TARBALL+=$(aws s3 ls pxb-build-cache/$tarball/ | grep x86_64-${DOCKER_OS//:/-}-asan | awk {'print $4'})
+                                    if [[ ! -z $TARBALL ]]; then
+                                        break
+                                    fi
+                                fi
+                            done
+                            PATH_TO_TARBALL=$tarball
+
+                            cd pxb/v2
+
+                            until aws s3 cp --no-progress s3://pxb-build-cache/$PATH_TO_TARBALL/$TARBALL ./sources/results/binary.tar.gz; do
+                                sleep 5
+                            done
+                            aws ecr-public get-login-password --region us-east-1 | docker login -u AWS --password-stdin public.ecr.aws/e7j3v3n0
+                            echo Test: \$(date -u "+%s")
+                            sg docker -c "
+                                if [ \$(docker ps -q | wc -l) -ne 0 ]; then
+                                    docker ps -q | xargs docker stop --time 1 || :
+                                    docker rm --force azurite || :
+                                fi
+                                ulimit -a
+                                ./docker/run-test ${DOCKER_OS}
+                            "
+                            echo Archive test: \$(date -u "+%s")
+                            gzip sources/results/* || true
+                            if [[ -d sources/results/results/ ]]; then
+                                tar -zcvf results.tar.gz sources/results/results/
+                                mv results.tar.gz sources/results/
+                            fi
+                            until aws s3 sync --no-progress --acl public-read --exclude 'binary.tar.gz' ./sources/results/ s3://pxb-build-cache/${BUILD_TAG}/; do
+                                sleep 5
+                            done
+                        '''
+                    }
+                }
+            }
+        }
+        stage('Archive Test Results') {
+            agent { label MICRO_LABEL }
+            steps {
+                retry(3) {
+                deleteDir()
+                withCredentials([[$class: 'AmazonWebServicesCredentialsBinding', accessKeyVariable: 'AWS_ACCESS_KEY_ID', credentialsId: '24e68886-c552-4033-8503-ed85bbaa31f3', secretKeyVariable: 'AWS_SECRET_ACCESS_KEY']]) {
+                    sh '''
+                        aws s3 cp --no-progress s3://pxb-build-cache/${BUILD_TAG}/xbtr.output.gz ./ || true
+                        aws s3 cp --no-progress s3://pxb-build-cache/${BUILD_TAG}/junit.xml.gz ./ || true
+                        aws s3 cp --no-progress s3://pxb-build-cache/${BUILD_TAG}/test_results.subunit.gz ./ || true
+                        aws s3 cp --no-progress s3://pxb-build-cache/${BUILD_TAG}/results.tar.gz ./ || true
+                        gunzip < xbtr.output.gz > xbtr.output || true
+                        gunzip < junit.xml.gz > junit.xml || true
+                        gunzip < test_results.subunit.gz > test_results.subunit || true
+                    '''
+                }
+                archiveArtifacts allowEmptyArchive: true, followSymlinks: false, onlyIfSuccessful: true, artifacts: 'xbtr.output,junit.xml,test_results.subunit,results.tar.gz'
+                step([$class: 'JUnitResultArchiver', testResults: 'junit.xml', healthScaleFactor: 1.0])
+                }
+            }
+        }
+    }
+    post {
+        always {
+            sh '''
+                echo Finish: \$(date -u "+%s")
+            '''
+        }
+    }
+}

--- a/pxb/v2/jenkins/percona-xtrabackup-9.x-test-pipeline.yml
+++ b/pxb/v2/jenkins/percona-xtrabackup-9.x-test-pipeline.yml
@@ -1,0 +1,80 @@
+- job:
+    name: percona-xtrabackup-9.x-test-pipeline
+    project-type: pipeline
+    description: |
+        Do not edit this job through the web!
+    concurrent: true
+    pipeline-scm:
+      scm:
+        - git:
+            url: https://github.com/Percona-Lab/jenkins-pipelines
+            branches:
+            - "master"
+            wipe-workspace: false
+      lightweight-checkout: true
+      script-path: pxb/v2/jenkins/percona-xtrabackup-9.x-test-pipeline.groovy
+    parameters:
+    - choice:
+        name: DOCKER_OS
+        choices:
+          - oraclelinux:9
+          - ubuntu:jammy
+          - ubuntu:noble
+          - debian:bookworm
+          - debian:trixie
+          - asan
+        description: OS version for compilation
+    - choice:
+        name: CMAKE_BUILD_TYPE
+        choices:
+          - RelWithDebInfo
+          - Debug
+        description: Type of build to produce
+    - choice:
+        name: XTRABACKUP_TARGET
+        choices:
+        - innodb9x
+        - xtradb9x
+        description: MySQL server flavour for QA run
+    - string:
+        name: BOOTSTRAP_URL
+        default: ""
+        description:
+    - string:
+        name: USE_BINARIES_FROM_BUILD_ID
+        default: "lastSuccessfulBuild"
+        description: Specific percona-xtrabackup-9.x-compile-param build id to use binaries from.
+    - string:
+        name: INNODB9X_VERSION
+        default: "9.6.0"
+        description: Version of MySQL InnoDB which will be used for bootstrap.sh script
+    - string:
+        name: XTRADB9X_VERSION
+        default: "9.6.0-1"
+        description: Version of Percona XtraDB which will be used for bootstrap.sh script
+    - string:
+        name: XBTR_ARGS
+        default:
+        description: "./run.sh options, for options like: -j N Run tests in N parallel processes, -T seconds, -x options Extra options to pass to xtrabackup"
+    - bool:
+        name: WITH_AZURITE
+        default: false
+        description: "Starts Microsoft Azurite emulator and tests xbcloud against it"
+    - bool:
+        name: WITH_XBCLOUD_TESTS
+        default: true
+        description: "Run xbcloud tests"
+    - bool:
+        name: WITH_VAULT_TESTS
+        default: true
+        description: "Run vault tests"
+    - bool:
+        name: WITH_KMIP_TESTS
+        default: true
+        description: "Run kmip tests"
+    - choice:
+        name: CLOUD
+        choices:
+        - "Hetzner"
+        - "AWS"
+        description: "Host provider for Jenkins workers"

--- a/pxb/v2/jenkins/percona-xtrabackup-9.x-trunk.yml
+++ b/pxb/v2/jenkins/percona-xtrabackup-9.x-trunk.yml
@@ -1,0 +1,94 @@
+- job:
+    name: percona-xtrabackup-9.x-trunk
+    project-type: freestyle
+    defaults: global
+    description: |
+        Do not edit this job through the web!
+    disabled: false
+    concurrent: false
+    auth-token: xbparam24
+    node: micro-amazon
+    properties:
+    - build-discarder:
+        days-to-keep: -1
+        num-to-keep: 50
+        artifact-days-to-keep: -1
+        artifact-num-to-keep: 50
+    builders:
+    - trigger-builds:
+      - project: percona-xtrabackup-9.x-compile-param
+        current-parameters: false
+        predefined-parameters: |
+          GIT_REPO=https://github.com/percona/percona-xtrabackup
+          BRANCH=trunk
+        block: true
+        block-thresholds:
+          build-step-failure-threshold: FAILURE
+          unstable-threshold: never
+          failure-threshold: FAILURE
+      - project: percona-xtrabackup-9.x-test-param
+        current-parameters: false
+        block: true
+        block-thresholds:
+          build-step-failure-threshold: FAILURE
+          unstable-threshold: never
+          failure-threshold: FAILURE
+    - shell: |
+        sudo find . -name "*.xml" -o -name "*.log" -delete
+    - copyartifact:
+        project: percona-xtrabackup-9.x-compile-param
+        which-build: specific-build
+        build-number: "${{TRIGGERED_BUILD_NUMBERS_percona_xtrabackup_9_x_compile_param}}"
+        do-not-fingerprint: true
+    - shell: |
+        echo "${{TRIGGERED_BUILD_NUMBERS_percona_xtrabackup_9_x_compile_param}}" > COMPILE_PIPELINE_BUILD_NUMBER
+    - copyartifact:
+        project: percona-xtrabackup-9.x-test-param
+        which-build: specific-build
+        build-number: "${{TRIGGERED_BUILD_NUMBERS_percona_xtrabackup_9_x_test_param}}"
+        do-not-fingerprint: true
+    - shell: |
+        echo "${{TRIGGERED_BUILD_NUMBERS_percona_xtrabackup_9_x_test_param}}" > TEST_PIPELINE_BUILD_NUMBER
+    publishers:
+    - raw:
+        xml: |
+          <io.jenkins.plugins.analysis.core.steps.IssuesRecorder plugin="warnings-ng@11.4.1">
+            <analysisTools>
+              <io.jenkins.plugins.analysis.warnings.Gcc4>
+                <id></id>
+                <name></name>
+                <jenkins plugin="plugin-util-api@4.1.0"/>
+                <pattern>build.log</pattern>
+                <reportEncoding></reportEncoding>
+                <skipSymbolicLinks>false</skipSymbolicLinks>
+              </io.jenkins.plugins.analysis.warnings.Gcc4>
+            </analysisTools>
+            <sourceCodeEncoding></sourceCodeEncoding>
+            <sourceDirectories/>
+            <sourceCodeRetention>EVERY_BUILD</sourceCodeRetention>
+            <ignoreQualityGate>false</ignoreQualityGate>
+            <failOnError>false</failOnError>
+            <healthy>0</healthy>
+            <unhealthy>0</unhealthy>
+            <minimumSeverity plugin="analysis-model-api@12.4.0">
+              <name>LOW</name>
+            </minimumSeverity>
+            <filters/>
+            <isEnabledForFailure>true</isEnabledForFailure>
+            <isAggregatingResults>false</isAggregatingResults>
+            <quiet>false</quiet>
+            <isBlameDisabled>false</isBlameDisabled>
+            <skipPublishingChecks>false</skipPublishingChecks>
+            <checksAnnotationScope>NEW</checksAnnotationScope>
+            <skipPostProcessing>false</skipPostProcessing>
+            <qualityGates/>
+            <trendChartType>AGGREGATION_TOOLS</trendChartType>
+            <scm></scm>
+          </io.jenkins.plugins.analysis.core.steps.IssuesRecorder>
+    - junit:
+        results: "**/junit.xml"
+        keep-long-stdio: true
+    - archive:
+        artifacts: 'COMPILE_PIPELINE_BUILD_NUMBER'
+    - archive:
+        artifacts: 'TEST_PIPELINE_BUILD_NUMBER'

--- a/pxb/v2/jenkins/percona-xtrabackup-9.x.yml
+++ b/pxb/v2/jenkins/percona-xtrabackup-9.x.yml
@@ -1,0 +1,77 @@
+- job:
+    name: percona-xtrabackup-9.x-multijob
+    project-type: multijob
+    node: launcher-x64
+    properties:
+    - groovy-label:
+        script: |
+            return (CLOUD == 'AWS') ? 'micro-amazon' : 'launcher-x64'
+        sandbox: true
+    parameters:
+        - string:
+            name: GIT_REPO
+            default: "https://github.com/percona/percona-xtrabackup"
+            description: URL to percona-xtrabackup repository
+        - string:
+            name: BRANCH
+            default: "trunk"
+            description: Tag/Branch for percona-xtrabackup repository
+        - string:
+            name: CMAKE_OPTS
+            default: ""
+            description: cmake options
+        - string:
+            name: MAKE_OPTS
+            default: ""
+            description: make options, like VERBOSE=1
+        - string:
+            name: BOOTSTRAP_URL
+            default: ""
+            description: ""
+        - string:
+            name: INNODB9X_VERSION
+            default: "9.6.0"
+            description: Version of MySQL InnoDB which will be used for bootstrap.sh script
+        - string:
+            name: XTRADB9X_VERSION
+            default: "9.6.0-1"
+            description: Version of Percona XtraDB which will be used for bootstrap.sh script
+        - string:
+            name: XBTR_ARGS
+            default: ""
+            description: "./run.sh options, for options like: -j N Run tests in N parallel processes, -T seconds, -x options Extra options to pass to xtrabackup"
+        - bool:
+            name: WITH_AZURITE
+            default: false
+            description: "Starts Microsoft Azurite emulator and tests xbcloud against it"
+        - bool:
+            name: WITH_XBCLOUD_TESTS
+            default: false
+            description: "Run xbcloud tests"
+        - bool:
+            name: WITH_VAULT_TESTS
+            default: false
+            description: "Run vault tests"
+        - bool:
+            name: WITH_KMIP_TESTS
+            default: false
+            description: "Run kmip tests"
+        - choice:
+            name: CLOUD
+            choices:
+            - "Hetzner"
+            - "AWS"
+            description: "Host provider for Jenkins workers"
+    builders:
+    - multijob:
+        name: compile-stage
+        condition: SUCCESSFUL
+        projects:
+            - name: percona-xtrabackup-9.x-compile-param
+              current-parameters: true
+    - multijob:
+        name: test-stage
+        condition: UNSTABLE
+        projects:
+            - name: percona-xtrabackup-9.x-test-param
+              current-parameters: true

--- a/pxb/v2/local/build-binary
+++ b/pxb/v2/local/build-binary
@@ -42,9 +42,6 @@ wget_loop() {
     fi
 }
 
-BOOST_VERSION=$(grep 'SET(BOOST_PACKAGE_NAME' ${SOURCEDIR}/cmake/boost.cmake | sed -re 's/.*([0-9]+_[0-9]+_[0-9]+).*/\1/')
-wget_loop "boost_${BOOST_VERSION}.tar.bz2" "http://downloads.sourceforge.net/boost/boost/${BOOST_VERSION//_/.}/boost_${BOOST_VERSION}.tar.bz2"
-
 # ------------------------------------------------------------------------------
 # Set OS/Arch flags
 # ------------------------------------------------------------------------------
@@ -75,6 +72,11 @@ fi
 source "${SOURCEDIR}/XB_VERSION"
 if [[ -n "$(which git)" ]] && [[ -d "${SOURCEDIR}/.git" ]]; then
     REVISION="$(cd "${SOURCEDIR}"; git rev-parse --short HEAD)"
+fi
+
+if [[ "${XB_VERSION_MAJOR}" == "8" ]] && [[ "${XB_VERSION_MINOR}" == "0" ]]; then
+    BOOST_VERSION=$(grep 'SET(BOOST_PACKAGE_NAME' ${SOURCEDIR}/cmake/boost.cmake | sed -re 's/.*([0-9]+_[0-9]+_[0-9]+).*/\1/')
+    wget_loop "boost_${BOOST_VERSION}.tar.bz2" "http://downloads.sourceforge.net/boost/boost/${BOOST_VERSION//_/.}/boost_${BOOST_VERSION}.tar.bz2"
 fi
 
 if [[ "${ASAN_SWITCH}" == "ON" ]]; then
@@ -112,11 +114,15 @@ FULL_PRODUCT_NAME="percona-xtrabackup-${XTRABACKUP_VERSION}-$(uname -s)-$(uname 
 # ------------------------------------------------------------------------------
 # Finaly, compile!
 # ------------------------------------------------------------------------------
+BOOST_FLAGS=""
+if [[ "${XB_VERSION_MAJOR}" == "8" ]] && [[ "${XB_VERSION_MINOR}" == "0" ]]; then
+    BOOST_FLAGS="-DDOWNLOAD_BOOST=ON -DWITH_BOOST=${DOWNLOAD_DIR}"
+fi
+
 pushd ${WORKDIR}
     ${JOB_CMAKE} \
         ${BUILD_TYPE} \
-        -DDOWNLOAD_BOOST=ON \
-        -DWITH_BOOST=${DOWNLOAD_DIR} \
+        ${BOOST_FLAGS} \
         -DCMAKE_INSTALL_PREFIX=${FULL_PRODUCT_NAME} \
         -DINSTALL_MYSQLTESTDIR=${FULL_PRODUCT_NAME}-test \
         -DINSTALL_MANDIR=${FULL_PRODUCT_NAME}/man \

--- a/pxb/v2/local/test-binary
+++ b/pxb/v2/local/test-binary
@@ -22,7 +22,7 @@ test: Compilation & Test run for this flavour(${XTRABACKUP_TARGET}) is masked as
 time: $(date +%Y-%m-%d) $(date +%H:%M:%S)
 success: Compilation & Test run for this flavour(${XTRABACKUP_TARGET}) is masked as its not supported on selected platform
 EOF
-  iconv -t UTF-8 ${WORKDIR_ABS}/test_results.subunit | eval ${SUBUNIT2JUNITXML_CMD} > ${WORKDIR_ABS}/junit.xml || true
+  iconv -c -t UTF-8 ${WORKDIR_ABS}/test_results.subunit | eval ${SUBUNIT2JUNITXML_CMD} > ${WORKDIR_ABS}/junit.xml || true
   echo "${SSL_VER} is not supported for ${XTRABACKUP_TARGET} target, this is a stub we decided to implement in PXB-2368"
   exit 0
 }
@@ -82,7 +82,7 @@ else
         errmsg
       fi
       ;;
-    noble|bookworm)
+    noble|bookworm|trixie)
       sudo apt update
       sudo DEBIAN_FRONTEND=noninteractive apt install -y python3-subunit python3-junitxml
       SUBUNIT2JUNITXML_CMD="./subunit2junitxml_python3"
@@ -164,5 +164,5 @@ fi
 cat results/setup
 sudo cp -r ${TEST_DIR}/results/ ${WORKDIR_ABS}/
 cp test_results.subunit ${WORKDIR_ABS}
-iconv -t UTF-8 test_results.subunit | eval ${SUBUNIT2JUNITXML_CMD} > ${WORKDIR_ABS}/junit.xml || true
+iconv -c -t UTF-8 test_results.subunit | eval ${SUBUNIT2JUNITXML_CMD} > ${WORKDIR_ABS}/junit.xml || true
 exit $status


### PR DESCRIPTION
## PXB-3752 : Create Jenkins pipelines for testing PXB 9.x versions

https://pxb.cd.percona.com/view/PXB%209.x/

Add a full set of Jenkins pipeline jobs for PXB 9.x, modeled after
the existing 8.1 pipeline structure:

```
multijob (9.x.yml)
  -> compile-param (matrix) -> compile-pipeline (groovy)
  -> test-param (matrix) -> test-pipeline (groovy)
```

Additionally, a **single-platform** job is introduced for 9.x
(no 8.0/8.1 equivalent exists) that combines build + test in one
pipeline for quick single-OS validation.

### Changes from the 8.1 baseline

- **Default branch:** `trunk` instead of `8.1`
- **Platform list:** dropped `centos:8`, `ubuntu:focal`, `debian:bullseye`; added `debian:trixie`. Retained: `oraclelinux:9`, `ubuntu:jammy`, `ubuntu:noble`, `debian:bookworm`, `asan`
- **Test targets:** introduced `innodb9x` and `xtradb9x` flavours (replacing `innodb80`/`xtradb80`), consumed by `bootstrap.sh`
- **Version defaults:** `INNODB9X_VERSION=9.6.0`, `XTRADB9X_VERSION=9.6.0-1`

### Shared script changes (affect both 8.0 and 9.x)

- `docker/run-build`, `docker/run-test`: default and ASAN base image changed from `centos:7/8` to `oraclelinux:9`
- `local/build-binary`: boost download now conditional on 8.0 only (9.x bundles boost in-tree)
- `local/test-binary`: added `debian:trixie` to python3 subunit/junitxml install path; added `-c` flag to `iconv` to ignore binary characters