### PR TITLE
fix(pxb): use Hetzner worker for pxb-new-ps-molecule orchestrator

### DIFF
--- a/pxb/jenkins/pxb-new-ps-molecule.groovy
+++ b/pxb/jenkins/pxb-new-ps-molecule.groovy
@@ -98,7 +98,7 @@ def loadEnvFile(envFilePath) {
 
 pipeline {
   agent {
-    label 'min-bookworm-x64'
+    label 'deb12-x64-min'
   }
   environment {
     PATH = '/usr/local/bin:/usr/bin:/usr/local/sbin:/usr/sbin:/home/ec2-user/.local/bin';


### PR DESCRIPTION
## Summary

- Switch orchestrator agent label from `min-bookworm-x64` (EC2 spot) to `deb12-x64-min` (Hetzner)
- The EC2 spot instance running the orchestrator gets reclaimed by AWS during long molecule runs (builds 143, 146 aborted after 3-7 hours)
- Hetzner workers are stable (no spot termination) and `deb12` is Debian Bookworm, same OS expected by `installMoleculeBookworm()`
- The molecule test VMs themselves (provisioned in us-west-1) are unaffected; only the Jenkins orchestrator node changes