### PR TITLE
PMM-15041: Add PSMDB in-memory setup to deploy-services mongo bundle

### DIFF
--- a/pmm/v3/pmm3-deploy-services.groovy
+++ b/pmm/v3/pmm3-deploy-services.groovy
@@ -285,10 +285,19 @@ pipeline {
           }
         }
 
-        stage('valkey') {
-          when { expression { return params.DEPLOY_VALKEY.toBoolean() } }
+        stage('valkey-psmdb-inmemory') {
+          when { expression { return params.DEPLOY_VALKEY.toBoolean() || params.DEPLOY_MONGO_GROUP.toBoolean() } }
           steps {
-            runClientWithRetry('--database valkey --database psmdb,SETUP_TYPE=pss,STORAGE_ENGINE=inMemory', 'valkey')
+            script {
+              def parts = []
+              if (params.DEPLOY_VALKEY.toBoolean()) {
+                parts << '--database valkey'
+              }
+              if (params.DEPLOY_MONGO_GROUP.toBoolean()) {
+                parts << '--database psmdb,SETUP_TYPE=pss,STORAGE_ENGINE=inMemory'
+              }
+              runClientWithRetry(parts.join(' '), 'valkey-psmdb-inmemory')
+            }
           }
         }
       }

--- a/pmm/v3/pmm3-deploy-services.groovy
+++ b/pmm/v3/pmm3-deploy-services.groovy
@@ -295,7 +295,7 @@ pipeline {
         stage('valkey') {
           when { expression { return params.DEPLOY_VALKEY.toBoolean() } }
           steps {
-            runClientWithRetry('--database valkey', 'valkey')
+            runClientWithRetry('--database valkey --database psmdb,SETUP_TYPE=pss,STORAGE_ENGINE=inMemory', 'valkey')
           }
         }
       }

--- a/pmm/v3/pmm3-deploy-services.groovy
+++ b/pmm/v3/pmm3-deploy-services.groovy
@@ -288,16 +288,7 @@ pipeline {
         stage('valkey-psmdb-inmemory') {
           when { expression { return params.DEPLOY_VALKEY.toBoolean() || params.DEPLOY_MONGO_GROUP.toBoolean() } }
           steps {
-            script {
-              def parts = []
-              if (params.DEPLOY_VALKEY.toBoolean()) {
-                parts << '--database valkey'
-              }
-              if (params.DEPLOY_MONGO_GROUP.toBoolean()) {
-                parts << '--database psmdb,SETUP_TYPE=pss,STORAGE_ENGINE=inMemory'
-              }
-              runClientWithRetry(parts.join(' '), 'valkey-psmdb-inmemory')
-            }
+            runClientWithRetry('--database valkey --database psmdb,SETUP_TYPE=pss,STORAGE_ENGINE=inMemory', 'valkey-psmdb-inmemory')
           }
         }
       }

--- a/pmm/v3/pmm3-deploy-services.groovy
+++ b/pmm/v3/pmm3-deploy-services.groovy
@@ -260,7 +260,7 @@ pipeline {
         stage('ps-single+psmdb-pss') {
           when { expression { return params.DEPLOY_MYSQL_GROUP.toBoolean() || params.DEPLOY_MONGO_GROUP.toBoolean() } }
           steps {
-            runClientWithRetry('--database ps,QUERY_SOURCE=slowlog,MY_ROCKS=true --database psmdb,SETUP_TYPE=pss', 'ps-single-psmdb')
+            runClientWithRetry('--database ps,QUERY_SOURCE=slowlog,MY_ROCKS=true --database psmdb,SETUP_TYPE=pss --database psmdb,SETUP_TYPE=pss,STORAGE_ENGINE=inMemory', 'ps-single-psmdb')
           }
         }
 

--- a/pmm/v3/pmm3-deploy-services.groovy
+++ b/pmm/v3/pmm3-deploy-services.groovy
@@ -264,13 +264,6 @@ pipeline {
           }
         }
 
-        stage('psmdb-pss-inmemory') {
-          when { expression { return params.DEPLOY_MONGO_GROUP.toBoolean() } }
-          steps {
-            runClientWithRetry('--database psmdb,SETUP_TYPE=pss,STORAGE_ENGINE=inMemory', 'psmdb-pss-inmemory')
-          }
-        }
-
         stage('pgsql-stack') {
           when { expression { return params.DEPLOY_POSTGRES_GROUP.toBoolean() } }
           steps {

--- a/pmm/v3/pmm3-deploy-services.groovy
+++ b/pmm/v3/pmm3-deploy-services.groovy
@@ -260,7 +260,14 @@ pipeline {
         stage('ps-single+psmdb-pss') {
           when { expression { return params.DEPLOY_MYSQL_GROUP.toBoolean() || params.DEPLOY_MONGO_GROUP.toBoolean() } }
           steps {
-            runClientWithRetry('--database ps,QUERY_SOURCE=slowlog,MY_ROCKS=true --database psmdb,SETUP_TYPE=pss --database psmdb,SETUP_TYPE=pss,STORAGE_ENGINE=inMemory', 'ps-single-psmdb')
+            runClientWithRetry('--database ps,QUERY_SOURCE=slowlog,MY_ROCKS=true --database psmdb,SETUP_TYPE=pss', 'ps-single-psmdb')
+          }
+        }
+
+        stage('psmdb-pss-inmemory') {
+          when { expression { return params.DEPLOY_MONGO_GROUP.toBoolean() } }
+          steps {
+            runClientWithRetry('--database psmdb,SETUP_TYPE=pss,STORAGE_ENGINE=inMemory', 'psmdb-pss-inmemory')
           }
         }
 


### PR DESCRIPTION
## Summary

Updates `pmm3-deploy-services` so the combined `ps-single+psmdb-pss` client bundle also provisions an additional Percona Server for MongoDB replica set using `STORAGE_ENGINE=inMemory`, alongside the existing WiredTiger PSS setup.

## Why

QA wants PMM environments to include MongoDB in-memory engine metrics without introducing an extra parallel staging VM by default.

## Change

- Append `--database psmdb,SETUP_TYPE=pss,STORAGE_ENGINE=inMemory` to the existing `runClientWithRetry(...)` `CLIENTS` string.

## Notes

This relies on `pmm-framework.py` supporting `STORAGE_ENGINE` for `PSMDB` (merged in `pmm-qa`).
