### PR TITLE
PKG-1312: pre-stage real LE cert before OpenResty start (ps3 canary)

### DIFF
--- a/IaC/cloud.cd/JenkinsStack.yml
+++ b/IaC/cloud.cd/JenkinsStack.yml
@@ -816,6 +816,23 @@ Resources:
                   systemctl restart certbot-renew.timer
               }
 
+              restore_real_cert_from_backup() {
+                  # Must run before setup_nginx: OpenResty would otherwise start
+                  # with the stale self-signed cert from create_fake_ssl_cert and
+                  # serve TLS warnings until setup_letsencrypt swaps the symlinks.
+                  [[ -d /mnt/ssl_backup ]] || return 0
+                  local src_cert=/mnt/ssl_backup/live/$JENKINS_HOST/fullchain.pem
+                  local src_key=/mnt/ssl_backup/live/$JENKINS_HOST/privkey.pem
+                  [[ -f $src_cert && -f $src_key ]] || return 0
+                  # Validate before rsync so an expired backup does not pollute
+                  # /etc/letsencrypt/; setup_letsencrypt will provision fresh.
+                  openssl x509 -in $src_cert -checkend 0 -noout || return 0
+                  rsync -aHSv --delete /mnt/ssl_backup/ /etc/letsencrypt/
+                  mkdir -p /etc/nginx/ssl
+                  ln -f -s /etc/letsencrypt/live/$JENKINS_HOST/fullchain.pem /etc/nginx/ssl/certificate.crt
+                  ln -f -s /etc/letsencrypt/live/$JENKINS_HOST/privkey.pem  /etc/nginx/ssl/certificate.key
+              }
+
               setup_dhparam() {
                   if [ ! -f /mnt/$JENKINS_HOST/ssl/dhparam-4096.pem ]; then
                       openssl dhparam -out /mnt/$JENKINS_HOST/ssl/dhparam-4096.pem 4096
@@ -875,6 +892,7 @@ Resources:
                   install_software
                   start_jenkins
                   create_fake_ssl_cert
+                  restore_real_cert_from_backup
                   setup_nginx
                   setup_dhparam
                   setup_letsencrypt

--- a/IaC/fb.cd/JenkinsStack.yml
+++ b/IaC/fb.cd/JenkinsStack.yml
@@ -794,6 +794,23 @@ Resources:
                   systemctl restart certbot-renew.timer
               }
 
+              restore_real_cert_from_backup() {
+                  # Must run before setup_nginx: OpenResty would otherwise start
+                  # with the stale self-signed cert from create_fake_ssl_cert and
+                  # serve TLS warnings until setup_letsencrypt swaps the symlinks.
+                  [[ -d /mnt/ssl_backup ]] || return 0
+                  local src_cert=/mnt/ssl_backup/live/$JENKINS_HOST/fullchain.pem
+                  local src_key=/mnt/ssl_backup/live/$JENKINS_HOST/privkey.pem
+                  [[ -f $src_cert && -f $src_key ]] || return 0
+                  # Validate before rsync so an expired backup does not pollute
+                  # /etc/letsencrypt/; setup_letsencrypt will provision fresh.
+                  openssl x509 -in $src_cert -checkend 0 -noout || return 0
+                  rsync -aHSv --delete /mnt/ssl_backup/ /etc/letsencrypt/
+                  mkdir -p /etc/nginx/ssl
+                  ln -f -s /etc/letsencrypt/live/$JENKINS_HOST/fullchain.pem /etc/nginx/ssl/certificate.crt
+                  ln -f -s /etc/letsencrypt/live/$JENKINS_HOST/privkey.pem  /etc/nginx/ssl/certificate.key
+              }
+
               setup_dhparam() {
                   if [ ! -f /mnt/$JENKINS_HOST/ssl/dhparam-4096.pem ]; then
                       openssl dhparam -out /mnt/$JENKINS_HOST/ssl/dhparam-4096.pem 4096
@@ -853,6 +870,7 @@ Resources:
                   mount_data_partition
                   start_jenkins
                   create_fake_ssl_cert
+                  restore_real_cert_from_backup
                   setup_nginx
                   setup_dhparam
                   setup_letsencrypt

--- a/IaC/pg.cd/JenkinsStack.yml
+++ b/IaC/pg.cd/JenkinsStack.yml
@@ -867,6 +867,23 @@ Resources:
                   systemctl restart certbot-renew.timer
               }
 
+              restore_real_cert_from_backup() {
+                  # Must run before setup_nginx: OpenResty would otherwise start
+                  # with the stale self-signed cert from create_fake_ssl_cert and
+                  # serve TLS warnings until setup_letsencrypt swaps the symlinks.
+                  [[ -d /mnt/ssl_backup ]] || return 0
+                  local src_cert=/mnt/ssl_backup/live/$JENKINS_HOST/fullchain.pem
+                  local src_key=/mnt/ssl_backup/live/$JENKINS_HOST/privkey.pem
+                  [[ -f $src_cert && -f $src_key ]] || return 0
+                  # Validate before rsync so an expired backup does not pollute
+                  # /etc/letsencrypt/; setup_letsencrypt will provision fresh.
+                  openssl x509 -in $src_cert -checkend 0 -noout || return 0
+                  rsync -aHSv --delete /mnt/ssl_backup/ /etc/letsencrypt/
+                  mkdir -p /etc/nginx/ssl
+                  ln -f -s /etc/letsencrypt/live/$JENKINS_HOST/fullchain.pem /etc/nginx/ssl/certificate.crt
+                  ln -f -s /etc/letsencrypt/live/$JENKINS_HOST/privkey.pem  /etc/nginx/ssl/certificate.key
+              }
+
               setup_dhparam() {
                   if [ ! -f /mnt/$JENKINS_HOST/ssl/dhparam-4096.pem ]; then
                       openssl dhparam -out /mnt/$JENKINS_HOST/ssl/dhparam-4096.pem 4096
@@ -926,6 +943,7 @@ Resources:
                   install_software
                   start_jenkins
                   create_fake_ssl_cert
+                  restore_real_cert_from_backup
                   setup_nginx
                   setup_dhparam
                   setup_letsencrypt

--- a/IaC/pmm.cd/JenkinsStack.yml
+++ b/IaC/pmm.cd/JenkinsStack.yml
@@ -862,6 +862,23 @@ Resources:
                 systemctl restart certbot-renew.timer
             }
 
+            restore_real_cert_from_backup() {
+                # Must run before setup_nginx: OpenResty would otherwise start
+                # with the stale self-signed cert from create_fake_ssl_cert and
+                # serve TLS warnings until setup_letsencrypt swaps the symlinks.
+                [[ -d /mnt/ssl_backup ]] || return 0
+                local src_cert=/mnt/ssl_backup/live/$JENKINS_HOST/fullchain.pem
+                local src_key=/mnt/ssl_backup/live/$JENKINS_HOST/privkey.pem
+                [[ -f $src_cert && -f $src_key ]] || return 0
+                # Validate before rsync so an expired backup does not pollute
+                # /etc/letsencrypt/; setup_letsencrypt will provision fresh.
+                openssl x509 -in $src_cert -checkend 0 -noout || return 0
+                rsync -aHSv --delete /mnt/ssl_backup/ /etc/letsencrypt/
+                mkdir -p /etc/nginx/ssl
+                ln -f -s /etc/letsencrypt/live/$JENKINS_HOST/fullchain.pem /etc/nginx/ssl/certificate.crt
+                ln -f -s /etc/letsencrypt/live/$JENKINS_HOST/privkey.pem  /etc/nginx/ssl/certificate.key
+            }
+
             setup_dhparam() {
                 if [ ! -f /mnt/$JENKINS_HOST/ssl/dhparam-4096.pem ]; then
                     openssl dhparam -out /mnt/$JENKINS_HOST/ssl/dhparam-4096.pem 4096
@@ -919,6 +936,7 @@ Resources:
                 setup_ssh_ciphers
                 start_jenkins
                 create_fake_ssl_cert
+                restore_real_cert_from_backup
                 setup_nginx
                 setup_dhparam
                 setup_letsencrypt

--- a/IaC/ps3.cd/JenkinsStack.yml
+++ b/IaC/ps3.cd/JenkinsStack.yml
@@ -797,6 +797,22 @@ Resources:
                   systemctl restart certbot-renew.timer
               }
 
+              restore_real_cert_from_backup() {
+                  # Must run before setup_nginx: OpenResty would otherwise start
+                  # with the stale self-signed cert from create_fake_ssl_cert and
+                  # serve TLS warnings until setup_letsencrypt swaps the symlinks.
+                  [[ -d /mnt/ssl_backup ]] || return 0
+                  rsync -aHSv --delete /mnt/ssl_backup/ /etc/letsencrypt/
+                  local cert=/etc/letsencrypt/live/$JENKINS_HOST/fullchain.pem
+                  local key=/etc/letsencrypt/live/$JENKINS_HOST/privkey.pem
+                  [[ -f $cert && -f $key ]] || return 0
+                  # Skip if backup cert is expired; setup_letsencrypt will provision fresh.
+                  openssl x509 -in $cert -checkend 0 -noout || return 0
+                  mkdir -p /etc/nginx/ssl
+                  ln -f -s $cert /etc/nginx/ssl/certificate.crt
+                  ln -f -s $key  /etc/nginx/ssl/certificate.key
+              }
+
               setup_dhparam() {
                   if [ ! -f /mnt/$JENKINS_HOST/ssl/dhparam-4096.pem ]; then
                       openssl dhparam -out /mnt/$JENKINS_HOST/ssl/dhparam-4096.pem 4096
@@ -856,6 +872,7 @@ Resources:
                   install_software
                   start_jenkins
                   create_fake_ssl_cert
+                  restore_real_cert_from_backup
                   setup_nginx
                   setup_dhparam
                   setup_letsencrypt

--- a/IaC/ps3.cd/JenkinsStack.yml
+++ b/IaC/ps3.cd/JenkinsStack.yml
@@ -802,15 +802,16 @@ Resources:
                   # with the stale self-signed cert from create_fake_ssl_cert and
                   # serve TLS warnings until setup_letsencrypt swaps the symlinks.
                   [[ -d /mnt/ssl_backup ]] || return 0
+                  local src_cert=/mnt/ssl_backup/live/$JENKINS_HOST/fullchain.pem
+                  local src_key=/mnt/ssl_backup/live/$JENKINS_HOST/privkey.pem
+                  [[ -f $src_cert && -f $src_key ]] || return 0
+                  # Validate before rsync so an expired backup does not pollute
+                  # /etc/letsencrypt/; setup_letsencrypt will provision fresh.
+                  openssl x509 -in $src_cert -checkend 0 -noout || return 0
                   rsync -aHSv --delete /mnt/ssl_backup/ /etc/letsencrypt/
-                  local cert=/etc/letsencrypt/live/$JENKINS_HOST/fullchain.pem
-                  local key=/etc/letsencrypt/live/$JENKINS_HOST/privkey.pem
-                  [[ -f $cert && -f $key ]] || return 0
-                  # Skip if backup cert is expired; setup_letsencrypt will provision fresh.
-                  openssl x509 -in $cert -checkend 0 -noout || return 0
                   mkdir -p /etc/nginx/ssl
-                  ln -f -s $cert /etc/nginx/ssl/certificate.crt
-                  ln -f -s $key  /etc/nginx/ssl/certificate.key
+                  ln -f -s /etc/letsencrypt/live/$JENKINS_HOST/fullchain.pem /etc/nginx/ssl/certificate.crt
+                  ln -f -s /etc/letsencrypt/live/$JENKINS_HOST/privkey.pem  /etc/nginx/ssl/certificate.key
               }
 
               setup_dhparam() {

--- a/IaC/ps57.cd/JenkinsStack.yml
+++ b/IaC/ps57.cd/JenkinsStack.yml
@@ -799,6 +799,23 @@ Resources:
                   systemctl restart certbot-renew.timer
               }
 
+              restore_real_cert_from_backup() {
+                  # Must run before setup_nginx: OpenResty would otherwise start
+                  # with the stale self-signed cert from create_fake_ssl_cert and
+                  # serve TLS warnings until setup_letsencrypt swaps the symlinks.
+                  [[ -d /mnt/ssl_backup ]] || return 0
+                  local src_cert=/mnt/ssl_backup/live/$JENKINS_HOST/fullchain.pem
+                  local src_key=/mnt/ssl_backup/live/$JENKINS_HOST/privkey.pem
+                  [[ -f $src_cert && -f $src_key ]] || return 0
+                  # Validate before rsync so an expired backup does not pollute
+                  # /etc/letsencrypt/; setup_letsencrypt will provision fresh.
+                  openssl x509 -in $src_cert -checkend 0 -noout || return 0
+                  rsync -aHSv --delete /mnt/ssl_backup/ /etc/letsencrypt/
+                  mkdir -p /etc/nginx/ssl
+                  ln -f -s /etc/letsencrypt/live/$JENKINS_HOST/fullchain.pem /etc/nginx/ssl/certificate.crt
+                  ln -f -s /etc/letsencrypt/live/$JENKINS_HOST/privkey.pem  /etc/nginx/ssl/certificate.key
+              }
+
               setup_dhparam() {
                   if [ ! -f /mnt/$JENKINS_HOST/ssl/dhparam-4096.pem ]; then
                       openssl dhparam -out /mnt/$JENKINS_HOST/ssl/dhparam-4096.pem 4096
@@ -858,6 +875,7 @@ Resources:
                   install_software
                   start_jenkins
                   create_fake_ssl_cert
+                  restore_real_cert_from_backup
                   setup_nginx
                   setup_dhparam
                   setup_letsencrypt

--- a/IaC/ps80.cd/JenkinsStack.yml
+++ b/IaC/ps80.cd/JenkinsStack.yml
@@ -798,6 +798,23 @@ Resources:
                   systemctl restart certbot-renew.timer
               }
 
+              restore_real_cert_from_backup() {
+                  # Must run before setup_nginx: OpenResty would otherwise start
+                  # with the stale self-signed cert from create_fake_ssl_cert and
+                  # serve TLS warnings until setup_letsencrypt swaps the symlinks.
+                  [[ -d /mnt/ssl_backup ]] || return 0
+                  local src_cert=/mnt/ssl_backup/live/$JENKINS_HOST/fullchain.pem
+                  local src_key=/mnt/ssl_backup/live/$JENKINS_HOST/privkey.pem
+                  [[ -f $src_cert && -f $src_key ]] || return 0
+                  # Validate before rsync so an expired backup does not pollute
+                  # /etc/letsencrypt/; setup_letsencrypt will provision fresh.
+                  openssl x509 -in $src_cert -checkend 0 -noout || return 0
+                  rsync -aHSv --delete /mnt/ssl_backup/ /etc/letsencrypt/
+                  mkdir -p /etc/nginx/ssl
+                  ln -f -s /etc/letsencrypt/live/$JENKINS_HOST/fullchain.pem /etc/nginx/ssl/certificate.crt
+                  ln -f -s /etc/letsencrypt/live/$JENKINS_HOST/privkey.pem  /etc/nginx/ssl/certificate.key
+              }
+
               setup_dhparam() {
                   if [ ! -f /mnt/$JENKINS_HOST/ssl/dhparam-4096.pem ]; then
                       openssl dhparam -out /mnt/$JENKINS_HOST/ssl/dhparam-4096.pem 4096
@@ -857,6 +874,7 @@ Resources:
                   install_software
                   start_jenkins
                   create_fake_ssl_cert
+                  restore_real_cert_from_backup
                   setup_nginx
                   setup_dhparam
                   setup_letsencrypt

--- a/IaC/psmdb.cd/JenkinsStack.yml
+++ b/IaC/psmdb.cd/JenkinsStack.yml
@@ -745,6 +745,23 @@ Resources:
                   systemctl restart certbot-renew.timer
               }
 
+              restore_real_cert_from_backup() {
+                  # Must run before setup_nginx: OpenResty would otherwise start
+                  # with the stale self-signed cert from create_fake_ssl_cert and
+                  # serve TLS warnings until setup_letsencrypt swaps the symlinks.
+                  [[ -d /mnt/ssl_backup ]] || return 0
+                  local src_cert=/mnt/ssl_backup/live/$JENKINS_HOST/fullchain.pem
+                  local src_key=/mnt/ssl_backup/live/$JENKINS_HOST/privkey.pem
+                  [[ -f $src_cert && -f $src_key ]] || return 0
+                  # Validate before rsync so an expired backup does not pollute
+                  # /etc/letsencrypt/; setup_letsencrypt will provision fresh.
+                  openssl x509 -in $src_cert -checkend 0 -noout || return 0
+                  rsync -aHSv --delete /mnt/ssl_backup/ /etc/letsencrypt/
+                  mkdir -p /etc/nginx/ssl
+                  ln -f -s /etc/letsencrypt/live/$JENKINS_HOST/fullchain.pem /etc/nginx/ssl/certificate.crt
+                  ln -f -s /etc/letsencrypt/live/$JENKINS_HOST/privkey.pem  /etc/nginx/ssl/certificate.key
+              }
+
               setup_dhparam() {
                   if [ ! -f /mnt/$JENKINS_HOST/ssl/dhparam-4096.pem ]; then
                       openssl dhparam -out /mnt/$JENKINS_HOST/ssl/dhparam-4096.pem 4096
@@ -804,6 +821,7 @@ Resources:
                   install_software
                   start_jenkins
                   create_fake_ssl_cert
+                  restore_real_cert_from_backup
                   setup_nginx
                   setup_dhparam
                   setup_letsencrypt

--- a/IaC/pxb.cd/terraform/master_user_data.sh
+++ b/IaC/pxb.cd/terraform/master_user_data.sh
@@ -289,6 +289,23 @@ EOF
     systemctl restart certbot-renew.timer
 }
 
+restore_real_cert_from_backup() {
+    # Must run before setup_nginx: OpenResty would otherwise start
+    # with the stale self-signed cert from create_fake_ssl_cert and
+    # serve TLS warnings until setup_letsencrypt swaps the symlinks.
+    [[ -d /mnt/ssl_backup ]] || return 0
+    local src_cert=/mnt/ssl_backup/live/$JENKINS_HOST/fullchain.pem
+    local src_key=/mnt/ssl_backup/live/$JENKINS_HOST/privkey.pem
+    [[ -f $src_cert && -f $src_key ]] || return 0
+    # Validate before rsync so an expired backup does not pollute
+    # /etc/letsencrypt/; setup_letsencrypt will provision fresh.
+    openssl x509 -in $src_cert -checkend 0 -noout || return 0
+    rsync -aHSv --delete /mnt/ssl_backup/ /etc/letsencrypt/
+    mkdir -p /etc/nginx/ssl
+    ln -f -s /etc/letsencrypt/live/$JENKINS_HOST/fullchain.pem /etc/nginx/ssl/certificate.crt
+    ln -f -s /etc/letsencrypt/live/$JENKINS_HOST/privkey.pem  /etc/nginx/ssl/certificate.key
+}
+
 setup_dhparam() {
     if [ ! -f /mnt/$JENKINS_HOST/ssl/dhparam-4096.pem ]; then
         openssl dhparam -out /mnt/$JENKINS_HOST/ssl/dhparam-4096.pem 4096
@@ -347,6 +364,7 @@ main() {
     mount_data_partition
     install_software
     create_fake_ssl_cert
+    restore_real_cert_from_backup
     setup_nginx
     start_jenkins
     setup_dhparam

--- a/IaC/pxc.cd/JenkinsStack.yml
+++ b/IaC/pxc.cd/JenkinsStack.yml
@@ -805,6 +805,23 @@ Resources:
                   systemctl restart certbot-renew.timer
               }
 
+              restore_real_cert_from_backup() {
+                  # Must run before setup_nginx: OpenResty would otherwise start
+                  # with the stale self-signed cert from create_fake_ssl_cert and
+                  # serve TLS warnings until setup_letsencrypt swaps the symlinks.
+                  [[ -d /mnt/ssl_backup ]] || return 0
+                  local src_cert=/mnt/ssl_backup/live/$JENKINS_HOST/fullchain.pem
+                  local src_key=/mnt/ssl_backup/live/$JENKINS_HOST/privkey.pem
+                  [[ -f $src_cert && -f $src_key ]] || return 0
+                  # Validate before rsync so an expired backup does not pollute
+                  # /etc/letsencrypt/; setup_letsencrypt will provision fresh.
+                  openssl x509 -in $src_cert -checkend 0 -noout || return 0
+                  rsync -aHSv --delete /mnt/ssl_backup/ /etc/letsencrypt/
+                  mkdir -p /etc/nginx/ssl
+                  ln -f -s /etc/letsencrypt/live/$JENKINS_HOST/fullchain.pem /etc/nginx/ssl/certificate.crt
+                  ln -f -s /etc/letsencrypt/live/$JENKINS_HOST/privkey.pem  /etc/nginx/ssl/certificate.key
+              }
+
               setup_dhparam() {
                   if [ ! -f /mnt/$JENKINS_HOST/ssl/dhparam-4096.pem ]; then
                       openssl dhparam -out /mnt/$JENKINS_HOST/ssl/dhparam-4096.pem 4096
@@ -866,6 +883,7 @@ Resources:
                   install_software
                   start_jenkins
                   create_fake_ssl_cert
+                  restore_real_cert_from_backup
                   setup_nginx
                   setup_dhparam
                   setup_letsencrypt

--- a/IaC/rel.cd/JenkinsStack.yml
+++ b/IaC/rel.cd/JenkinsStack.yml
@@ -797,6 +797,23 @@ Resources:
                   systemctl restart certbot-renew.timer
               }
 
+              restore_real_cert_from_backup() {
+                  # Must run before setup_nginx: OpenResty would otherwise start
+                  # with the stale self-signed cert from create_fake_ssl_cert and
+                  # serve TLS warnings until setup_letsencrypt swaps the symlinks.
+                  [[ -d /mnt/ssl_backup ]] || return 0
+                  local src_cert=/mnt/ssl_backup/live/$JENKINS_HOST/fullchain.pem
+                  local src_key=/mnt/ssl_backup/live/$JENKINS_HOST/privkey.pem
+                  [[ -f $src_cert && -f $src_key ]] || return 0
+                  # Validate before rsync so an expired backup does not pollute
+                  # /etc/letsencrypt/; setup_letsencrypt will provision fresh.
+                  openssl x509 -in $src_cert -checkend 0 -noout || return 0
+                  rsync -aHSv --delete /mnt/ssl_backup/ /etc/letsencrypt/
+                  mkdir -p /etc/nginx/ssl
+                  ln -f -s /etc/letsencrypt/live/$JENKINS_HOST/fullchain.pem /etc/nginx/ssl/certificate.crt
+                  ln -f -s /etc/letsencrypt/live/$JENKINS_HOST/privkey.pem  /etc/nginx/ssl/certificate.key
+              }
+
               setup_dhparam() {
                   if [ ! -f /mnt/$JENKINS_HOST/ssl/dhparam-4096.pem ]; then
                       openssl dhparam -out /mnt/$JENKINS_HOST/ssl/dhparam-4096.pem 4096
@@ -856,6 +873,7 @@ Resources:
                   install_software
                   start_jenkins
                   create_fake_ssl_cert
+                  restore_real_cert_from_backup
                   setup_nginx
                   setup_dhparam
                   setup_letsencrypt


### PR DESCRIPTION
Tracking in [PKG-1312](https://perconadev.atlassian.net/browse/PKG-1312).

## Issue

During instance bootstrap, OpenResty starts with a self-signed cert before the real Let's Encrypt cert is restored. Clients hitting the box during that window see TLS warnings.

Affects all Jenkins masters that share this bootstrap pattern.

## Fix

Restore the real LE cert from the on-disk backup before OpenResty starts, so the trusted cert is in place from the first request. Existing renewal flow is unchanged; first-time bootstrap (no backup present) is unaffected.


[PKG-1312]: https://perconadev.atlassian.net/browse/PKG-1312?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ