### PR TITLE
PPG-2302: Fix Trivy installation on Debian/Ubuntu agents

### DIFF
--- a/ppg/docker-cve-scan.groovy
+++ b/ppg/docker-cve-scan.groovy
@@ -221,7 +221,7 @@ def scanImageGroup(String groupName, List images, boolean fixesOnly) {
             def txtFile  = "${fileBase}-${arch}.txt"
             def xmlFile  = "${fileBase}-${arch}.xml"
 
-            sh """/usr/local/bin/trivy image --platform ${platform} --severity HIGH,CRITICAL \
+            sh """trivy image --platform ${platform} --severity HIGH,CRITICAL \
                 --timeout 30m \
                 ${fixFlag} --format json --output ${jsonFile} "${image}" """
             sh "python3 scan_to_txt.py '${jsonFile}' '${platform}' > '${txtFile}'"
@@ -340,7 +340,7 @@ docker.io/perconalab/percona-distribution-postgresql-upgrade-custom:18.3-17.9-16
             steps {
                 cleanWs()
                 script {
-                    installTrivy(method: 'auto')
+                    installTrivy(method: 'binary')
                     writeHelperScripts()
                 }
             }


### PR DESCRIPTION
- Replace hardcoded /usr/local/bin/trivy path with plain trivy command 
so it works regardless of installation method or OS

- Switch installTrivy from auto-detect to binary method to bypass apt 
dpkg lock errors caused by unattended-upgrades running at agent 
startup on Hetzner docker-x64 nodes