### PR TITLE
PS-11075: mirror Ubuntu 26.04 telemetry OS list to hetzner branch

### DIFF
--- a/vars/ps80telemOperatingSystems.groovy
+++ b/vars/ps80telemOperatingSystems.groovy
@@ -1,3 +1,3 @@
 def call() {
-  return ['oracle-8', 'oracle-9', 'rhel-8', 'rhel-9', 'debian-11', 'debian-12','ubuntu-focal', 'ubuntu-jammy', 'ubuntu-noble', 'rhel-8-arm', 'rhel-9-arm',  'debian-11-arm', 'debian-12-arm','ubuntu-focal-arm', 'ubuntu-jammy-arm', 'ubuntu-noble-arm',]
+  return ['oracle-8', 'oracle-9', 'rhel-8', 'rhel-9', 'debian-11', 'debian-12','ubuntu-focal', 'ubuntu-jammy', 'ubuntu-noble', 'ubuntu-resolute', 'rhel-8-arm', 'rhel-9-arm',  'debian-11-arm', 'debian-12-arm','ubuntu-focal-arm', 'ubuntu-jammy-arm', 'ubuntu-noble-arm', 'ubuntu-resolute-arm',]
 }


### PR DESCRIPTION
Follow-up to merged [PR #3996](https://github.com/Percona-Lab/jenkins-pipelines/pull/3996) ([PS-11075](https://perconadev.atlassian.net/browse/PS-11075), [PKG-1313](https://perconadev.atlassian.net/browse/PKG-1313)).

`vars/ps80telemOperatingSystems.groovy` is policy-identical between `master` and `hetzner` and is consumed by molecule pipelines (`telemetry/ps80-telemetry*.groovy`) on both branches. PR #3996 added `ubuntu-resolute` and `ubuntu-resolute-arm` on `master` only, so this PR mirrors the same one-line change on `hetzner` to keep the branches aligned. After this lands, the file matches `master` byte-for-byte.

No `htz.cloud.groovy` change is required today. There is no Hetzner `docker-resolute-*` template, and neither branch's `percona-telemetry-agent.groovy` has a Resolute build stage yet (only Focal / Jammy / Noble). When a Resolute stage lands, whoever writes it picks the cloud and the cloud-specific labels.

Tracked in [PKG-1313 comment 458312](https://perconadev.atlassian.net/browse/PKG-1313?focusedId=458312).

[PS-11075]: https://perconadev.atlassian.net/browse/PS-11075?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[PKG-1313]: https://perconadev.atlassian.net/browse/PKG-1313?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ