### PR TITLE
PKG-1323/PKG-1324: pin apt to deb.debian.org + bootDeadline=8 across Hetzner Debian fleet

### DIFF
--- a/IaC/pg.cd/init.groovy.d/htz.cloud.groovy
+++ b/IaC/pg.cd/init.groovy.d/htz.cloud.groovy
@@ -30,7 +30,7 @@ execMap['launcher-x64-hel1']  = 30
 execMap['launcher-x64-fsn1']  = 30
 
 bootDeadlineMap =[:]
-bootDeadlineMap['default']            = 3
+bootDeadlineMap['default']            = 8
 bootDeadlineMap['deb12-x64-nbg1']     = bootDeadlineMap['default']
 bootDeadlineMap['deb12-x64-hel1']     = bootDeadlineMap['default']
 bootDeadlineMap['deb12-x64-fsn1']     = bootDeadlineMap['default']
@@ -85,6 +85,14 @@ initMap['deb-docker'] = '''#!/bin/bash -x
     sudo chmod 600 /swapfile
     sudo mkswap /swapfile
     sudo swapon /swapfile
+
+    # Pin apt to deb.debian.org (avoid Hetzner mirror lottery, see PKG-1323/PKG-1324)
+    sudo tee /etc/apt/sources.list > /dev/null <<'APT_EOF'
+deb http://deb.debian.org/debian bookworm main contrib non-free non-free-firmware
+deb http://deb.debian.org/debian bookworm-updates main contrib non-free non-free-firmware
+deb http://deb.debian.org/debian bookworm-backports main contrib non-free non-free-firmware
+deb http://security.debian.org/debian-security bookworm-security main contrib non-free non-free-firmware
+APT_EOF
 
     export DEBIAN_FRONTEND=noninteractive
     until sudo apt-get update; do

--- a/IaC/pmm.cd/init.groovy.d/htz.cloud.groovy
+++ b/IaC/pmm.cd/init.groovy.d/htz.cloud.groovy
@@ -30,7 +30,7 @@ execMap['launcher-x64-hel1']  = 30
 execMap['launcher-x64-fsn1']  = 30
 
 bootDeadlineMap =[:]
-bootDeadlineMap['default']            = 3
+bootDeadlineMap['default']            = 8
 bootDeadlineMap['deb12-x64-nbg1']     = bootDeadlineMap['default']
 bootDeadlineMap['deb12-x64-hel1']     = bootDeadlineMap['default']
 bootDeadlineMap['deb12-x64-fsn1']     = bootDeadlineMap['default']
@@ -85,6 +85,14 @@ initMap['deb-docker'] = '''#!/bin/bash -x
     sudo chmod 600 /swapfile
     sudo mkswap /swapfile
     sudo swapon /swapfile
+
+    # Pin apt to deb.debian.org (avoid Hetzner mirror lottery, see PKG-1323/PKG-1324)
+    sudo tee /etc/apt/sources.list > /dev/null <<'APT_EOF'
+deb http://deb.debian.org/debian bookworm main contrib non-free non-free-firmware
+deb http://deb.debian.org/debian bookworm-updates main contrib non-free non-free-firmware
+deb http://deb.debian.org/debian bookworm-backports main contrib non-free non-free-firmware
+deb http://security.debian.org/debian-security bookworm-security main contrib non-free non-free-firmware
+APT_EOF
 
     export DEBIAN_FRONTEND=noninteractive
     until sudo apt-get update; do

--- a/IaC/ps3.cd/init.groovy.d/htz.cloud.groovy
+++ b/IaC/ps3.cd/init.groovy.d/htz.cloud.groovy
@@ -30,7 +30,7 @@ execMap['launcher-x64-hel1']  = 30
 execMap['launcher-x64-fsn1']  = 30
 
 bootDeadlineMap =[:]
-bootDeadlineMap['default']            = 3
+bootDeadlineMap['default']            = 8
 bootDeadlineMap['deb12-x64-nbg1']     = bootDeadlineMap['default']
 bootDeadlineMap['deb12-x64-hel1']     = bootDeadlineMap['default']
 bootDeadlineMap['deb12-x64-fsn1']     = bootDeadlineMap['default']
@@ -85,6 +85,14 @@ initMap['deb-docker'] = '''#!/bin/bash -x
     sudo chmod 600 /swapfile
     sudo mkswap /swapfile
     sudo swapon /swapfile
+
+    # Pin apt to deb.debian.org (avoid Hetzner mirror lottery, see PKG-1323/PKG-1324)
+    sudo tee /etc/apt/sources.list > /dev/null <<'APT_EOF'
+deb http://deb.debian.org/debian bookworm main contrib non-free non-free-firmware
+deb http://deb.debian.org/debian bookworm-updates main contrib non-free non-free-firmware
+deb http://deb.debian.org/debian bookworm-backports main contrib non-free non-free-firmware
+deb http://security.debian.org/debian-security bookworm-security main contrib non-free non-free-firmware
+APT_EOF
 
     export DEBIAN_FRONTEND=noninteractive
     until sudo apt-get update; do

--- a/IaC/ps57.cd/init.groovy.d/htz.cloud.groovy
+++ b/IaC/ps57.cd/init.groovy.d/htz.cloud.groovy
@@ -30,7 +30,7 @@ execMap['launcher-x64-hel1']  = 30
 execMap['launcher-x64-fsn1']  = 30
 
 bootDeadlineMap =[:]
-bootDeadlineMap['default']            = 3
+bootDeadlineMap['default']            = 8
 bootDeadlineMap['deb12-x64-nbg1']     = bootDeadlineMap['default']
 bootDeadlineMap['deb12-x64-hel1']     = bootDeadlineMap['default']
 bootDeadlineMap['deb12-x64-fsn1']     = bootDeadlineMap['default']
@@ -85,6 +85,14 @@ initMap['deb-docker'] = '''#!/bin/bash -x
     sudo chmod 600 /swapfile
     sudo mkswap /swapfile
     sudo swapon /swapfile
+
+    # Pin apt to deb.debian.org (avoid Hetzner mirror lottery, see PKG-1323/PKG-1324)
+    sudo tee /etc/apt/sources.list > /dev/null <<'APT_EOF'
+deb http://deb.debian.org/debian bookworm main contrib non-free non-free-firmware
+deb http://deb.debian.org/debian bookworm-updates main contrib non-free non-free-firmware
+deb http://deb.debian.org/debian bookworm-backports main contrib non-free non-free-firmware
+deb http://security.debian.org/debian-security bookworm-security main contrib non-free non-free-firmware
+APT_EOF
 
     export DEBIAN_FRONTEND=noninteractive
     until sudo apt-get update; do

--- a/IaC/ps80.cd/init.groovy.d/htz.cloud.groovy
+++ b/IaC/ps80.cd/init.groovy.d/htz.cloud.groovy
@@ -30,7 +30,7 @@ execMap['launcher-x64-hel1']  = 30
 execMap['launcher-x64-fsn1']  = 30
 
 bootDeadlineMap =[:]
-bootDeadlineMap['default']            = 3
+bootDeadlineMap['default']            = 8
 bootDeadlineMap['deb12-x64-nbg1']     = bootDeadlineMap['default']
 bootDeadlineMap['deb12-x64-hel1']     = bootDeadlineMap['default']
 bootDeadlineMap['deb12-x64-fsn1']     = bootDeadlineMap['default']
@@ -85,6 +85,14 @@ initMap['deb-docker'] = '''#!/bin/bash -x
     sudo chmod 600 /swapfile
     sudo mkswap /swapfile
     sudo swapon /swapfile
+
+    # Pin apt to deb.debian.org (avoid Hetzner mirror lottery, see PKG-1323/PKG-1324)
+    sudo tee /etc/apt/sources.list > /dev/null <<'APT_EOF'
+deb http://deb.debian.org/debian bookworm main contrib non-free non-free-firmware
+deb http://deb.debian.org/debian bookworm-updates main contrib non-free non-free-firmware
+deb http://deb.debian.org/debian bookworm-backports main contrib non-free non-free-firmware
+deb http://security.debian.org/debian-security bookworm-security main contrib non-free non-free-firmware
+APT_EOF
 
     export DEBIAN_FRONTEND=noninteractive
     until sudo apt-get update; do

--- a/IaC/psmdb.cd/init.groovy.d/htz.cloud.groovy
+++ b/IaC/psmdb.cd/init.groovy.d/htz.cloud.groovy
@@ -30,7 +30,7 @@ execMap['launcher-x64-hel1']  = 30
 execMap['launcher-x64-fsn1']  = 30
 
 bootDeadlineMap =[:]
-bootDeadlineMap['default']            = 3
+bootDeadlineMap['default']            = 8
 bootDeadlineMap['deb12-x64-nbg1']     = bootDeadlineMap['default']
 bootDeadlineMap['deb12-x64-hel1']     = bootDeadlineMap['default']
 bootDeadlineMap['deb12-x64-fsn1']     = bootDeadlineMap['default']

--- a/IaC/psmdb.cd/init.groovy.d/htz.cloud.groovy
+++ b/IaC/psmdb.cd/init.groovy.d/htz.cloud.groovy
@@ -87,6 +87,14 @@ initMap['deb-docker'] = '''#!/bin/bash -x
     sudo mkswap /swapfile
     sudo swapon /swapfile
 
+    # Pin apt to deb.debian.org (avoid Hetzner mirror lottery, see PKG-1323/PKG-1324)
+    sudo tee /etc/apt/sources.list > /dev/null <<'APT_EOF'
+deb http://deb.debian.org/debian bookworm main contrib non-free non-free-firmware
+deb http://deb.debian.org/debian bookworm-updates main contrib non-free non-free-firmware
+deb http://deb.debian.org/debian bookworm-backports main contrib non-free non-free-firmware
+deb http://security.debian.org/debian-security bookworm-security main contrib non-free non-free-firmware
+APT_EOF
+
     export DEBIAN_FRONTEND=noninteractive
     until sudo apt-get update; do
         sleep 1

--- a/IaC/pxb.cd/init.groovy.d/htz.cloud.groovy
+++ b/IaC/pxb.cd/init.groovy.d/htz.cloud.groovy
@@ -30,7 +30,7 @@ execMap['launcher-x64-hel1']  = 30
 execMap['launcher-x64-fsn1']  = 30
 
 bootDeadlineMap =[:]
-bootDeadlineMap['default']            = 3
+bootDeadlineMap['default']            = 8
 bootDeadlineMap['deb12-x64-nbg1']     = bootDeadlineMap['default']
 bootDeadlineMap['deb12-x64-hel1']     = bootDeadlineMap['default']
 bootDeadlineMap['deb12-x64-fsn1']     = bootDeadlineMap['default']
@@ -85,6 +85,14 @@ initMap['deb-docker'] = '''#!/bin/bash -x
     sudo chmod 600 /swapfile
     sudo mkswap /swapfile
     sudo swapon /swapfile
+
+    # Pin apt to deb.debian.org (avoid Hetzner mirror lottery, see PKG-1323/PKG-1324)
+    sudo tee /etc/apt/sources.list > /dev/null <<'APT_EOF'
+deb http://deb.debian.org/debian bookworm main contrib non-free non-free-firmware
+deb http://deb.debian.org/debian bookworm-updates main contrib non-free non-free-firmware
+deb http://deb.debian.org/debian bookworm-backports main contrib non-free non-free-firmware
+deb http://security.debian.org/debian-security bookworm-security main contrib non-free non-free-firmware
+APT_EOF
 
     export DEBIAN_FRONTEND=noninteractive
     until sudo apt-get update; do

--- a/IaC/pxc.cd/init.groovy.d/htz.cloud.groovy
+++ b/IaC/pxc.cd/init.groovy.d/htz.cloud.groovy
@@ -30,7 +30,7 @@ execMap['launcher-x64-hel1']  = 30
 execMap['launcher-x64-fsn1']  = 30
 
 bootDeadlineMap =[:]
-bootDeadlineMap['default']            = 3
+bootDeadlineMap['default']            = 8
 bootDeadlineMap['deb12-x64-nbg1']     = bootDeadlineMap['default']
 bootDeadlineMap['deb12-x64-hel1']     = bootDeadlineMap['default']
 bootDeadlineMap['deb12-x64-fsn1']     = bootDeadlineMap['default']
@@ -85,6 +85,14 @@ initMap['deb-docker'] = '''#!/bin/bash -x
     sudo chmod 600 /swapfile
     sudo mkswap /swapfile
     sudo swapon /swapfile
+
+    # Pin apt to deb.debian.org (avoid Hetzner mirror lottery, see PKG-1323/PKG-1324)
+    sudo tee /etc/apt/sources.list > /dev/null <<'APT_EOF'
+deb http://deb.debian.org/debian bookworm main contrib non-free non-free-firmware
+deb http://deb.debian.org/debian bookworm-updates main contrib non-free non-free-firmware
+deb http://deb.debian.org/debian bookworm-backports main contrib non-free non-free-firmware
+deb http://security.debian.org/debian-security bookworm-security main contrib non-free non-free-firmware
+APT_EOF
 
     export DEBIAN_FRONTEND=noninteractive
     until sudo apt-get update; do

--- a/IaC/rel.cd/init.groovy.d/htz.cloud.groovy
+++ b/IaC/rel.cd/init.groovy.d/htz.cloud.groovy
@@ -30,7 +30,7 @@ execMap['launcher-x64-hel1']  = 30
 execMap['launcher-x64-fsn1']  = 30
 
 bootDeadlineMap =[:]
-bootDeadlineMap['default']            = 3
+bootDeadlineMap['default']            = 8
 bootDeadlineMap['deb12-x64-nbg1']     = bootDeadlineMap['default']
 bootDeadlineMap['deb12-x64-hel1']     = bootDeadlineMap['default']
 bootDeadlineMap['deb12-x64-fsn1']     = bootDeadlineMap['default']

--- a/IaC/rel.cd/init.groovy.d/htz.cloud.groovy
+++ b/IaC/rel.cd/init.groovy.d/htz.cloud.groovy
@@ -87,6 +87,14 @@ initMap['deb-docker'] = '''#!/bin/bash -x
     sudo mkswap /swapfile
     sudo swapon /swapfile
 
+    # Pin apt to deb.debian.org (avoid Hetzner mirror lottery, see PKG-1323/PKG-1324)
+    sudo tee /etc/apt/sources.list > /dev/null <<'APT_EOF'
+deb http://deb.debian.org/debian bookworm main contrib non-free non-free-firmware
+deb http://deb.debian.org/debian bookworm-updates main contrib non-free non-free-firmware
+deb http://deb.debian.org/debian bookworm-backports main contrib non-free non-free-firmware
+deb http://security.debian.org/debian-security bookworm-security main contrib non-free non-free-firmware
+APT_EOF
+
     export DEBIAN_FRONTEND=noninteractive
     until sudo apt-get update; do
         sleep 1


### PR DESCRIPTION
## Summary

Two changes applied to **all 9 Debian Hetzner instances** (`pg`, `pmm`, `ps3`, `ps57`, `ps80`, `psmdb`, `pxb`, `pxc`, `rel`):

1. **Pin `/etc/apt/sources.list` to `deb.debian.org`** — drops the default Hetzner image's `mirror.hetzner.com` entries.
2. **Bump `bootDeadlineMap['default']`** from 3 to 8 minutes (where not already 8).

`cloud.cd` uses Fedora and is excluded from this PR.

## Context

`rel.cd` and `psmdb.cd` both hit a worker-provisioning outage on 2026-05-04: all 3 DC circuit breakers OPEN, last successful provision ~12 hours earlier, queues stalled ([PKG-1323](https://perconadev.atlassian.net/browse/PKG-1323) / [PKG-1324](https://perconadev.atlassian.net/browse/PKG-1324)).

Root cause: the default Hetzner Debian 12 image ships a `sources.list` that includes BOTH `deb.debian.org` AND `mirror.hetzner.com`. When `mirror.hetzner.com` (`2a01:4ff:ff00::3:3`) returns stale `bookworm-backports` indexes, `apt-get update` blocks ~5 min waiting for it, exceeding the 3-min `bootDeadline`. The plugin destroys the VM mid-bootstrap; the DC breaker trips.

## Empirical benchmark

3 variants × 3 DCs (`hel1`/`nbg1`/`fsn1`), n=9, healthy mirror window:

| Variant | avg `apt-get update` | sources queried |
|---|---|---|
| A — default Hetzner image | **3.22s** | `deb.debian.org` + `mirror.hetzner.com` |
| B — `Acquire::ForceIPv4=true` | **3.13s** | same as A (no functional change) |
| C — `deb.debian.org` only | **1.97s** | `deb.debian.org` + `security.debian.org` |

Variant C is **35% faster** in the healthy window AND removes the mirror lottery entirely. Variant B (force IPv4) had no measurable effect.

The bootDeadline bump remains as a defence-in-depth margin: even with debian.org-only, a slow upstream still has 5x+ headroom over the previous deadline.

## Rollout note

In-memory hotfix already applied to `rel.cd` and `psmdb.cd` masters earlier today (Script Console reload + `TemplateErrorTracker.resetAll()`). This PR persists the change fleet-wide and adds the sources.list pin. Reporter attributions and full hotfix detail live in [PKG-1323](https://perconadev.atlassian.net/browse/PKG-1323) / [PKG-1324](https://perconadev.atlassian.net/browse/PKG-1324).


[PKG-1323]: https://perconadev.atlassian.net/browse/PKG-1323?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[PKG-1324]: https://perconadev.atlassian.net/browse/PKG-1324?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[PKG-1323]: https://perconadev.atlassian.net/browse/PKG-1323?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ