### PR TITLE
PKG-1322: tag-anchored OpenShift cluster discovery + orphan-EIP sweep on force-destroy

### DIFF
--- a/vars/openshiftCluster.groovy
+++ b/vars/openshiftCluster.groovy
@@ -419,6 +419,22 @@ def destroy(Map config) {
                     aws s3 rb "s3://\$b" --force --region ${params.awsRegion} || true
                 done
             """
+
+            // Sweep orphan EIPs left tagged with this cluster's infraID. The OpenShift
+            // installer doesn't always reach EIPs when it tears down a partially-installed
+            // cluster, so unattached cluster-tagged EIPs accumulate against the regional
+            // quota until they're released by hand (PKG-1321 root cause).
+            sh """
+                ALLOCATIONS=\$(aws ec2 describe-addresses \\
+                    --region ${params.awsRegion} \\
+                    --filters Name=tag-key,Values=kubernetes.io/cluster/${params.infraID} \\
+                    --query 'Addresses[?!AssociationId].AllocationId' \\
+                    --output text 2>/dev/null || echo '')
+                for ALLOC in \$ALLOCATIONS; do
+                    echo "Force mode: releasing orphan EIP \$ALLOC tagged with kubernetes.io/cluster/${params.infraID}"
+                    aws ec2 release-address --allocation-id "\$ALLOC" --region ${params.awsRegion} || true
+                done
+            """
         } else {
             // Clean up S3 state for this cluster
             openshiftS3.cleanup([

--- a/vars/openshiftCluster.groovy
+++ b/vars/openshiftCluster.groovy
@@ -424,14 +424,19 @@ def destroy(Map config) {
             // installer doesn't always reach EIPs when it tears down a partially-installed
             // cluster, so unattached cluster-tagged EIPs accumulate against the regional
             // quota until they're released by hand (PKG-1321 root cause).
+            //
+            // Filter scope: tag key matches THIS cluster's infraID exactly, AND value is
+            // 'owned' (OpenShift's marker for installer-created resources). Excludes any
+            // hypothetical 'shared' resource and any other cluster's EIPs. Also gated to
+            // unattached EIPs so attached infrastructure stays safe.
             sh """
                 ALLOCATIONS=\$(aws ec2 describe-addresses \\
                     --region ${params.awsRegion} \\
-                    --filters Name=tag-key,Values=kubernetes.io/cluster/${params.infraID} \\
+                    --filters Name=tag:kubernetes.io/cluster/${params.infraID},Values=owned \\
                     --query 'Addresses[?!AssociationId].AllocationId' \\
                     --output text 2>/dev/null || echo '')
                 for ALLOC in \$ALLOCATIONS; do
-                    echo "Force mode: releasing orphan EIP \$ALLOC tagged with kubernetes.io/cluster/${params.infraID}"
+                    echo "Force mode: releasing orphan EIP \$ALLOC tagged kubernetes.io/cluster/${params.infraID}=owned"
                     aws ec2 release-address --allocation-id "\$ALLOC" --region ${params.awsRegion} || true
                 done
             """

--- a/vars/openshiftDiscovery.groovy
+++ b/vars/openshiftDiscovery.groovy
@@ -198,13 +198,15 @@ private performAWSResourceDiscovery(String region, String accessKey = null, Stri
             awsEnvVars = ["AWS_ACCESS_KEY_ID=${accessKey}", "AWS_SECRET_ACCESS_KEY=${secretKey}"]
         }
 
-        // First, get all VPCs to identify cluster names
-        def vpcOutput = ''
+        // Discover cluster names from any resource carrying a kubernetes.io/cluster/<name>
+        // tag, not just VPCs. A partially-torn-down cluster can leave orphan EIPs, IAM
+        // roles, or NAT gateways with the cluster tag but no surviving VPC; anchoring
+        // discovery to VPCs alone hides those clusters from the list/destroy paths.
+        def tagOutput = ''
         withEnv(awsEnvVars) {
-            vpcOutput = sh(
+            tagOutput = sh(
                 script: """
                     aws resourcegroupstaggingapi get-resources \
-                        --resource-type-filters 'ec2:vpc' \
                         --region ${region} \
                         --query 'ResourceTagMappingList[].Tags[?starts_with(Key, `kubernetes.io/cluster/`)].Key' \
                         --output text 2>/dev/null || echo ''
@@ -213,12 +215,12 @@ private performAWSResourceDiscovery(String region, String accessKey = null, Stri
             ).trim()
         }
 
-        if (!vpcOutput) {
+        if (!tagOutput) {
             return [clusters: [], error: null]
         }
 
         // Extract unique cluster names (handle both newline and tab separators)
-        def clusterNames = vpcOutput.split('[\\n\\t]').collect { tagKey ->
+        def clusterNames = tagOutput.split('[\\n\\t]').collect { tagKey ->
             tagKey.trim().replace('kubernetes.io/cluster/', '')
         }.findAll { it }.unique()
 


### PR DESCRIPTION
## Problem

`helm-test-135` create was blocked by EIP quota (`18/20` in `us-east-2`) while `openshift-cluster-list` reported zero clusters. Two bugs:

1. **List is VPC-anchored.** `openshiftDiscovery` finds clusters by querying `ec2:vpc` resources tagged `kubernetes.io/cluster/<infraID>`. If the VPC is gone but the cluster's EIPs (or IAM, NAT GWs) still carry the tag, the cluster is invisible. 7 such orphans (`helm-test-101/106/127`) were eating quota, hidden from operators.
2. **Force-destroy doesn't sweep orphan EIPs.** `openshift-install destroy` occasionally misses EIPs on partially-installed clusters. Quota fills up until someone releases them by hand.

## Fix

- **`vars/openshiftDiscovery.groovy`** — drop `--resource-type-filters 'ec2:vpc'`. Cluster names now extract from any resource carrying a `kubernetes.io/cluster/` tag.
- **`vars/openshiftCluster.groovy`** — in force mode, after `openshift-install destroy`, release any *unattached* EIP tagged `kubernetes.io/cluster/<infraID>=owned`.

The destroy sweep is scoped narrowly:

| Filter | Effect |
|---|---|
| `Name=tag:kubernetes.io/cluster/<infraID>,Values=owned` | Only this cluster's installer-tagged resources |
| `[?!AssociationId]` | Only unattached EIPs |
| `--region <awsRegion>` | Only this region |
| Gated on `params.force` | Normal S3-state destroy unaffected |

So it cannot touch other clusters' EIPs, attached infrastructure, `=shared` resources, or anything in another region.

Closes [PKG-1322](https://perconadev.atlassian.net/browse/PKG-1322). Follow-up to [PKG-1321](https://perconadev.atlassian.net/browse/PKG-1321).

[PKG-1322]: https://perconadev.atlassian.net/browse/PKG-1322?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ