### PR TITLE
pg.cd: optimize EC2 init script to reduce worker boot time from 8min to ~2min

### DIFF
--- a/IaC/pg.cd/init.groovy.d/cloud.groovy
+++ b/IaC/pg.cd/init.groovy.d/cloud.groovy
@@ -89,21 +89,17 @@ initMap['micro-amazon'] = '''
         echo try again
     done
 
-    sudo yum -y install java-17-amazon-corretto || :
-    sudo yum -y install java-17-openjdk || :
-    sudo yum -y install tzdata-java git unzip || :
-    sudo yum -y remove awscli java-1.7.0-openjdk || :
+    sudo yum -y remove java-1.8.0-openjdk || :
+    sudo yum -y remove java-1.8.0-openjdk-headless || :
 
-    # Install AWS CLI v2
-    if ! $(aws --version | grep -q 'aws-cli/2'); then
-        sudo rm -rf /tmp/aws* || true
-        until curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "/tmp/awscliv2.zip"; do
-            sleep 1
-            echo try again
-        done
-        cd /tmp && unzip -q awscliv2.zip
-        sudo /tmp/aws/install
+    SYSREL=$(cat /etc/system-release | tr -dc '0-9.' | awk -F'.' '{print $1}')
+    if [ "${SYSREL}" = "2023" ]; then
+        JAVA_PKG="java-17-amazon-corretto"
+    else
+        JAVA_PKG="java-17-openjdk-headless"
     fi
+    sudo yum -y install ${JAVA_PKG} tzdata-java || :
+    sudo yum -y install git || :
 
     echo '10.30.6.9 repo.ci.percona.com' | sudo tee -a /etc/hosts
 


### PR DESCRIPTION
## Summary

- Replace dual Java install (tries both corretto AND openjdk every boot) with single OS-detected package
- Remove AWS CLI v2 zip download (50MB curl + unzip on every boot — the primary bottleneck)
- Align with the ps80.cd init script pattern, which is proven at 2.5 min avg

## Problem

EC2 spot workers on pg.cd take **8 minutes avg** (480s) from provision request to agent ready.
This was reported by Manika Singhal and Naeem Akhter as jobs waiting unusually long for nodes.

The bottleneck is the init script, which on every single spot instance boot:
1. Runs `yum install java-17-amazon-corretto` (fails silently on OL9, wastes time)
2. Runs `yum install java-17-openjdk` (redundant second Java install)
3. Downloads AWS CLI v2 zip (50MB from `awscli.amazonaws.com`)
4. Unzips and installs AWS CLI v2

Meanwhile, ps80/rel/cloud run the **same stock OL9 AMIs** with a streamlined init script
and achieve **2-2.5 min avg** (134-153s across 294+ samples).

## What changed

The init script now:
- Detects OS via `/etc/system-release` to pick the correct single Java package
  - Amazon Linux 2023: `java-17-amazon-corretto`
  - OL9/CentOS/RHEL: `java-17-openjdk-headless`
- Installs only `git` (no `unzip`, no AWS CLI v2 download)
- Keeps the `repo.ci.percona.com` hosts entry (pg-specific)

## Measured data

| Instance | Template | Avg boot time | Samples |
|----------|----------|--------------|---------|
| **pg (before)** | **min-ol-9-x64** | **480s (8.0 min)** | **18 batches** |
| ps80 | docker | 153s (2.6 min) | 294 |
| rel | docker | 134s (2.2 min) | 51 |
| cloud | docker | 142s (2.4 min) | 114 |
| pxb | min-bookworm-x64 | 138s (2.3 min) | 13 |

Expected pg after this change: **~150s (2.5 min)**, matching the fleet average.

## Verification plan

#### Pre-deploy checklist
- [ ] Verify `java-17-openjdk-headless` is in OL9 default repos (confirmed: ps80 uses it successfully)
- [ ] Verify `java-17-amazon-corretto` is in AL2023 repos (confirmed: pg controller has it installed)
- [ ] Verify no pg pipeline Groovy scripts reference `aws` CLI directly in init/setup stages

#### Deploy procedure
1. SSH to pg controller, backup current cloud.groovy
2. Deploy updated cloud.groovy to `/mnt/pg.cd.percona.com/init.groovy.d/cloud.groovy`
3. Re-evaluate the Groovy script via Script Console to reload templates
4. Trigger a test build that uses `min-ol-9-x64` label

#### Post-deploy verification
- [ ] Monitor `jenkins.log` for `"agent launched for"` entries — confirm delta from `"Started provisioning"` drops to ~150s
- [ ] Verify launched workers have Java 17: check via `jenkins admin -i pg executors`
- [ ] Confirm `ppg-multiOS-parallel` and `component-generic-parallel` jobs complete successfully
- [ ] Watch for 24h — no init script failures (`"Failed to execute init script"`)
- [ ] Verify `repo.ci.percona.com` is still resolvable from workers

#### Rollback
Restore the backup cloud.groovy and re-evaluate via Script Console.