### PR TITLE
fix(openshift): add force-destroy path for clusters without S3 state

### DIFF
--- a/pmm/openshift/openshift-cluster-destroy.yml
+++ b/pmm/openshift/openshift-cluster-destroy.yml
@@ -37,6 +37,27 @@
             - 'error-cleanup'
             - 'other'
           description: 'Reason for cluster destruction'
+      - bool:
+          name: FORCE_MODE
+          default: false
+          description: |
+            Force-destroy a cluster that has no S3 state (leaked from a failed create job).
+            Synthesizes a minimal metadata.json from the AWS-tag infraID and runs
+            openshift-install destroy without touching S3.
+      - string:
+          name: INFRA_ID
+          default: ''
+          description: |
+            AWS-tag infraID (kubernetes.io/cluster/<infraID>) shown by openshift-cluster-list.
+            When FORCE_MODE=true and this is blank, defaults to CLUSTER_NAME (which is
+            already the infraID for clusters that show up as aws-tags only).
+            Override only when CLUSTER_NAME is the base name and the infraID has a suffix.
+          trim: true
+      - string:
+          name: OPENSHIFT_VERSION
+          default: '4.16.9'
+          description: 'OpenShift version of the openshift-install binary to use in FORCE_MODE'
+          trim: true
 
     pipeline-scm:
       scm:

--- a/pmm/openshift/openshift_cluster_create.groovy
+++ b/pmm/openshift/openshift_cluster_create.groovy
@@ -37,30 +37,53 @@ def attemptClusterCleanup(String reason) {
                             secretKeyVariable: 'AWS_SECRET_ACCESS_KEY'
                         )
                     ]) {
-                        // For aborted jobs, only attempt cleanup if state files exist
-                        // This prevents unnecessary destroy attempts for very early aborts
-                        if (reason == 'aborted') {
-                            def clusterDir = "${env.WORK_DIR}/${env.FINAL_CLUSTER_NAME}"
-                            def hasMetadata = fileExists("${clusterDir}/metadata.json")
-                            def hasTerraformState = fileExists("${clusterDir}/terraform.tfstate")
+                        def clusterDir = "${env.WORK_DIR}/${env.FINAL_CLUSTER_NAME}"
+                        def hasMetadata = fileExists("${clusterDir}/metadata.json")
+                        def hasTerraformState = fileExists("${clusterDir}/terraform.tfstate")
 
-                            if (!hasMetadata && !hasTerraformState) {
-                                echo 'No cluster state found - skipping cleanup'
-                                return
-                            }
-                            echo 'Found cluster state files - attempting destroy'
+                        // For aborted jobs, only attempt cleanup if state files exist.
+                        // This prevents unnecessary destroy attempts for very early aborts.
+                        if (reason == 'aborted' && !hasMetadata && !hasTerraformState) {
+                            echo 'No cluster state found - skipping cleanup'
+                            return
                         }
 
-                        openshiftCluster.destroy([
+                        // openshift-install writes its metadata.json (with the AWS
+                        // infraID) before AWS resources are torn down on failure,
+                        // but openshiftCluster.create() only uploads it to S3 *after*
+                        // the installer succeeds. If the installer aborted partway
+                        // there's an on-disk infraID we can use to force-destroy
+                        // the leaked AWS resources without ever touching S3.
+                        def infraID = null
+                        if (hasMetadata) {
+                            try {
+                                def m = readJSON file: "${clusterDir}/metadata.json"
+                                infraID = m?.infraID
+                            } catch (Exception parseErr) {
+                                echo "Could not parse metadata.json for infraID: ${parseErr.message}"
+                            }
+                        }
+
+                        def destroyConfig = [
                             clusterName: env.FINAL_CLUSTER_NAME,
                             awsRegion: params.AWS_REGION,
-                            s3Bucket: env.S3_BUCKET,
                             workDir: env.WORK_DIR,
                             accessKey: AWS_ACCESS_KEY_ID,
                             secretKey: AWS_SECRET_ACCESS_KEY,
                             reason: "${reason}-cleanup",
                             destroyedBy: env.BUILD_USER_ID ?: "jenkins-${reason}"
-                        ])
+                        ]
+
+                        if (infraID) {
+                            echo "Found infraID ${infraID} on disk - using force mode (no S3 state required)"
+                            destroyConfig.force = true
+                            destroyConfig.infraID = infraID
+                            destroyConfig.openshiftVersion = params.OPENSHIFT_VERSION
+                        } else {
+                            destroyConfig.s3Bucket = env.S3_BUCKET
+                        }
+
+                        openshiftCluster.destroy(destroyConfig)
                         echo 'Cleanup completed successfully'
                     }
                 } catch (Exception e) {

--- a/pmm/openshift/openshift_cluster_destroy.groovy
+++ b/pmm/openshift/openshift_cluster_destroy.groovy
@@ -30,22 +30,42 @@ pipeline {
                         error 'Cluster name is required'
                     }
 
+                    // FORCE_MODE recovers clusters that were leaked by a failed
+                    // create job (no S3 state). For aws-tags-only clusters the
+                    // value openshift-cluster-list shows as "Cluster Name" *is*
+                    // the infraID, so default INFRA_ID to CLUSTER_NAME when the
+                    // operator leaves it blank. The operator can still override
+                    // INFRA_ID explicitly when the two differ.
+                    env.RESOLVED_INFRA_ID = ''
+                    if (params.FORCE_MODE) {
+                        if (!params.INFRA_ID || params.INFRA_ID.trim().isEmpty()) {
+                            env.RESOLVED_INFRA_ID = params.CLUSTER_NAME
+                            echo "INFRA_ID not set; defaulting to CLUSTER_NAME='${params.CLUSTER_NAME}'"
+                        } else {
+                            env.RESOLVED_INFRA_ID = params.INFRA_ID
+                        }
+                    }
+
                     // Clean workspace
                     deleteDir()
 
                     // Create work directory
                     sh "mkdir -p ${WORK_DIR}"
 
-                    echo "Preparing to destroy cluster: ${params.CLUSTER_NAME}"
+                    echo "Preparing to destroy cluster: ${params.CLUSTER_NAME}${params.FORCE_MODE ? " (force mode, infraID=${env.RESOLVED_INFRA_ID})" : ''}"
 
                     // Set initial build description - optimized for Blue Ocean
                     currentBuild.displayName = "#${BUILD_NUMBER} - ${params.CLUSTER_NAME}"
-                    currentBuild.description = "${params.CLUSTER_NAME} | ${params.AWS_REGION} | ${params.DESTROY_REASON} | DESTROYING"
+                    def forceTag = params.FORCE_MODE ? ' | FORCE' : ''
+                    currentBuild.description = "${params.CLUSTER_NAME} | ${params.AWS_REGION} | ${params.DESTROY_REASON}${forceTag} | DESTROYING"
                 }
             }
         }
 
         stage('Check Cluster State') {
+            when {
+                expression { !params.FORCE_MODE }
+            }
             steps {
                 withCredentials([
                     aws(
@@ -67,7 +87,16 @@ pipeline {
                         def stateExists = (metadata != null)
 
                         if (!stateExists) {
-                            error "Cluster state not found in S3 for cluster: ${params.CLUSTER_NAME}"
+                            // No S3 state — cluster was leaked from a failed
+                            // create. Auto-promote to force mode using
+                            // CLUSTER_NAME as the infraID. The operator does
+                            // not need to set FORCE_MODE/INFRA_ID for this
+                            // common-case recovery path.
+                            echo "No S3 state for ${params.CLUSTER_NAME}; auto-promoting to force-destroy with infraID='${params.CLUSTER_NAME}'."
+                            env.AUTO_FORCE_MODE = 'true'
+                            env.RESOLVED_INFRA_ID = params.INFRA_ID?.trim() ?: params.CLUSTER_NAME
+                            currentBuild.description = "${params.CLUSTER_NAME} | ${params.AWS_REGION} | ${params.DESTROY_REASON} | AUTO-FORCE | DESTROYING"
+                            return
                         }
 
                         // Get cluster metadata if available
@@ -119,11 +148,18 @@ pipeline {
                         def destroyConfig = [
                             clusterName: params.CLUSTER_NAME,
                             awsRegion: params.AWS_REGION,
-                            s3Bucket: env.S3_BUCKET,
                             workDir: env.WORK_DIR,
                             reason: params.DESTROY_REASON,
                             destroyedBy: env.BUILD_USER_ID ?: 'jenkins'
                         ]
+
+                        if (params.FORCE_MODE || env.AUTO_FORCE_MODE == 'true') {
+                            destroyConfig.force = true
+                            destroyConfig.infraID = env.RESOLVED_INFRA_ID
+                            destroyConfig.openshiftVersion = params.OPENSHIFT_VERSION
+                        } else {
+                            destroyConfig.s3Bucket = env.S3_BUCKET
+                        }
 
                         // Destroy the cluster
                         def result = openshiftCluster.destroy(destroyConfig)

--- a/vars/openshiftCluster.groovy
+++ b/vars/openshiftCluster.groovy
@@ -295,7 +295,12 @@ def create(Map config) {
  * ])
  */
 def destroy(Map config) {
-    def required = ['clusterName', 's3Bucket', 'awsRegion', 'workDir']
+    // In force mode the caller skips the S3 state lookup and provides the
+    // AWS infraID directly. Used to recover from create-job failures where
+    // S3 state was never written (e.g. the installer aborted mid-run).
+    def required = config.force
+        ? ['clusterName', 'infraID', 'awsRegion', 'workDir']
+        : ['clusterName', 's3Bucket', 'awsRegion', 'workDir']
     required.each { param ->
         if (!config.containsKey(param) || !config[param]) {
             error "Missing required parameter: ${param}"
@@ -315,48 +320,70 @@ def destroy(Map config) {
     openshiftTools.log('INFO', "Destroying OpenShift cluster: ${params.clusterName}")
 
     try {
-        // Get metadata and cluster state from S3
-        def metadataResult = openshiftS3.getMetadata([
-            bucket: params.s3Bucket,
-            clusterName: params.clusterName,
-            region: params.awsRegion
-        ])
-
-        if (!metadataResult) {
-            error "No metadata found for cluster ${params.clusterName}."
-        }
-
-        // Convert LazyMap to regular Map for serialization
-        def metadata = metadataResult.collectEntries { k, v -> [k, v] }
-
         def clusterDir = "${params.workDir}/${params.clusterName}"
         sh "mkdir -p ${clusterDir}"
 
-        // Download cluster state from S3
-        def stateExists = openshiftS3.downloadState([
-            bucket: params.s3Bucket,
-            clusterName: params.clusterName,
-            region: params.awsRegion,
-            workDir: params.workDir
-        ])
+        def metadata = [:]
 
-        if (!stateExists) {
-            openshiftTools.log('WARN', "No valid state found for cluster ${params.clusterName}. May be test data or corrupt state file.", params)
-            openshiftTools.log('INFO', "Proceeding with S3 cleanup only (no OpenShift resources to destroy).", params)
-
-            // Even without valid state, we should clean up S3
-            openshiftS3.cleanup([
+        if (params.force) {
+            // Synthesize the minimal metadata.json that `openshift-install
+            // destroy cluster` requires (infraID + aws.region + aws.identifier).
+            // clusterName/clusterID are required by the JSON schema but never
+            // read by the AWS destroyer.
+            openshiftTools.log('WARN', "FORCE mode: synthesizing metadata.json from infraID ${params.infraID}", params)
+            def synth = [
+                clusterName: params.clusterName,
+                clusterID  : '00000000-0000-0000-0000-000000000000',
+                infraID    : params.infraID,
+                aws        : [
+                    region       : params.awsRegion,
+                    identifier   : [["kubernetes.io/cluster/${params.infraID}".toString(): 'owned']],
+                    clusterDomain: ''
+                ]
+            ]
+            writeFile file: "${clusterDir}/metadata.json", text: new JsonBuilder(synth).toPrettyString()
+            metadata = [openshift_version: params.openshiftVersion]
+        } else {
+            // Get metadata and cluster state from S3
+            def metadataResult = openshiftS3.getMetadata([
                 bucket: params.s3Bucket,
                 clusterName: params.clusterName,
                 region: params.awsRegion
             ])
 
-            return [
+            if (!metadataResult) {
+                error "No metadata found for cluster ${params.clusterName}."
+            }
+
+            // Convert LazyMap to regular Map for serialization
+            metadata = metadataResult.collectEntries { k, v -> [k, v] }
+
+            // Download cluster state from S3
+            def stateExists = openshiftS3.downloadState([
+                bucket: params.s3Bucket,
                 clusterName: params.clusterName,
-                destroyed: false,
-                s3Cleaned: true,
-                reason: 'Invalid or corrupt state file - S3 cleanup only'
-            ]
+                region: params.awsRegion,
+                workDir: params.workDir
+            ])
+
+            if (!stateExists) {
+                openshiftTools.log('WARN', "No valid state found for cluster ${params.clusterName}. May be test data or corrupt state file.", params)
+                openshiftTools.log('INFO', "Proceeding with S3 cleanup only (no OpenShift resources to destroy).", params)
+
+                // Even without valid state, we should clean up S3
+                openshiftS3.cleanup([
+                    bucket: params.s3Bucket,
+                    clusterName: params.clusterName,
+                    region: params.awsRegion
+                ])
+
+                return [
+                    clusterName: params.clusterName,
+                    destroyed: false,
+                    s3Cleaned: true,
+                    reason: 'Invalid or corrupt state file - S3 cleanup only'
+                ]
+            }
         }
 
         // Install OpenShift tools
@@ -382,17 +409,29 @@ def destroy(Map config) {
             openshift-install destroy cluster --log-level=info
         """
 
-        // Clean up S3
-        openshiftS3.cleanup([
-            bucket: params.s3Bucket,
-            clusterName: params.clusterName,
-            region: params.awsRegion
-        ])
+        // Sweep any leftover image-registry bucket the installer may have missed
+        // when it was started without S3 state (force mode).
+        if (params.force) {
+            sh """
+                for b in \$(aws s3api list-buckets --query "Buckets[?starts_with(Name,'${params.infraID}-image-registry')].Name" --output text); do
+                    echo "Force mode: removing leftover image-registry bucket s3://\$b"
+                    aws s3 rb "s3://\$b" --force --region ${params.awsRegion} || true
+                done
+            """
+        } else {
+            // Clean up S3 state for this cluster
+            openshiftS3.cleanup([
+                bucket: params.s3Bucket,
+                clusterName: params.clusterName,
+                region: params.awsRegion
+            ])
+        }
 
         return [
             clusterName: params.clusterName,
             destroyed: true,
-            s3Cleaned: true
+            s3Cleaned: !params.force,
+            force: params.force ?: false
         ]
     } catch (Exception e) {
         error "Failed to destroy OpenShift cluster: ${e.message}"


### PR DESCRIPTION
Tracking: [PKG-1321](https://perconadev.atlassian.net/browse/PKG-1321)

**Problem.** When `openshift-install create cluster` aborts partway (e.g. the 15-min CAPI infra-readiness timeout), `openshiftCluster.create()` never reaches the line that uploads cluster state to S3. The leaked AWS resources are unrecoverable through `openshift-cluster-destroy`, which hard-errors at "Check Cluster State" because no S3 metadata exists. Operators clean VPCs, subnets, IAM roles, and EIPs by hand.

**Mechanism.** `openshift-install` writes its `metadata.json` (containing the AWS `infraID` baked into every cluster tag) to the cluster directory *before* any rollback. The on-disk file survives a failed install even when S3 doesn't get its copy. This PR teaches `destroy()` to accept the infraID directly and synthesize the minimal `metadata.json` schema needed by `openshift-install destroy cluster` (verified against upstream `pkg/destroy/aws/aws.go`: the AWS destroyer reads only `aws.region`, `aws.identifier`, and `infraID`; `clusterName`/`clusterID` are required by the JSON schema but never used). Three callers benefit:

- `attemptClusterCleanup` in the create job reads the on-disk `metadata.json`, extracts the infraID, and invokes `destroy()` in force mode. Failed creates self-heal without operator intervention.
- `openshift-cluster-destroy` **auto-falls-back to force mode** when the S3 state for `CLUSTER_NAME` is missing — the operator does not need to set any flags. The cluster name is used as the infraID (which is what `openshift-cluster-list` shows for `aws-tags`-only clusters).
- The destroy job also exposes explicit `FORCE_MODE` / `INFRA_ID` / `OPENSHIFT_VERSION` parameters for the rare case where the operator needs to override (e.g. cluster name is the base name and the AWS infraID has a random suffix).

Leftover `<infraID>-image-registry-*` S3 buckets are swept after force-destroy, since those are tagged but separate from the cluster state bucket.

**Post-merge action required.** `pmm/openshift/openshift-cluster-destroy.yml` is reference (jobs at Percona are managed via the `jenkins` CLI, not JJB). The new `FORCE_MODE`, `INFRA_ID`, `OPENSHIFT_VERSION` parameters need to be applied to the live job on `pmm.cd.percona.com` after merge:

```
jenkins job update pmm/openshift-cluster-destroy -c pmm/openshift/openshift-cluster-destroy.yml
```

`openshift-cluster-create` needs **no** job-config change.

**Verified** end-to-end on Apr 29: 5 stuck clusters in `us-east-2` (`helm-test-131/132`, `nightly-test-2054/2056/2059`) cleaned, all return zero tagged resources.

[PKG-1321]: https://perconadev.atlassian.net/browse/PKG-1321?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ