### PR TITLE
fix(ps3): bump Jenkins to 2.541.3 to match live (PKG-1312)

### DIFF
--- a/IaC/ps3.cd/JenkinsStack.yml
+++ b/IaC/ps3.cd/JenkinsStack.yml
@@ -557,7 +557,7 @@ Resources:
                   rpm --import https://pkg.jenkins.io/redhat-stable/jenkins.io-2026.key
                   yum -y install java-17-amazon-corretto
                   yum -y update --security
-                  yum -y install jenkins-2.528.3 certbot git dnf-automatic aws-cli xfsprogs openresty
+                  yum -y install jenkins-2.541.3 certbot git dnf-automatic aws-cli xfsprogs openresty
 
                   sed -i 's/upgrade_type = default/upgrade_type = security/' /etc/dnf/automatic.conf
                   sed -i 's/apply_updates = no/apply_updates = yes/'         /etc/dnf/automatic.conf


### PR DESCRIPTION
## Why

The ps3.cd master was running plugins on JENKINS_HOME that required Jenkins core >= 2.541.1, but the IaC pinned `jenkins-2.528.3`. The mismatch was latent until 2026-04-29 when the [PKG-1312](https://perconadev.atlassian.net/browse/PKG-1312) CFN change-set replaced the master and triggered the crash loop:

```
Failed to load: Credentials Plugin (credentials 1502.v5c95e620ddfe)
[LF]>  - Jenkins (2.541.1) or higher required
```

The PKG-1312 bootstrap-window TLS fix itself is verified working (`restore_real_cert_from_backup` ran before `setup_nginx`, LE cert served from first handshake). The crash was a separate pre-existing issue that PKG-1312's restart triggered.

## What

Replace `jenkins-2.528.3` with `jenkins-2.541.3` on the single `yum -y install` line in `IaC/ps3.cd/JenkinsStack.yml`. Live ps3 already runs 2.541.3 (manually replaced `/usr/share/java/jenkins.war` at 12:55 UTC). Without this PR, the next spot eviction on ps3 reinstalls 2.528.3 and re-triggers the same crash.

## Why 2.541.3

- Latest LTS in the 2.541.x line, which is the last LTS to support Java 17
- Amazon Corretto 17 is what the Jenkins masters currently run; bumping to 2.555.x requires Java 21
- ps3 has been on 2.541.3 since 12:55 UTC and is stable

## Scope

Single-master fix. The other 9 masters (pg, ps57, pxc, rel, cloud, psmdb, pxb, ps80, pmm) were audited and have zero plugins on disk requiring core > 2.528.3 — no mismatch, safe to remain at 2.528.3. The fleet-wide Jenkins core bump is a separate workstream tied to the eventual Java 17 to 21 migration before April 2026.

[PKG-1312]: https://perconadev.atlassian.net/browse/PKG-1312?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ