### PR TITLE
fix(fleet): increase EC2 worker idle termination from 3 to 15 minutes

### DIFF
--- a/IaC/cloud.cd/init.groovy.d/cloud.groovy
+++ b/IaC/cloud.cd/init.groovy.d/cloud.groovy
@@ -359,7 +359,7 @@ SlaveTemplate getTemplate(String OSType, String AZ) {
             new EC2Tag('Name', 'jenkins-cloud-' + OSType),
             new EC2Tag('iit-billing-tag', 'jenkins-cloud-worker')
         ],                                          // List<EC2Tag> tags
-        '3',                                        // String idleTerminationMinutes
+        '15',                                       // String idleTerminationMinutes
         0,                                          // Init minimumNumberOfInstances
         0,                                          // minimumNumberOfSpareInstances
         capMap[typeMap[OSType]],                    // String instanceCapStr

--- a/IaC/pg.cd/init.groovy.d/cloud.groovy
+++ b/IaC/pg.cd/init.groovy.d/cloud.groovy
@@ -179,7 +179,7 @@ SlaveTemplate getTemplate(String OSType, String AZ) {
             new EC2Tag('Name', 'jenkins-pg-' + OSType),
             new EC2Tag('iit-billing-tag', 'jenkins-pg-worker')
         ],                                          // List<EC2Tag> tags
-        '3',                                        // String idleTerminationMinutes
+        '15',                                       // String idleTerminationMinutes
         0,                                          // Init minimumNumberOfInstances
         0,                                          // minimumNumberOfSpareInstances
         capMap[typeMap[OSType]],                    // String instanceCapStr

--- a/IaC/ps3.cd/init.groovy.d/cloud.groovy
+++ b/IaC/ps3.cd/init.groovy.d/cloud.groovy
@@ -805,7 +805,7 @@ SlaveTemplate getTemplate(String OSType, String AZ) {
             new EC2Tag('Name', 'jenkins-ps3-' + OSType),
             new EC2Tag('iit-billing-tag', 'jenkins-ps3-worker')
         ],                                          // List<EC2Tag> tags
-        '3',                                        // String idleTerminationMinutes
+        '15',                                       // String idleTerminationMinutes
         0,                                          // Init minimumNumberOfInstances
         0,                                          // minimumNumberOfSpareInstances
         capMap[typeMap[OSType]],                    // String instanceCapStr

--- a/IaC/ps57.cd/init.groovy.d/cloud.groovy
+++ b/IaC/ps57.cd/init.groovy.d/cloud.groovy
@@ -547,7 +547,7 @@ SlaveTemplate getTemplate(String OSType, String AZ) {
             new EC2Tag('Name', 'jenkins-ps57-' + OSType),
             new EC2Tag('iit-billing-tag', 'jenkins-ps57-worker')
         ],                                          // List<EC2Tag> tags
-        '3',                                        // String idleTerminationMinutes
+        '15',                                       // String idleTerminationMinutes
         0,                                          // Init minimumNumberOfInstances
         0,                                          // minimumNumberOfSpareInstances
         capMap[typeMap[OSType]],                    // String instanceCapStr

--- a/IaC/ps80.cd/init.groovy.d/cloud.groovy
+++ b/IaC/ps80.cd/init.groovy.d/cloud.groovy
@@ -957,7 +957,7 @@ SlaveTemplate getTemplate(String OSType, String AZ) {
             new EC2Tag('Name', 'jenkins-ps80-' + OSType),
             new EC2Tag('iit-billing-tag', 'jenkins-ps80-worker')
         ],                                          // List<EC2Tag> tags
-        '3',                                        // String idleTerminationMinutes
+        '15',                                       // String idleTerminationMinutes
         0,                                          // Init minimumNumberOfInstances
         0,                                          // minimumNumberOfSpareInstances
         capMap[typeMap[OSType]],                    // String instanceCapStr

--- a/IaC/psmdb.cd/init.groovy.d/cloud.groovy
+++ b/IaC/psmdb.cd/init.groovy.d/cloud.groovy
@@ -569,7 +569,7 @@ SlaveTemplate getTemplate(String OSType, String AZ) {
             new EC2Tag('Name', 'jenkins-psmdb-' + OSType),
             new EC2Tag('iit-billing-tag', 'jenkins-psmdb-slave')
         ],                                          // List<EC2Tag> tags
-        '3',                                        // String idleTerminationMinutes
+        '15',                                       // String idleTerminationMinutes
         0,                                          // Init minimumNumberOfInstances
         0,                                          // minimumNumberOfSpareInstances
         capMap[typeMap[OSType]],                    // String instanceCapStr

--- a/IaC/pxb.cd/init.groovy.d/cloud.groovy
+++ b/IaC/pxb.cd/init.groovy.d/cloud.groovy
@@ -434,7 +434,7 @@ SlaveTemplate getTemplate(String OSType, String AZ) {
             new EC2Tag('Name', 'jenkins-pxb-' + OSType),
             new EC2Tag('iit-billing-tag', 'jenkins-pxb-worker')
         ],                                          // List<EC2Tag> tags
-        '3',                                        // String idleTerminationMinutes
+        '15',                                       // String idleTerminationMinutes
         0,                                          // Init minimumNumberOfInstances
         0,                                          // minimumNumberOfSpareInstances
         capMap[typeMap[OSType]],                    // String instanceCapStr

--- a/IaC/pxc.cd/init.groovy.d/cloud.groovy
+++ b/IaC/pxc.cd/init.groovy.d/cloud.groovy
@@ -837,7 +837,7 @@ SlaveTemplate getTemplate(String OSType, String AZ) {
             new EC2Tag('Name', 'jenkins-pxc-' + OSType),
             new EC2Tag('iit-billing-tag', 'jenkins-pxc-worker')
         ],                                          // List<EC2Tag> tags
-        '3',                                        // String idleTerminationMinutes
+        '15',                                       // String idleTerminationMinutes
         0,                                          // Init minimumNumberOfInstances
         0,                                          // minimumNumberOfSpareInstances
         capMap[typeMap[OSType]],                    // String instanceCapStr

--- a/IaC/rel.cd/init.groovy.d/cloud.groovy
+++ b/IaC/rel.cd/init.groovy.d/cloud.groovy
@@ -615,7 +615,7 @@ SlaveTemplate getTemplate(String OSType, String AZ) {
             new EC2Tag('Name', 'jenkins-rel-' + OSType),
             new EC2Tag('iit-billing-tag', 'jenkins-rel-worker')
         ],                                          // List<EC2Tag> tags
-        '3',                                        // String idleTerminationMinutes
+        '15',                                       // String idleTerminationMinutes
         0,                                          // Init minimumNumberOfInstances
         0,                                          // minimumNumberOfSpareInstances
         capMap[typeMap[OSType]],                    // String instanceCapStr


### PR DESCRIPTION
## Summary

- Increases `idleTerminationMinutes` from `3` to `15` for all EC2 worker templates on pxb.cd
- Prevents premature worker termination during parallel test pipeline runs where workers appear briefly idle between pipeline stages
- Already deployed to the live instance on 2026-04-24 after an incident where 59 builds were aborted in a single run

## Context

The EC2 plugin's `ComputerRetentionWork` timer terminates workers idle longer than `idleTerminationMinutes`. With a 3-minute window, workers running parallel PXB test pipelines were killed between stages (brief idle gap while the next stage schedules), causing `AgentOfflineException` and mass build aborts.

15 minutes provides sufficient grace for stage transitions. Worst-case cost: ~$0.05/worker for 12 extra idle minutes on m5n.2xlarge spot.