### PR TITLE
PS-11067: Fix MySQL tag notifications

### DIFF
--- a/ps/jenkins/check_mysql_repo.groovy
+++ b/ps/jenkins/check_mysql_repo.groovy
@@ -84,18 +84,20 @@ pipeline {
                                     comm -13 ${repoName}.last ${repoName}.current | \
                                         awk '{print "${repoUrl}/tree/"\$1}' > ${repoName}.newtags || true
 
-                                    mv -fv ${repoName}.current ${repoName}.last
+                                    # State promotion (current -> last) and S3 push deferred to
+                                    # 'Persist State' stage so a failure in 'Process New Tags' or
+                                    # 'Send Notifications' does not silently advance S3 state and
+                                    # cause new tags to be lost without an alert.
                                 else
                                     # First run - just save current state
                                     git ls-remote --tags --refs ${repoUrl} | awk -F'/' '{print \$3}' | sort > ${repoName}.last
                                     touch ${repoName}.newtags
                                 fi
                             """
-                            pushArtifactFile("${repoName}.last", S3_PATH)
                         }
                     }
                     }
-                stash allowEmpty: true, includes: '*.newtags, *.last', name: 'TagFiles'
+                stash allowEmpty: true, includes: '*.newtags, *.last, *.current', name: 'TagFiles'
             }
         }
         stage('Process New Tags') {
@@ -128,10 +130,20 @@ pipeline {
                         set -o xtrace
 
                         git clone --filter=blob:none ${ReposPathMap['MySQL']} mysql-server-repo
-
-                        curl -fsSL -o mysql_commit_report.py \
-                            https://raw.githubusercontent.com/percona/mysql-eol-dev/b42ac69b49a6ed489f25400efc9f0b8d1ac1df68/scripts/mysql_commit_report.py
                     """
+
+                    // mysql-eol-dev is a private repo. Anonymous fetches from
+                    // raw.githubusercontent.com return 404. Use a Jenkins-stored
+                    // token; pinned SHA preserves reproducibility.
+                    withCredentials([string(credentialsId: 'Github_Integration', variable: 'GITHUB_API_TOKEN')]) {
+                        sh '''
+                            set -o errexit
+                            set -o xtrace
+                            curl -fsSL -H "Authorization: token ${GITHUB_API_TOKEN}" \
+                                -o mysql_commit_report.py \
+                                https://raw.githubusercontent.com/percona/mysql-eol-dev/b42ac69b49a6ed489f25400efc9f0b8d1ac1df68/scripts/mysql_commit_report.py
+                        '''
+                    }
 
                     // Create directory for CSV output
                     sh 'mkdir -p csv_output'
@@ -227,6 +239,30 @@ CSV Reports: ${artifactUrl}"""
                             SlackChannels.each { channel ->
                                 slackNotify(channel, '#00FF00', message)
                             }
+                        }
+                    }
+                }
+            }
+        }
+        stage('Persist State') {
+            // Runs only when all earlier stages succeed. If 'Process New Tags' or
+            // 'Send Notifications' fails, this stage is skipped and S3 keeps the
+            // old baseline so the next cron run will retry.
+            steps {
+                withCredentials([[$class: 'AmazonWebServicesCredentialsBinding',
+                    accessKeyVariable: 'AWS_ACCESS_KEY_ID',
+                    credentialsId: 'AWS_STASH',
+                    secretKeyVariable: 'AWS_SECRET_ACCESS_KEY']]) {
+                    script {
+                        ReposPathMap.each { repoName, repoUrl ->
+                            sh """
+                                set -o errexit
+                                set -o xtrace
+                                if [ -f ${repoName}.current ]; then
+                                    mv -fv ${repoName}.current ${repoName}.last
+                                fi
+                            """
+                            pushArtifactFile("${repoName}.last", S3_PATH)
                         }
                     }
                 }

--- a/ps/jenkins/check_mysql_repo.groovy
+++ b/ps/jenkins/check_mysql_repo.groovy
@@ -136,9 +136,12 @@ pipeline {
                     // raw.githubusercontent.com return 404. Use a Jenkins-stored
                     // token; pinned SHA preserves reproducibility.
                     withCredentials([string(credentialsId: 'Github_Integration', variable: 'GITHUB_API_TOKEN')]) {
+                        // Intentionally no `set -o xtrace`. Jenkins masks
+                        // ${GITHUB_API_TOKEN} as **** in logs, but skipping trace
+                        // on this secret-bearing command keeps the Authorization
+                        // header out of the build console entirely.
                         sh '''
                             set -o errexit
-                            set -o xtrace
                             curl -fsSL -H "Authorization: token ${GITHUB_API_TOKEN}" \
                                 -o mysql_commit_report.py \
                                 https://raw.githubusercontent.com/percona/mysql-eol-dev/b42ac69b49a6ed489f25400efc9f0b8d1ac1df68/scripts/mysql_commit_report.py


### PR DESCRIPTION
Fixes [PS-11067](https://perconadev.atlassian.net/browse/PS-11067). Two latent bugs blocked `[check-mysql-repo]` Slack alerts since [PR #3770](https://github.com/Percona-Lab/jenkins-pipelines/pull/3770) ([PKG-1228](https://perconadev.atlassian.net/browse/PKG-1228)):

1. `curl` for `mysql_commit_report.py` from private repo `percona/mysql-eol-dev` was unauthenticated → 404. Now uses the `Github_Integration` credential (`percona` org scope; `GITHUB_API_TOKEN` is `Percona-Lab` only).
2. `MySQL.last` was pushed to S3 in stage 1, before notifications. When the curl 404 killed stage 2, S3 had already advanced past the new tags, hiding the failure on the next cron run. State promotion + S3 push moved to a final `Persist State` stage gated on prior-stage success.

Validated on `ps80/check-mysql-repo` (temporarily pointed at this branch, with `mysql-cluster-9.4.0` dropped from S3):

- [#738](https://ps80.cd.percona.com/job/check-mysql-repo/738/): stage 2 404, `Persist State` skipped, S3 untouched. Confirms (2).
- [#739](https://ps80.cd.percona.com/job/check-mysql-repo/739/): green; `slackSend` to `#mysql` + `#eol-dev`; S3 advanced. Confirms (1) and end-to-end.

Job restored to `master`.

[PS-11067]: https://perconadev.atlassian.net/browse/PS-11067?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ