### PR TITLE
fix(openshift): parenthesize dynamic key in synthesized metadata.json

### DIFF
--- a/vars/openshiftCluster.groovy
+++ b/vars/openshiftCluster.groovy
@@ -331,13 +331,14 @@ def destroy(Map config) {
             // clusterName/clusterID are required by the JSON schema but never
             // read by the AWS destroyer.
             openshiftTools.log('WARN', "FORCE mode: synthesizing metadata.json from infraID ${params.infraID}", params)
+            def tagKey = "kubernetes.io/cluster/${params.infraID}".toString()
             def synth = [
                 clusterName: params.clusterName,
                 clusterID  : '00000000-0000-0000-0000-000000000000',
                 infraID    : params.infraID,
                 aws        : [
                     region       : params.awsRegion,
-                    identifier   : [["kubernetes.io/cluster/${params.infraID}".toString(): 'owned']],
+                    identifier   : [[(tagKey): 'owned']],
                     clusterDomain: ''
                 ]
             ]


### PR DESCRIPTION
Tracking: [PKG-1321](https://perconadev.atlassian.net/browse/PKG-1321)

Follow-up to #4009. The synthesized `metadata.json` for force-destroy was failing to compile under the Jenkins CPS Groovy parser:

```
WorkflowScript: 1: a complex label expression before a colon must be parenthesized
@ line 340, column 90.
identifier : [["kubernetes.io/cluster/${params.infraID}".toString(): 'owned']],
```

The parser misread the `${...}.toString():` pattern as a label expression. Compute the tag key into a local variable first, then wrap it in parentheses so it parses unambiguously as a map key.

Verified by running `pmm/openshift-cluster-destroy` against `nightly-test-2067-h57tv` (no S3 state) — first run failed with the parse error above. Re-running after this lands.

[PKG-1321]: https://perconadev.atlassian.net/browse/PKG-1321?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ