### PR TITLE
PS-11075: pxb cloud.groovy install openjdk-17 on Ubuntu 26.04 Resolute

### DIFF
--- a/IaC/pxb.cd/init.groovy.d/cloud.groovy
+++ b/IaC/pxb.cd/init.groovy.d/cloud.groovy
@@ -281,12 +281,12 @@ initMap['debMap'] = '''
         echo try again
     done
     DEB_VER=$(lsb_release -sc)
-    if [[ ${DEB_VER} == "bookworm" ]] || [[ ${DEB_VER} == "bullseye" ]]; then
+    if [[ ${DEB_VER} == "bookworm" ]] || [[ ${DEB_VER} == "bullseye" ]] || [[ ${DEB_VER} == "resolute" ]]; then
         JAVA_VER="openjdk-17-jre-headless"
     else
         JAVA_VER="openjdk-11-jre-headless"
     fi
-    if [[ ${DEB_VER} == "bookworm" ]] || [[ ${DEB_VER} == "bullseye" ]] || [[ ${DEB_VER} == "buster" ]]; then
+    if [[ ${DEB_VER} == "bookworm" ]] || [[ ${DEB_VER} == "bullseye" ]] || [[ ${DEB_VER} == "buster" ]] || [[ ${DEB_VER} == "resolute" ]]; then
         sudo DEBIAN_FRONTEND=noninteractive sudo apt-get -y install ${JAVA_VER} git
         sudo mv /etc/ssl /etc/ssl_old
         sudo DEBIAN_FRONTEND=noninteractive sudo apt-get -y install ${JAVA_VER}


### PR DESCRIPTION
Follow-up to merged [PR #3996](https://github.com/Percona-Lab/jenkins-pipelines/pull/3996) ([PS-11075](https://perconadev.atlassian.net/browse/PS-11075), [PKG-1313](https://perconadev.atlassian.net/browse/PKG-1313)).

After PR #3996, all 5 affected masters got `min-resolute-x64` EC2 templates loaded. 4 of them provisioned and ran the smoke test green. **pxb did not** because workers came up, the Jenkins SSH connection succeeded, but the remoting agent never attached:

```
Error: LinkageError occurred while loading main class hudson.remoting.Launcher
java.lang.UnsupportedClassVersionError: hudson/remoting/Launcher has been compiled by a more recent version of the Java Runtime (class file version 61.0), this version of the Java Runtime only recognizes class file versions up to 55.0
```

The current `remoting.jar` requires Java 17 (class file 61). pxb's `debMap` initScript only set `JAVA_VER=openjdk-17-jre-headless` for `bookworm` and `bullseye`; every other Debian/Ubuntu codename fell through to `openjdk-11-jre-headless`. Resolute (Ubuntu 26.04) hit the fallback. Java 11 cannot load the new remoting.jar, so the agent process exited and Jenkins terminated the spot, leaving a ghost `Node` behind on every retry.

Add `resolute` to the `openjdk-17` branch and to the SSL-rebuild branch, matching the pattern already in `pxc.cd`, `ps80.cd`, `rel.cd`, and `ps3.cd` debMaps.

## Validation

Applied to pxb live (in-memory `init.groovy.d/cloud.groovy` reload + on-disk persist via `paws ssh`) and ran a smoke test on `min-resolute-x64`:

- Worker `i-03446dd971c5417ce` (`sir-1hsfdrxn`) provisioned, attached, ran the validation script.
- Console: `Ubuntu 26.04 LTS (Resolute Raccoon)`, kernel `7.0.0-1004-aws`, `openjdk version "17.0.18" 2026-01-20`.
- Build [#1](https://pxb.cd.percona.com/job/temp-resolute-validation/1/) SUCCESS, no residual ghost Node.

PR is the disk-persist of the same patch already running on the master.

[PS-11075]: https://perconadev.atlassian.net/browse/PS-11075?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[PKG-1313]: https://perconadev.atlassian.net/browse/PKG-1313?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ