### PR TITLE
PMM-7 Fix concurrency of executors instabilities of setup

### DIFF
--- a/pmm/v3/pmm3-rc-testing.groovy
+++ b/pmm/v3/pmm3-rc-testing.groovy
@@ -21,8 +21,8 @@ def triggerJenkinsRc(String shortName, String jobName, List jobParams) {
     def run = build job: jobName, wait: true, propagate: false, parameters: jobParams
     slackRcMessage("*${shortName}*: ${run.absoluteUrl}")
     if (run.result != 'SUCCESS') {
-        error("${shortName} finished with: ${run.result}")
-    } 
+        unstable("${shortName} finished with: ${run.result}")
+    }
 }
 
 // ---------- pipeline ---------------------------------------------------------
@@ -113,162 +113,40 @@ pipeline {
 
         stage('Trigger RC suites') {
             parallel {
-                stage('AMI upgrade') {
-                    steps {
-                        script {
-                            triggerJenkinsRc('pmm3-upgrade-ami-test', 'pmm3-upgrade-ami-test', [
-                                string(name: 'PMM_UI_GIT_BRANCH',         value: 'main'),
-                                string(name: 'PMM_QA_GIT_BRANCH',         value: 'main'),
-                                string(name: 'QA_INTEGRATION_GIT_BRANCH', value: 'main'),
-                                booleanParam(name: 'IS_RC_TESTING',       value: true),
-                            ])
+                stage('Lane 1') {
+                    stages {
+                        stage('nightly (AMI)') {
+                            steps {
+                                script {
+                                    triggerJenkinsRc('pmm3-ui-tests-nightly (ami)', 'pmm3-ui-tests-nightly', [
+                                        string(name: 'PMM_QA_GIT_BRANCH',       value: 'main'),
+                                        string(name: 'SERVER_TYPE',             value: 'ami'),
+                                        string(name: 'DOCKER_VERSION',          value: params.AMI_ID.trim()),
+                                        string(name: 'CLIENT_VERSION',          value: 'pmm3-rc'),
+                                        string(name: 'ENABLE_PULL_MODE',        value: 'no'),
+                                        string(name: 'ADMIN_PASSWORD',          value: 'pmm3admin!'),
+                                        string(name: 'HELM_CHART_BRANCH',       value: 'main'),
+                                        string(name: 'OPENSHIFT_VERSION',       value: 'latest'),
+                                        string(name: 'K8S_VERSION',             value: '1.34'),
+                                        string(name: 'PXC_VERSION',             value: '8.0'),
+                                        string(name: 'PS_VERSION',              value: '8.4'),
+                                        string(name: 'MS_VERSION',              value: '8.4'),
+                                        string(name: 'PGSQL_VERSION',           value: '17'),
+                                        string(name: 'PDPGSQL_VERSION',         value: '17'),
+                                        string(name: 'MD_VERSION',              value: '10.6'),
+                                        string(name: 'PSMDB_VERSION',           value: '8.0'),
+                                        string(name: 'MODB_VERSION',            value: '8.0'),
+                                        string(name: 'QUERY_SOURCE',            value: 'slowlog'),
+                                        string(name: 'PTS_CONFIDENCE',          value: '93'),
+                                    ])
+                                }
+                            }
                         }
-                    }
-                }
-
-                stage('AMI nightly') {
-                    steps {
-                        script {
-                            triggerJenkinsRc('pmm3-ui-tests-nightly (ami)', 'pmm3-ui-tests-nightly', [
-                                string(name: 'PMM_QA_GIT_BRANCH',       value: 'main'),
-                                string(name: 'SERVER_TYPE',             value: 'ami'),
-                                string(name: 'DOCKER_VERSION',          value: params.AMI_ID.trim()),
-                                string(name: 'CLIENT_VERSION',          value: 'pmm3-rc'),
-                                string(name: 'ENABLE_PULL_MODE',        value: 'no'),
-                                string(name: 'ADMIN_PASSWORD',          value: 'pmm3admin!'),
-                                string(name: 'HELM_CHART_BRANCH',       value: 'main'),
-                                string(name: 'OPENSHIFT_VERSION',       value: 'latest'),
-                                string(name: 'K8S_VERSION',             value: '1.34'),
-                                string(name: 'PXC_VERSION',             value: '8.0'),
-                                string(name: 'PS_VERSION',              value: '8.4'),
-                                string(name: 'MS_VERSION',              value: '8.4'),
-                                string(name: 'PGSQL_VERSION',           value: '17'),
-                                string(name: 'PDPGSQL_VERSION',         value: '17'),
-                                string(name: 'MD_VERSION',              value: '10.6'),
-                                string(name: 'PSMDB_VERSION',           value: '8.0'),
-                                string(name: 'MODB_VERSION',            value: '8.0'),
-                                string(name: 'QUERY_SOURCE',            value: 'slowlog'),
-                                string(name: 'PTS_CONFIDENCE',          value: '93'),
-                            ])
-                        }
-                    }
-                }
-                stage('OVF nightly') {
-                    steps {
-                        script {
-                            triggerJenkinsRc('pmm3-ui-tests-nightly (ovf)', 'pmm3-ui-tests-nightly', [
-                                string(name: 'PMM_QA_GIT_BRANCH',       value: 'main'),
-                                string(name: 'SERVER_TYPE',             value: 'ovf'),
-                                string(name: 'DOCKER_VERSION',          value: "https://percona-vm.s3.amazonaws.com/PMM3-Server-${params.RC_VERSION.trim()}.ova"),
-                                string(name: 'CLIENT_VERSION',          value: 'pmm3-rc'),
-                                string(name: 'ENABLE_PULL_MODE',        value: 'no'),
-                                string(name: 'ADMIN_PASSWORD',          value: 'admin1'),
-                                string(name: 'HELM_CHART_BRANCH',       value: 'main'),
-                                string(name: 'OPENSHIFT_VERSION',       value: 'latest'),
-                                string(name: 'K8S_VERSION',             value: '1.34'),
-                                string(name: 'PXC_VERSION',             value: '8.0'),
-                                string(name: 'PS_VERSION',              value: '8.4'),
-                                string(name: 'MS_VERSION',              value: '8.4'),
-                                string(name: 'PGSQL_VERSION',           value: '17'),
-                                string(name: 'PDPGSQL_VERSION',         value: '17'),
-                                string(name: 'MD_VERSION',              value: '10.6'),
-                                string(name: 'PSMDB_VERSION',           value: '8.0'),
-                                string(name: 'MODB_VERSION',            value: '8.0'),
-                                string(name: 'QUERY_SOURCE',            value: 'slowlog'),
-                                string(name: 'PTS_CONFIDENCE',          value: '99'),
-                            ])
-                        }
-                    }
-                }
-                stage('Docker nightly') {
-                    steps {
-                        script {
-                            triggerJenkinsRc('pmm3-ui-tests-nightly (docker)', 'pmm3-ui-tests-nightly', [
-                                string(name: 'PMM_QA_GIT_BRANCH',       value: 'main'),
-                                string(name: 'SERVER_TYPE',             value: 'docker'),
-                                string(name: 'DOCKER_VERSION',          value: env.PMM_SERVER_IMAGE),
-                                string(name: 'CLIENT_VERSION',          value: 'pmm3-rc'),
-                                string(name: 'ENABLE_PULL_MODE',        value: 'no'),
-                                string(name: 'ADMIN_PASSWORD',          value: 'pmm3admin!'),
-                                string(name: 'HELM_CHART_BRANCH',       value: 'main'),
-                                string(name: 'OPENSHIFT_VERSION',       value: 'latest'),
-                                string(name: 'K8S_VERSION',             value: '1.34'),
-                                string(name: 'PXC_VERSION',             value: '8.0'),
-                                string(name: 'PS_VERSION',              value: '8.4'),
-                                string(name: 'MS_VERSION',              value: '8.4'),
-                                string(name: 'PGSQL_VERSION',           value: '17'),
-                                string(name: 'PDPGSQL_VERSION',         value: '17'),
-                                string(name: 'MD_VERSION',              value: '10.6'),
-                                string(name: 'PSMDB_VERSION',           value: '8.0'),
-                                string(name: 'MODB_VERSION',            value: '8.0'),
-                                string(name: 'QUERY_SOURCE',            value: 'slowlog'),
-                                string(name: 'PTS_CONFIDENCE',          value: '93'),
-                            ])
-                        }
-                    }
-                }
-                stage('OpenShift nightly') {
-                    steps {
-                        script {
-                            triggerJenkinsRc('pmm3-ui-tests-nightly (helm)', 'pmm3-ui-tests-nightly', [
-                                string(name: 'PMM_QA_GIT_BRANCH',       value: 'main'),
-                                string(name: 'SERVER_TYPE',             value: 'helm'),
-                                string(name: 'DOCKER_VERSION',          value: env.PMM_SERVER_IMAGE),
-                                string(name: 'CLIENT_VERSION',          value: 'pmm3-rc'),
-                                string(name: 'ENABLE_PULL_MODE',        value: 'no'),
-                                string(name: 'ADMIN_PASSWORD',          value: 'admin1'),
-                                string(name: 'HELM_CHART_BRANCH',       value: 'main'),
-                                string(name: 'OPENSHIFT_VERSION',       value: 'latest'),
-                                string(name: 'K8S_VERSION',             value: '1.34'),
-                                string(name: 'PXC_VERSION',             value: '8.0'),
-                                string(name: 'PS_VERSION',              value: '8.4'),
-                                string(name: 'MS_VERSION',              value: '8.4'),
-                                string(name: 'PGSQL_VERSION',           value: '17'),
-                                string(name: 'PDPGSQL_VERSION',         value: '17'),
-                                string(name: 'MD_VERSION',              value: '10.6'),
-                                string(name: 'PSMDB_VERSION',           value: '8.0'),
-                                string(name: 'MODB_VERSION',            value: '8.0'),
-                                string(name: 'QUERY_SOURCE',            value: 'slowlog'),
-                                string(name: 'PTS_CONFIDENCE',          value: '93'),
-                            ])
-                        }
-                    }
-                }
-                stage('HA nightly') {
-                    steps {
-                        script {
-                            triggerJenkinsRc('pmm3-ui-tests-nightly (ha)', 'pmm3-ui-tests-nightly', [
-                                string(name: 'PMM_QA_GIT_BRANCH',       value: 'main'),
-                                string(name: 'SERVER_TYPE',             value: 'ha'),
-                                string(name: 'DOCKER_VERSION',          value: env.PMM_SERVER_IMAGE),
-                                string(name: 'CLIENT_VERSION',          value: 'pmm3-rc'),
-                                string(name: 'ENABLE_PULL_MODE',        value: 'no'),
-                                string(name: 'ADMIN_PASSWORD',          value: 'admin1'),
-                                string(name: 'HELM_CHART_BRANCH',       value: 'main'),
-                                string(name: 'OPENSHIFT_VERSION',       value: 'latest'),
-                                string(name: 'K8S_VERSION',             value: '1.34'),
-                                string(name: 'PXC_VERSION',             value: '8.0'),
-                                string(name: 'PS_VERSION',              value: '8.4'),
-                                string(name: 'MS_VERSION',              value: '8.4'),
-                                string(name: 'PGSQL_VERSION',           value: '17'),
-                                string(name: 'PDPGSQL_VERSION',         value: '17'),
-                                string(name: 'MD_VERSION',              value: '10.6'),
-                                string(name: 'PSMDB_VERSION',           value: '8.0'),
-                                string(name: 'MODB_VERSION',            value: '8.0'),
-                                string(name: 'QUERY_SOURCE',            value: 'slowlog'),
-                                string(name: 'PTS_CONFIDENCE',          value: '93'),
-                            ])
-                        }
-                    }
-                }
-                stage('Compatibility nightlies (GA matrix)') {
-                    steps {
-                        script {
-                            def tags = readFile('compat-tags.txt').trim().split('\n').collect { it.trim() }.findAll { it }
-                            def branches = [:]
-                            tags.each { t ->
-                                def ver = t.toString()
-                                branches["compat ${ver}"] = {
+                        stage('nightly (compat #1)') {
+                            steps {
+                                script {
+                                    def tags = readFile('compat-tags.txt').trim().split('\n').collect { it.trim() }.findAll { it }
+                                    def ver = tags[0]
                                     triggerJenkinsRc("pmm3-ui-tests-nightly (compat ${ver})", 'pmm3-ui-tests-nightly', [
                                         string(name: 'PMM_QA_GIT_BRANCH',       value: 'main'),
                                         string(name: 'SERVER_TYPE',             value: 'docker'),
@@ -292,145 +170,385 @@ pipeline {
                                     ])
                                 }
                             }
-                            parallel branches
                         }
-                    }
-                }
-                stage('GSSAPI nightly') {
-                    steps {
-                        script {
-                            triggerJenkinsRc('pmm3-ui-tests-nightly-gssapi', 'pmm3-ui-tests-nightly-gssapi', [
-                                string(name: 'PMM_QA_GIT_BRANCH',       value: 'main'),
-                                string(name: 'SERVER_TYPE',             value: 'docker'),
-                                string(name: 'DOCKER_VERSION',          value: env.PMM_SERVER_IMAGE),
-                                string(name: 'CLIENT_VERSION',          value: params.PMM_CLIENT_TARBALL_OL9.trim()),
-                                string(name: 'ENABLE_PULL_MODE',        value: 'no'),
-                                string(name: 'ADMIN_PASSWORD',          value: 'pmm3admin!'),
-                                string(name: 'PSMDB_VERSION',           value: '8.0'),
-                                string(name: 'MODB_VERSION',            value: '8.0'),
-                            ])
-                        }
-                    }
-                }
-
-                stage('package-testing-matrix (amd64)') {
-                    steps {
-                        script {
-                            triggerJenkinsRc('pmm3-package-testing-matrix', 'pmm3-package-testing-matrix', [
-                                string(name: 'GIT_BRANCH',      value: 'main'),
-                                string(name: 'GIT_COMMIT_HASH', value: ''),
-                                string(name: 'DOCKER_VERSION',  value: env.PMM_SERVER_IMAGE),
-                                string(name: 'PMM_VERSION',     value: params.RC_VERSION.trim()),
-                                string(name: 'INSTALL_REPO',    value: 'testing'),
-                                string(name: 'TARBALL',         value: params.PMM_CLIENT_TARBALL.trim()),
-                                string(name: 'METRICS_MODE',    value: 'auto'),
-                            ])
-                        }
-                    }
-                }
-                stage('package-testing-arm-matrix') {
-                    steps {
-                        script {
-                            triggerJenkinsRc('pmm3-package-testing-arm-matrix', 'pmm3-package-testing-arm-matrix', [
-                                string(name: 'GIT_BRANCH',      value: 'main'),
-                                string(name: 'GIT_COMMIT_HASH', value: ''),
-                                string(name: 'DOCKER_VERSION',  value: env.PMM_SERVER_IMAGE),
-                                string(name: 'PMM_VERSION',     value: params.RC_VERSION.trim()),
-                                string(name: 'INSTALL_REPO',    value: 'testing'),
-                                string(name: 'TARBALL',         value: params.PMM_CLIENT_TARBALL_ARM64.trim()),
-                                string(name: 'METRICS_MODE',    value: 'auto'),
-                            ])
-                        }
-                    }
-                }
-
-                stage('upgrade-tests-matrix') {
-                    steps {
-                        script {
-                            triggerJenkinsRc('pmm3-upgrade-tests-matrix', 'pmm3-upgrade-tests-matrix', [
-                                string(name: 'PMM_QA_GIT_BRANCH', value: 'main'),
-                            ])
-                        }
-                    }
-                }
-                stage('migration-tests') {
-                    steps {
-                        script {
-                            triggerJenkinsRc('pmm3-migration-tests', 'pmm3-migration-tests', [
-                                string(name: 'PMM_V3_UI_GIT_BRANCH', value: 'main'),
-                                string(name: 'PMM_V2_UI_GIT_BRANCH', value: 'v2'),
-                                string(name: 'DOCKER_VERSION',       value: 'perconalab/pmm-server:2.44.1'),
-                                string(name: 'CLIENT_VERSION',       value: '2.44.1'),
-                                string(name: 'ADMIN_PASSWORD',       value: 'pmm3admin!'),
-                                string(name: 'PMM_QA_GIT_BRANCH',   value: 'v2'),
-                                string(name: 'UPGRADE_TAG',          value: 'testing'),
-                            ])
-                        }
-                    }
-                }
-
-                stage('pmm3-ui-tests-matrix') {
-                    steps {
-                        script {
-                            triggerJenkinsRc('pmm3-ui-tests-matrix', 'pmm3-ui-tests-matrix', [
-                                string(name: 'PMM_QA_GIT_BRANCH', value: 'main'),
-                                string(name: 'GIT_COMMIT_HASH',  value: ''),
-                                string(name: 'DOCKER_VERSION',   value: env.PMM_SERVER_IMAGE),
-                                string(name: 'CLIENT_VERSION',   value: 'pmm3-rc'),
-                                string(name: 'MYSQL_IMAGE',      value: 'percona:5.7'),
-                                string(name: 'POSTGRES_IMAGE',   value: 'perconalab/percona-distribution-postgresql:16.0'),
-                                string(name: 'MONGO_IMAGE',      value: 'percona/percona-server-mongodb:4.4'),
-                                string(name: 'PROXYSQL_IMAGE',   value: 'proxysql/proxysql:2.3.0'),
-                            ])
-                        }
-                    }
-                }
-
-                stage('openshift-helm-tests') {
-                    steps {
-                        script {
-                            triggerJenkinsRc('openshift-helm-tests', 'openshift-helm-tests', [
-                                string(name: 'PMM_QA_GIT_BRANCH',  value: 'main'),
-                                string(name: 'PMM_CHART_BRANCH',   value: 'latest'),
-                                string(name: 'IMAGE_REPO',         value: env.PMM_SERVER_IMAGE.split(':')[0]),
-                                string(name: 'IMAGE_TAG',          value: env.PMM_SERVER_IMAGE.split(':')[1]),
-                                string(name: 'OPENSHIFT_VERSION',  value: 'latest'),
-                            ])
-                        }
-                    }
-                }
-
-                stage('GHA rc-testing-suite') {
-                    steps {
-                        script {
-                            try {
-                                def payload = new JsonBuilder([
-                                    ref   : 'main',
-                                    inputs: [
-                                        rc_version             : params.RC_VERSION.trim(),
-                                        pmm_client_tarball_ol8 : params.PMM_CLIENT_TARBALL_OL8.trim(),
-                                        pmm_client_tarball_ol9 : params.PMM_CLIENT_TARBALL_OL9.trim(),
-                                        pmm_qa_branch          : 'main',
-                                        pxc_version            : '8.0',
-                                        pxc_glibc              : '2.35',
-                                        pdpgsql_version        : '17',
-                                    ],
-                                ]).toString()
-                                writeFile file: 'rc-suite-dispatch.json', text: payload
-                                withCredentials([string(credentialsId: 'GITHUB_API_TOKEN', variable: 'GITHUB_TOKEN')]) {
-                                    sh """
-                                        set -euo pipefail
-                                        curl -fsS -X POST \\
-                                            -H "Accept: application/vnd.github+json" \\
-                                            -H "Authorization: Bearer \${GITHUB_TOKEN}" \\
-                                            -H "X-GitHub-Api-Version: 2022-11-28" \\
-                                            "https://api.github.com/repos/percona/pmm-qa/actions/workflows/rc-testing-suite.yml/dispatches" \\
-                                            --data @rc-suite-dispatch.json
-                                    """
+                        stage('nightly (compat #2)') {
+                            steps {
+                                script {
+                                    def tags = readFile('compat-tags.txt').trim().split('\n').collect { it.trim() }.findAll { it }
+                                    def ver = tags[1]
+                                    triggerJenkinsRc("pmm3-ui-tests-nightly (compat ${ver})", 'pmm3-ui-tests-nightly', [
+                                        string(name: 'PMM_QA_GIT_BRANCH',       value: 'main'),
+                                        string(name: 'SERVER_TYPE',             value: 'docker'),
+                                        string(name: 'DOCKER_VERSION',          value: env.PMM_SERVER_IMAGE),
+                                        string(name: 'CLIENT_VERSION',          value: ver),
+                                        string(name: 'ENABLE_PULL_MODE',        value: 'no'),
+                                        string(name: 'ADMIN_PASSWORD',          value: 'pmm3admin!'),
+                                        string(name: 'HELM_CHART_BRANCH',       value: 'main'),
+                                        string(name: 'OPENSHIFT_VERSION',       value: 'latest'),
+                                        string(name: 'K8S_VERSION',             value: '1.34'),
+                                        string(name: 'PXC_VERSION',             value: '8.0'),
+                                        string(name: 'PS_VERSION',              value: '8.4'),
+                                        string(name: 'MS_VERSION',              value: '8.4'),
+                                        string(name: 'PGSQL_VERSION',           value: '17'),
+                                        string(name: 'PDPGSQL_VERSION',         value: '17'),
+                                        string(name: 'MD_VERSION',              value: '10.6'),
+                                        string(name: 'PSMDB_VERSION',           value: '8.0'),
+                                        string(name: 'MODB_VERSION',            value: '8.0'),
+                                        string(name: 'QUERY_SOURCE',            value: 'slowlog'),
+                                        string(name: 'PTS_CONFIDENCE',          value: '93'),
+                                    ])
                                 }
-                                slackRcMessage("*Github Release Testing Suite*: https://github.com/percona/pmm-qa/actions/workflows/rc-testing-suite.yml")
-                            } catch (err) {
-                                slackRcMessage("*Github Release Testing Suite* (dispatch failed): ${err.getMessage()}")
+                            }
+                        }
+                        stage('nightly (compat #3)') {
+                            steps {
+                                script {
+                                    def tags = readFile('compat-tags.txt').trim().split('\n').collect { it.trim() }.findAll { it }
+                                    def ver = tags[2]
+                                    triggerJenkinsRc("pmm3-ui-tests-nightly (compat ${ver})", 'pmm3-ui-tests-nightly', [
+                                        string(name: 'PMM_QA_GIT_BRANCH',       value: 'main'),
+                                        string(name: 'SERVER_TYPE',             value: 'docker'),
+                                        string(name: 'DOCKER_VERSION',          value: env.PMM_SERVER_IMAGE),
+                                        string(name: 'CLIENT_VERSION',          value: ver),
+                                        string(name: 'ENABLE_PULL_MODE',        value: 'no'),
+                                        string(name: 'ADMIN_PASSWORD',          value: 'pmm3admin!'),
+                                        string(name: 'HELM_CHART_BRANCH',       value: 'main'),
+                                        string(name: 'OPENSHIFT_VERSION',       value: 'latest'),
+                                        string(name: 'K8S_VERSION',             value: '1.34'),
+                                        string(name: 'PXC_VERSION',             value: '8.0'),
+                                        string(name: 'PS_VERSION',              value: '8.4'),
+                                        string(name: 'MS_VERSION',              value: '8.4'),
+                                        string(name: 'PGSQL_VERSION',           value: '17'),
+                                        string(name: 'PDPGSQL_VERSION',         value: '17'),
+                                        string(name: 'MD_VERSION',              value: '10.6'),
+                                        string(name: 'PSMDB_VERSION',           value: '8.0'),
+                                        string(name: 'MODB_VERSION',            value: '8.0'),
+                                        string(name: 'QUERY_SOURCE',            value: 'slowlog'),
+                                        string(name: 'PTS_CONFIDENCE',          value: '93'),
+                                    ])
+                                }
+                            }
+                        }
+                        stage('nightly (compat #4)') {
+                            steps {
+                                script {
+                                    def tags = readFile('compat-tags.txt').trim().split('\n').collect { it.trim() }.findAll { it }
+                                    def ver = tags[3]
+                                    triggerJenkinsRc("pmm3-ui-tests-nightly (compat ${ver})", 'pmm3-ui-tests-nightly', [
+                                        string(name: 'PMM_QA_GIT_BRANCH',       value: 'main'),
+                                        string(name: 'SERVER_TYPE',             value: 'docker'),
+                                        string(name: 'DOCKER_VERSION',          value: env.PMM_SERVER_IMAGE),
+                                        string(name: 'CLIENT_VERSION',          value: ver),
+                                        string(name: 'ENABLE_PULL_MODE',        value: 'no'),
+                                        string(name: 'ADMIN_PASSWORD',          value: 'pmm3admin!'),
+                                        string(name: 'HELM_CHART_BRANCH',       value: 'main'),
+                                        string(name: 'OPENSHIFT_VERSION',       value: 'latest'),
+                                        string(name: 'K8S_VERSION',             value: '1.34'),
+                                        string(name: 'PXC_VERSION',             value: '8.0'),
+                                        string(name: 'PS_VERSION',              value: '8.4'),
+                                        string(name: 'MS_VERSION',              value: '8.4'),
+                                        string(name: 'PGSQL_VERSION',           value: '17'),
+                                        string(name: 'PDPGSQL_VERSION',         value: '17'),
+                                        string(name: 'MD_VERSION',              value: '10.6'),
+                                        string(name: 'PSMDB_VERSION',           value: '8.0'),
+                                        string(name: 'MODB_VERSION',            value: '8.0'),
+                                        string(name: 'QUERY_SOURCE',            value: 'slowlog'),
+                                        string(name: 'PTS_CONFIDENCE',          value: '93'),
+                                    ])
+                                }
+                            }
+                        }
+                        stage('nightly (compat #5)') {
+                            steps {
+                                script {
+                                    def tags = readFile('compat-tags.txt').trim().split('\n').collect { it.trim() }.findAll { it }
+                                    def ver = tags[4]
+                                    triggerJenkinsRc("pmm3-ui-tests-nightly (compat ${ver})", 'pmm3-ui-tests-nightly', [
+                                        string(name: 'PMM_QA_GIT_BRANCH',       value: 'main'),
+                                        string(name: 'SERVER_TYPE',             value: 'docker'),
+                                        string(name: 'DOCKER_VERSION',          value: env.PMM_SERVER_IMAGE),
+                                        string(name: 'CLIENT_VERSION',          value: ver),
+                                        string(name: 'ENABLE_PULL_MODE',        value: 'no'),
+                                        string(name: 'ADMIN_PASSWORD',          value: 'pmm3admin!'),
+                                        string(name: 'HELM_CHART_BRANCH',       value: 'main'),
+                                        string(name: 'OPENSHIFT_VERSION',       value: 'latest'),
+                                        string(name: 'K8S_VERSION',             value: '1.34'),
+                                        string(name: 'PXC_VERSION',             value: '8.0'),
+                                        string(name: 'PS_VERSION',              value: '8.4'),
+                                        string(name: 'MS_VERSION',              value: '8.4'),
+                                        string(name: 'PGSQL_VERSION',           value: '17'),
+                                        string(name: 'PDPGSQL_VERSION',         value: '17'),
+                                        string(name: 'MD_VERSION',              value: '10.6'),
+                                        string(name: 'PSMDB_VERSION',           value: '8.0'),
+                                        string(name: 'MODB_VERSION',            value: '8.0'),
+                                        string(name: 'QUERY_SOURCE',            value: 'slowlog'),
+                                        string(name: 'PTS_CONFIDENCE',          value: '93'),
+                                    ])
+                                }
+                            }
+                        }
+                    }
+                }
+
+                stage('Lane 2') {
+                    stages {
+                        stage('nightly (OVF)') {
+                            steps {
+                                script {
+                                    triggerJenkinsRc('pmm3-ui-tests-nightly (ovf)', 'pmm3-ui-tests-nightly', [
+                                        string(name: 'PMM_QA_GIT_BRANCH',       value: 'main'),
+                                        string(name: 'SERVER_TYPE',             value: 'ovf'),
+                                        string(name: 'DOCKER_VERSION',          value: "https://percona-vm.s3.amazonaws.com/PMM3-Server-${params.RC_VERSION.trim()}.ova"),
+                                        string(name: 'CLIENT_VERSION',          value: 'pmm3-rc'),
+                                        string(name: 'ENABLE_PULL_MODE',        value: 'no'),
+                                        string(name: 'ADMIN_PASSWORD',          value: 'admin1'),
+                                        string(name: 'HELM_CHART_BRANCH',       value: 'main'),
+                                        string(name: 'OPENSHIFT_VERSION',       value: 'latest'),
+                                        string(name: 'K8S_VERSION',             value: '1.34'),
+                                        string(name: 'PXC_VERSION',             value: '8.0'),
+                                        string(name: 'PS_VERSION',              value: '8.4'),
+                                        string(name: 'MS_VERSION',              value: '8.4'),
+                                        string(name: 'PGSQL_VERSION',           value: '17'),
+                                        string(name: 'PDPGSQL_VERSION',         value: '17'),
+                                        string(name: 'MD_VERSION',              value: '10.6'),
+                                        string(name: 'PSMDB_VERSION',           value: '8.0'),
+                                        string(name: 'MODB_VERSION',            value: '8.0'),
+                                        string(name: 'QUERY_SOURCE',            value: 'slowlog'),
+                                        string(name: 'PTS_CONFIDENCE',          value: '99'),
+                                    ])
+                                }
+                            }
+                        }
+                        stage('nightly (Docker)') {
+                            steps {
+                                script {
+                                    triggerJenkinsRc('pmm3-ui-tests-nightly (docker)', 'pmm3-ui-tests-nightly', [
+                                        string(name: 'PMM_QA_GIT_BRANCH',       value: 'main'),
+                                        string(name: 'SERVER_TYPE',             value: 'docker'),
+                                        string(name: 'DOCKER_VERSION',          value: env.PMM_SERVER_IMAGE),
+                                        string(name: 'CLIENT_VERSION',          value: 'pmm3-rc'),
+                                        string(name: 'ENABLE_PULL_MODE',        value: 'no'),
+                                        string(name: 'ADMIN_PASSWORD',          value: 'pmm3admin!'),
+                                        string(name: 'HELM_CHART_BRANCH',       value: 'main'),
+                                        string(name: 'OPENSHIFT_VERSION',       value: 'latest'),
+                                        string(name: 'K8S_VERSION',             value: '1.34'),
+                                        string(name: 'PXC_VERSION',             value: '8.0'),
+                                        string(name: 'PS_VERSION',              value: '8.4'),
+                                        string(name: 'MS_VERSION',              value: '8.4'),
+                                        string(name: 'PGSQL_VERSION',           value: '17'),
+                                        string(name: 'PDPGSQL_VERSION',         value: '17'),
+                                        string(name: 'MD_VERSION',              value: '10.6'),
+                                        string(name: 'PSMDB_VERSION',           value: '8.0'),
+                                        string(name: 'MODB_VERSION',            value: '8.0'),
+                                        string(name: 'QUERY_SOURCE',            value: 'slowlog'),
+                                        string(name: 'PTS_CONFIDENCE',          value: '93'),
+                                    ])
+                                }
+                            }
+                        }
+                        stage('nightly (Helm)') {
+                            steps {
+                                script {
+                                    triggerJenkinsRc('pmm3-ui-tests-nightly (helm)', 'pmm3-ui-tests-nightly', [
+                                        string(name: 'PMM_QA_GIT_BRANCH',       value: 'main'),
+                                        string(name: 'SERVER_TYPE',             value: 'helm'),
+                                        string(name: 'DOCKER_VERSION',          value: env.PMM_SERVER_IMAGE),
+                                        string(name: 'CLIENT_VERSION',          value: 'pmm3-rc'),
+                                        string(name: 'ENABLE_PULL_MODE',        value: 'no'),
+                                        string(name: 'ADMIN_PASSWORD',          value: 'admin1'),
+                                        string(name: 'HELM_CHART_BRANCH',       value: 'main'),
+                                        string(name: 'OPENSHIFT_VERSION',       value: 'latest'),
+                                        string(name: 'K8S_VERSION',             value: '1.34'),
+                                        string(name: 'PXC_VERSION',             value: '8.0'),
+                                        string(name: 'PS_VERSION',              value: '8.4'),
+                                        string(name: 'MS_VERSION',              value: '8.4'),
+                                        string(name: 'PGSQL_VERSION',           value: '17'),
+                                        string(name: 'PDPGSQL_VERSION',         value: '17'),
+                                        string(name: 'MD_VERSION',              value: '10.6'),
+                                        string(name: 'PSMDB_VERSION',           value: '8.0'),
+                                        string(name: 'MODB_VERSION',            value: '8.0'),
+                                        string(name: 'QUERY_SOURCE',            value: 'slowlog'),
+                                        string(name: 'PTS_CONFIDENCE',          value: '93'),
+                                    ])
+                                }
+                            }
+                        }
+                        stage('nightly (HA)') {
+                            steps {
+                                script {
+                                    triggerJenkinsRc('pmm3-ui-tests-nightly (ha)', 'pmm3-ui-tests-nightly', [
+                                        string(name: 'PMM_QA_GIT_BRANCH',       value: 'main'),
+                                        string(name: 'SERVER_TYPE',             value: 'ha'),
+                                        string(name: 'DOCKER_VERSION',          value: env.PMM_SERVER_IMAGE),
+                                        string(name: 'CLIENT_VERSION',          value: 'pmm3-rc'),
+                                        string(name: 'ENABLE_PULL_MODE',        value: 'no'),
+                                        string(name: 'ADMIN_PASSWORD',          value: 'admin1'),
+                                        string(name: 'HELM_CHART_BRANCH',       value: 'main'),
+                                        string(name: 'OPENSHIFT_VERSION',       value: 'latest'),
+                                        string(name: 'K8S_VERSION',             value: '1.34'),
+                                        string(name: 'PXC_VERSION',             value: '8.0'),
+                                        string(name: 'PS_VERSION',              value: '8.4'),
+                                        string(name: 'MS_VERSION',              value: '8.4'),
+                                        string(name: 'PGSQL_VERSION',           value: '17'),
+                                        string(name: 'PDPGSQL_VERSION',         value: '17'),
+                                        string(name: 'MD_VERSION',              value: '10.6'),
+                                        string(name: 'PSMDB_VERSION',           value: '8.0'),
+                                        string(name: 'MODB_VERSION',            value: '8.0'),
+                                        string(name: 'QUERY_SOURCE',            value: 'slowlog'),
+                                        string(name: 'PTS_CONFIDENCE',          value: '93'),
+                                    ])
+                                }
+                            }
+                        }
+                        stage('nightly (GSSAPI)') {
+                            steps {
+                                script {
+                                    triggerJenkinsRc('pmm3-ui-tests-nightly-gssapi', 'pmm3-ui-tests-nightly-gssapi', [
+                                        string(name: 'PMM_QA_GIT_BRANCH',       value: 'main'),
+                                        string(name: 'SERVER_TYPE',             value: 'docker'),
+                                        string(name: 'DOCKER_VERSION',          value: env.PMM_SERVER_IMAGE),
+                                        string(name: 'CLIENT_VERSION',          value: params.PMM_CLIENT_TARBALL_OL9.trim()),
+                                        string(name: 'ENABLE_PULL_MODE',        value: 'no'),
+                                        string(name: 'ADMIN_PASSWORD',          value: 'pmm3admin!'),
+                                        string(name: 'PSMDB_VERSION',           value: '8.0'),
+                                        string(name: 'MODB_VERSION',            value: '8.0'),
+                                    ])
+                                }
+                            }
+                        }
+                        stage('openshift-helm-tests') {
+                            steps {
+                                script {
+                                    triggerJenkinsRc('openshift-helm-tests', 'openshift-helm-tests', [
+                                        string(name: 'PMM_QA_GIT_BRANCH',  value: 'main'),
+                                        string(name: 'PMM_CHART_BRANCH',   value: 'latest'),
+                                        string(name: 'IMAGE_REPO',         value: env.PMM_SERVER_IMAGE.split(':')[0]),
+                                        string(name: 'IMAGE_TAG',          value: env.PMM_SERVER_IMAGE.split(':')[1]),
+                                        string(name: 'OPENSHIFT_VERSION',  value: 'latest'),
+                                    ])
+                                }
+                            }
+                        }
+                    }
+                }
+
+                stage('Lane 3') {
+                    stages {
+                        stage('GitHub rc-testing-suite') {
+                            steps {
+                                script {
+                                    try {
+                                        def payload = new JsonBuilder([
+                                            ref   : 'main',
+                                            inputs: [
+                                                rc_version             : params.RC_VERSION.trim(),
+                                                pmm_client_tarball_ol8 : params.PMM_CLIENT_TARBALL_OL8.trim(),
+                                                pmm_client_tarball_ol9 : params.PMM_CLIENT_TARBALL_OL9.trim(),
+                                                pmm_qa_branch          : 'main',
+                                                pxc_version            : '8.0',
+                                                pxc_glibc              : '2.35',
+                                                pdpgsql_version        : '17',
+                                            ],
+                                        ]).toString()
+                                        writeFile file: 'rc-suite-dispatch.json', text: payload
+                                        withCredentials([string(credentialsId: 'GITHUB_API_TOKEN', variable: 'GITHUB_TOKEN')]) {
+                                            sh """
+                                                set -euo pipefail
+                                                curl -fsS -X POST \\
+                                                    -H "Accept: application/vnd.github+json" \\
+                                                    -H "Authorization: Bearer \${GITHUB_TOKEN}" \\
+                                                    -H "X-GitHub-Api-Version: 2022-11-28" \\
+                                                    "https://api.github.com/repos/percona/pmm-qa/actions/workflows/rc-testing-suite.yml/dispatches" \\
+                                                    --data @rc-suite-dispatch.json
+                                            """
+                                        }
+                                        slackRcMessage("*Github Release Testing Suite*: https://github.com/percona/pmm-qa/actions/workflows/rc-testing-suite.yml")
+                                    } catch (err) {
+                                        slackRcMessage("*Github Release Testing Suite* (dispatch failed): ${err.getMessage()}")
+                                    }
+                                }
+                            }
+                        }
+                        stage('pmm3-migration-tests') {
+                            steps {
+                                script {
+                                    triggerJenkinsRc('pmm3-migration-tests', 'pmm3-migration-tests', [
+                                        string(name: 'PMM_V3_UI_GIT_BRANCH', value: 'main'),
+                                        string(name: 'PMM_V2_UI_GIT_BRANCH', value: 'v2'),
+                                        string(name: 'DOCKER_VERSION',       value: 'perconalab/pmm-server:2.44.1'),
+                                        string(name: 'CLIENT_VERSION',       value: '2.44.1'),
+                                        string(name: 'ADMIN_PASSWORD',       value: 'pmm3admin!'),
+                                        string(name: 'PMM_QA_GIT_BRANCH',   value: 'v2'),
+                                        string(name: 'UPGRADE_TAG',          value: 'testing'),
+                                    ])
+                                }
+                            }
+                        }
+                        stage('pmm3-ui-tests-matrix') {
+                            steps {
+                                script {
+                                    triggerJenkinsRc('pmm3-ui-tests-matrix', 'pmm3-ui-tests-matrix', [
+                                        string(name: 'PMM_QA_GIT_BRANCH', value: 'main'),
+                                        string(name: 'GIT_COMMIT_HASH',  value: ''),
+                                        string(name: 'DOCKER_VERSION',   value: env.PMM_SERVER_IMAGE),
+                                        string(name: 'CLIENT_VERSION',   value: 'pmm3-rc'),
+                                        string(name: 'MYSQL_IMAGE',      value: 'percona:5.7'),
+                                        string(name: 'POSTGRES_IMAGE',   value: 'perconalab/percona-distribution-postgresql:16.0'),
+                                        string(name: 'MONGO_IMAGE',      value: 'percona/percona-server-mongodb:4.4'),
+                                        string(name: 'PROXYSQL_IMAGE',   value: 'proxysql/proxysql:2.3.0'),
+                                    ])
+                                }
+                            }
+                        }
+                        stage('pmm3-upgrade-ami-test') {
+                            steps {
+                                script {
+                                    triggerJenkinsRc('pmm3-upgrade-ami-test', 'pmm3-upgrade-ami-test', [
+                                        string(name: 'PMM_UI_GIT_BRANCH',         value: 'main'),
+                                        string(name: 'PMM_QA_GIT_BRANCH',         value: 'main'),
+                                        string(name: 'QA_INTEGRATION_GIT_BRANCH', value: 'main'),
+                                        booleanParam(name: 'IS_RC_TESTING',       value: true),
+                                    ])
+                                }
+                            }
+                        }
+                        stage('pmm3-package-testing-matrix') {
+                            steps {
+                                script {
+                                    triggerJenkinsRc('pmm3-package-testing-matrix', 'pmm3-package-testing-matrix', [
+                                        string(name: 'GIT_BRANCH',      value: 'main'),
+                                        string(name: 'GIT_COMMIT_HASH', value: ''),
+                                        string(name: 'DOCKER_VERSION',  value: env.PMM_SERVER_IMAGE),
+                                        string(name: 'PMM_VERSION',     value: params.RC_VERSION.trim()),
+                                        string(name: 'INSTALL_REPO',    value: 'testing'),
+                                        string(name: 'TARBALL',         value: params.PMM_CLIENT_TARBALL.trim()),
+                                        string(name: 'METRICS_MODE',    value: 'auto'),
+                                    ])
+                                }
+                            }
+                        }
+                        stage('pmm3-package-testing-arm-matrix') {
+                            steps {
+                                script {
+                                    triggerJenkinsRc('pmm3-package-testing-arm-matrix', 'pmm3-package-testing-arm-matrix', [
+                                        string(name: 'GIT_BRANCH',      value: 'main'),
+                                        string(name: 'GIT_COMMIT_HASH', value: ''),
+                                        string(name: 'DOCKER_VERSION',  value: env.PMM_SERVER_IMAGE),
+                                        string(name: 'PMM_VERSION',     value: params.RC_VERSION.trim()),
+                                        string(name: 'INSTALL_REPO',    value: 'testing'),
+                                        string(name: 'TARBALL',         value: params.PMM_CLIENT_TARBALL_ARM64.trim()),
+                                        string(name: 'METRICS_MODE',    value: 'auto'),
+                                    ])
+                                }
+                            }
+                        }
+                        stage('pmm3-upgrade-tests-matrix') {
+                            steps {
+                                script {
+                                    triggerJenkinsRc('pmm3-upgrade-tests-matrix', 'pmm3-upgrade-tests-matrix', [
+                                        string(name: 'PMM_QA_GIT_BRANCH', value: 'main'),
+                                    ])
+                                }
                             }
                         }
                     }


### PR DESCRIPTION
This pull request refactors and streamlines the nightly compatibility test stages in the `pmm/v3/pmm3-rc-testing.groovy` pipeline, consolidating and parameterizing the test stages for better maintainability and flexibility. It also introduces minor improvements to error handling and environment preparation in related scripts.

**Pipeline refactoring and test improvements:**

* Consolidated multiple nightly test stages (AMI, OVF, Docker, OpenShift, HA, and compatibility matrix) into a single `Lane 1` with sequential, parameterized stages (`nightly (AMI)`, `nightly (compat #1)` through `nightly (compat #5)`). Each compatibility stage dynamically reads the relevant version from `compat-tags.txt` and passes it as the `CLIENT_VERSION` parameter, improving maintainability and reducing code duplication. [[1]](diffhunk://#diff-1f22dd26c31359094a11e323ff1b8de047135668b26d02019a7647b92719eed6L116-R118) [[2]](diffhunk://#diff-1f22dd26c31359094a11e323ff1b8de047135668b26d02019a7647b92719eed6L156-R156) [[3]](diffhunk://#diff-1f22dd26c31359094a11e323ff1b8de047135668b26d02019a7647b92719eed6L178-R183) [[4]](diffhunk://#diff-1f22dd26c31359094a11e323ff1b8de047135668b26d02019a7647b92719eed6L210-R214) [[5]](diffhunk://#diff-1f22dd26c31359094a11e323ff1b8de047135668b26d02019a7647b92719eed6L237-R243) [[6]](diffhunk://#diff-1f22dd26c31359094a11e323ff1b8de047135668b26d02019a7647b92719eed6L264-R265)

**Error handling and setup improvements:**

* Changed the error handling in `triggerJenkinsRc` to mark the build as `unstable` instead of failing with `error`, allowing the pipeline to continue running even if a stage fails.

* In the AWS staging start script, added a wait for `cloud-init` to finish (if present) and cleaned DNF packages before installing Percona release, improving environment consistency.