### PR TITLE
PG-2354: Add Ubuntu 26.04 LTS (Resolute) support and deduplicate AMIs

### DIFF
--- a/vars/moleculeEnvPPG.groovy
+++ b/vars/moleculeEnvPPG.groovy
@@ -1,0 +1,37 @@
+def call() {
+    return """
+        export ami_debian11_x86_64=ami-009e9420630204b5d
+        export ami_debian12_x86_64=ami-09ca7bd4727fb280b
+        export ami_debian13_x86_64=ami-0be4fe95f0181e6ae
+        export ami_ol8_x86_64=ami-058eb9eaa259563c0
+        export ami_ol9_x86_64=ami-0514f056ab68c7863
+        export ami_rhel8_x86_64=ami-013babf09dd3650a0
+        export ami_rhel9_x86_64=ami-01ea92f779cc1c71f
+        export ami_rhel10_x86_64=ami-01777900cf626c469
+        export ami_rocky8_x86_64=ami-0f99e90e01ec42b57
+        export ami_rocky9_x86_64=ami-019aef84b4837f73d
+        export ami_rocky10_x86_64=ami-09f9edbd6a2d85ba9
+        export ami_ubuntu22_x86_64=ami-0b3a21dbff1fffb4c
+        export ami_ubuntu24_x86_64=ami-0596cf3199908321b
+        export ami_ubuntu26_x86_64=ami-051eaec1417c5d4ae
+        export ami_debian11_arm64=ami-08bb051b83411b514
+        export ami_debian12_arm64=ami-04991928175cf27a1
+        export ami_debian13_arm64=ami-06732b4e86178978f
+        export ami_ol8_arm64=ami-02063adb64607f0f3
+        export ami_ol9_arm64=ami-0fcd8b1be597c5fcd
+        export ami_rhel8_arm64=ami-0262cbd29d3c00f2e
+        export ami_rhel9_arm64=ami-024a0efb56778bc6b
+        export ami_rhel10_arm64=ami-0ad16a1fbf63249be
+        export ami_rocky8_arm64=ami-07212fece0fd77907
+        export ami_rocky9_arm64=ami-02ef97e98cb13bbf6
+        export ami_rocky10_arm64=ami-0ecc8cb2d8f5b6948
+        export ami_ubuntu22_arm64=ami-0e61fa0475e5cdf7d
+        export ami_ubuntu24_arm64=ami-0abed25eed793978d
+        export ami_ubuntu26_arm64=ami-042f11a836094cda0
+        export region=eu-central-1
+        export vpc_subnet_id_aws1=subnet-0775d65ad1e9703bc
+        export vpc_subnet_id_aws2=subnet-09947b46d69590c50
+        export vpc_subnet_id_aws3=subnet-0fad4db6fdd8025b6
+        export driver=ec2
+    """
+}

--- a/vars/moleculeExecuteActionWithScenarioPPG.groovy
+++ b/vars/moleculeExecuteActionWithScenarioPPG.groovy
@@ -2,37 +2,7 @@ def call(moleculeDir, action, scenario) {
     sh """
         . virtenv/bin/activate
         cd ${moleculeDir}
-        export ami_debian11_x86_64=ami-0c902832debf5f049
-        export ami_debian12_x86_64=ami-09a2f0264769556f1
-        export ami_debian13_x86_64=ami-0eb2a285617d18845
-        export ami_ol8_x86_64=ami-058eb9eaa259563c0
-        export ami_ol9_x86_64=ami-0514f056ab68c7863
-        export ami_rhel8_x86_64=ami-0d38405c22c6dfaf3
-        export ami_rhel9_x86_64=ami-0b6540c077ff41a81
-        export ami_rhel10_x86_64=ami-015b77c74fad9f40d
-        export ami_rocky8_x86_64=ami-0f99e90e01ec42b57
-        export ami_rocky9_x86_64=ami-019aef84b4837f73d
-        export ami_rocky10_x86_64=ami-09f9edbd6a2d85ba9
-        export ami_ubuntu22_x86_64=ami-074dd8e8dac7651a5
-        export ami_ubuntu24_x86_64=ami-0aad10862ade98f27
-        export ami_debian11_arm64=ami-0d12d5e9cf10ddd9b
-        export ami_debian12_arm64=ami-0ca65bfaeef7deb8f
-        export ami_debian13_arm64=ami-07e718c51f8ef6ef1
-        export ami_ol8_arm64=ami-02063adb64607f0f3
-        export ami_ol9_arm64=ami-0fcd8b1be597c5fcd
-        export ami_rhel8_arm64=ami-05796f88f5487ea38
-        export ami_rhel9_arm64=ami-0ddb23de4a4be5a3c
-        export ami_rhel10_arm64=ami-0ad16a1fbf63249be
-        export ami_rocky8_arm64=ami-07212fece0fd77907
-        export ami_rocky9_arm64=ami-02ef97e98cb13bbf6
-        export ami_rocky10_arm64=ami-0ecc8cb2d8f5b6948
-        export ami_ubuntu22_arm64=ami-01099d45fb386e13b
-        export ami_ubuntu24_arm64=ami-0a96a698343e1007e
-        export region=eu-central-1
-        export vpc_subnet_id_aws1=subnet-0775d65ad1e9703bc
-        export vpc_subnet_id_aws2=subnet-09947b46d69590c50
-        export vpc_subnet_id_aws3=subnet-0fad4db6fdd8025b6
-        export driver=ec2
+        ${moleculeEnvPPG()}
         molecule ${action} -s ${scenario}
     """
 }

--- a/vars/moleculeExecuteActionWithVariableAndScenarioPPG.groovy
+++ b/vars/moleculeExecuteActionWithVariableAndScenarioPPG.groovy
@@ -2,37 +2,7 @@ def call(moleculeDir, action, scenario, varName, varValue) {
     sh """
         . virtenv/bin/activate
         cd ${moleculeDir}
-        export ami_debian11_x86_64=ami-0c902832debf5f049
-        export ami_debian12_x86_64=ami-09a2f0264769556f1
-        export ami_debian13_x86_64=ami-0eb2a285617d18845
-        export ami_ol8_x86_64=ami-058eb9eaa259563c0
-        export ami_ol9_x86_64=ami-0514f056ab68c7863
-        export ami_rhel8_x86_64=ami-0d38405c22c6dfaf3
-        export ami_rhel9_x86_64=ami-0b6540c077ff41a81
-        export ami_rhel10_x86_64=ami-015b77c74fad9f40d
-        export ami_rocky8_x86_64=ami-0f99e90e01ec42b57
-        export ami_rocky9_x86_64=ami-019aef84b4837f73d
-        export ami_rocky10_x86_64=ami-09f9edbd6a2d85ba9
-        export ami_ubuntu22_x86_64=ami-074dd8e8dac7651a5
-        export ami_ubuntu24_x86_64=ami-0aad10862ade98f27
-        export ami_debian11_arm64=ami-0d12d5e9cf10ddd9b
-        export ami_debian12_arm64=ami-0ca65bfaeef7deb8f
-        export ami_debian13_arm64=ami-07e718c51f8ef6ef1
-        export ami_ol8_arm64=ami-02063adb64607f0f3
-        export ami_ol9_arm64=ami-0fcd8b1be597c5fcd
-        export ami_rhel8_arm64=ami-05796f88f5487ea38
-        export ami_rhel9_arm64=ami-0ddb23de4a4be5a3c
-        export ami_rhel10_arm64=ami-0ad16a1fbf63249be
-        export ami_rocky8_arm64=ami-07212fece0fd77907
-        export ami_rocky9_arm64=ami-02ef97e98cb13bbf6
-        export ami_rocky10_arm64=ami-0ecc8cb2d8f5b6948
-        export ami_ubuntu22_arm64=ami-01099d45fb386e13b
-        export ami_ubuntu24_arm64=ami-0a96a698343e1007e
-        export region=eu-central-1
-        export vpc_subnet_id_aws1=subnet-0775d65ad1e9703bc
-        export vpc_subnet_id_aws2=subnet-09947b46d69590c50
-        export vpc_subnet_id_aws3=subnet-0fad4db6fdd8025b6
-        export driver=ec2
+        ${moleculeEnvPPG()}
         ${varName}=${varValue} molecule ${action} -s ${scenario}
     """
 }

--- a/vars/moleculeExecuteActionWithVariableListAndScenarioPPG.groovy
+++ b/vars/moleculeExecuteActionWithVariableListAndScenarioPPG.groovy
@@ -2,37 +2,7 @@ def call(moleculeDir, action, scenario, varList) {
     sh """
         . virtenv/bin/activate
         cd ${moleculeDir}
-        export ami_debian11_x86_64=ami-0c902832debf5f049
-        export ami_debian12_x86_64=ami-09a2f0264769556f1
-        export ami_debian13_x86_64=ami-0eb2a285617d18845
-        export ami_ol8_x86_64=ami-058eb9eaa259563c0
-        export ami_ol9_x86_64=ami-0514f056ab68c7863
-        export ami_rhel8_x86_64=ami-0d38405c22c6dfaf3
-        export ami_rhel9_x86_64=ami-0b6540c077ff41a81
-        export ami_rhel10_x86_64=ami-015b77c74fad9f40d
-        export ami_rocky8_x86_64=ami-0f99e90e01ec42b57
-        export ami_rocky9_x86_64=ami-019aef84b4837f73d
-        export ami_rocky10_x86_64=ami-09f9edbd6a2d85ba9
-        export ami_ubuntu22_x86_64=ami-074dd8e8dac7651a5
-        export ami_ubuntu24_x86_64=ami-0aad10862ade98f27
-        export ami_debian11_arm64=ami-0d12d5e9cf10ddd9b
-        export ami_debian12_arm64=ami-0ca65bfaeef7deb8f
-        export ami_debian13_arm64=ami-07e718c51f8ef6ef1
-        export ami_ol8_arm64=ami-02063adb64607f0f3
-        export ami_ol9_arm64=ami-0fcd8b1be597c5fcd
-        export ami_rhel8_arm64=ami-05796f88f5487ea38
-        export ami_rhel9_arm64=ami-0ddb23de4a4be5a3c
-        export ami_rhel10_arm64=ami-0ad16a1fbf63249be
-        export ami_rocky8_arm64=ami-07212fece0fd77907
-        export ami_rocky9_arm64=ami-02ef97e98cb13bbf6
-        export ami_rocky10_arm64=ami-0ecc8cb2d8f5b6948
-        export ami_ubuntu22_arm64=ami-01099d45fb386e13b
-        export ami_ubuntu24_arm64=ami-0a96a698343e1007e
-        export region=eu-central-1
-        export vpc_subnet_id_aws1=subnet-0775d65ad1e9703bc
-        export vpc_subnet_id_aws2=subnet-09947b46d69590c50
-        export vpc_subnet_id_aws3=subnet-0fad4db6fdd8025b6
-        export driver=ec2
+        ${moleculeEnvPPG()}
         ${varList} molecule ${action} -s ${scenario}
     """
 }

--- a/vars/moleculeParallelTestPPG.groovy
+++ b/vars/moleculeParallelTestPPG.groovy
@@ -6,37 +6,7 @@ def call(operatingSystems, moleculeDir) {
             sh """
                   . virtenv/bin/activate
                   cd ${moleculeDir}
-                  export ami_debian11_x86_64=ami-0c902832debf5f049
-                  export ami_debian12_x86_64=ami-09a2f0264769556f1
-                  export ami_debian13_x86_64=ami-0eb2a285617d18845
-                  export ami_ol8_x86_64=ami-058eb9eaa259563c0
-                  export ami_ol9_x86_64=ami-0514f056ab68c7863
-                  export ami_rhel8_x86_64=ami-0d38405c22c6dfaf3
-                  export ami_rhel9_x86_64=ami-0b6540c077ff41a81
-                  export ami_rhel10_x86_64=ami-015b77c74fad9f40d
-                  export ami_rocky8_x86_64=ami-0f99e90e01ec42b57
-                  export ami_rocky9_x86_64=ami-019aef84b4837f73d
-                  export ami_rocky10_x86_64=ami-09f9edbd6a2d85ba9
-                  export ami_ubuntu22_x86_64=ami-074dd8e8dac7651a5
-                  export ami_ubuntu24_x86_64=ami-0aad10862ade98f27
-                  export ami_debian11_arm64=ami-0d12d5e9cf10ddd9b
-                  export ami_debian12_arm64=ami-0ca65bfaeef7deb8f
-                  export ami_debian13_arm64=ami-07e718c51f8ef6ef1
-                  export ami_ol8_arm64=ami-02063adb64607f0f3
-                  export ami_ol9_arm64=ami-0fcd8b1be597c5fcd
-                  export ami_rhel8_arm64=ami-05796f88f5487ea38
-                  export ami_rhel9_arm64=ami-0ddb23de4a4be5a3c
-                  export ami_rhel10_arm64=ami-0ad16a1fbf63249be
-                  export ami_rocky8_arm64=ami-07212fece0fd77907
-                  export ami_rocky9_arm64=ami-02ef97e98cb13bbf6
-                  export ami_rocky10_arm64=ami-0ecc8cb2d8f5b6948
-                  export ami_ubuntu22_arm64=ami-01099d45fb386e13b
-                  export ami_ubuntu24_arm64=ami-0a96a698343e1007e
-                  export region=eu-central-1
-                  export vpc_subnet_id_aws1=subnet-0775d65ad1e9703bc
-                  export vpc_subnet_id_aws2=subnet-09947b46d69590c50
-                  export vpc_subnet_id_aws3=subnet-0fad4db6fdd8025b6
-                  export driver=ec2
+                  ${moleculeEnvPPG()}
                   molecule test -s ${os}
                """
         }

--- a/vars/ppgOperatingSystemsALL.groovy
+++ b/vars/ppgOperatingSystemsALL.groovy
@@ -1,3 +1,3 @@
 def call() {
-  return ['ol-8', 'ol-9', 'rocky-8', 'rocky-9', 'rocky-10', 'rhel-8', 'rhel-9', 'rhel-10', 'debian-11', 'debian-12', 'debian-13', 'ubuntu-jammy', 'ubuntu-noble', 'ol-8-arm', 'ol-9-arm', 'rocky-8-arm', 'rocky-9-arm', 'rocky-10-arm', 'rhel-8-arm', 'rhel-9-arm', 'rhel-10-arm', 'debian-11-arm', 'debian-12-arm', 'debian-13-arm', 'ubuntu-jammy-arm', 'ubuntu-noble-arm']
+  return ['ol-8', 'ol-9', 'rocky-8', 'rocky-9', 'rocky-10', 'rhel-8', 'rhel-9', 'rhel-10', 'debian-11', 'debian-12', 'debian-13', 'ubuntu-jammy', 'ubuntu-noble', 'ubuntu-resolute', 'ol-8-arm', 'ol-9-arm', 'rocky-8-arm', 'rocky-9-arm', 'rocky-10-arm', 'rhel-8-arm', 'rhel-9-arm', 'rhel-10-arm', 'debian-11-arm', 'debian-12-arm', 'debian-13-arm', 'ubuntu-jammy-arm', 'ubuntu-noble-arm', 'ubuntu-resolute-arm']
 }

--- a/vars/ppgOperatingSystemsAMD.groovy
+++ b/vars/ppgOperatingSystemsAMD.groovy
@@ -1,3 +1,3 @@
 def call() {
-  return ['ol-8', 'ol-9', 'rocky-8', 'rocky-9', 'rocky-10', 'rhel-8', 'rhel-9', 'rhel-10', 'debian-11', 'debian-12', 'debian-13', 'ubuntu-jammy', 'ubuntu-noble']
+  return ['ol-8', 'ol-9', 'rocky-8', 'rocky-9', 'rocky-10', 'rhel-8', 'rhel-9', 'rhel-10', 'debian-11', 'debian-12', 'debian-13', 'ubuntu-jammy', 'ubuntu-noble', 'ubuntu-resolute']
 }

--- a/vars/ppgOperatingSystemsARM.groovy
+++ b/vars/ppgOperatingSystemsARM.groovy
@@ -1,3 +1,3 @@
 def call() {
-  return ['ol-8-arm', 'ol-9-arm', 'rocky-8-arm', 'rocky-9-arm', 'rocky-10-arm', 'rhel-8-arm', 'rhel-9-arm', 'rhel-10-arm', 'debian-11-arm', 'debian-12-arm', 'debian-13-arm', 'ubuntu-jammy-arm', 'ubuntu-noble-arm']
+  return ['ol-8-arm', 'ol-9-arm', 'rocky-8-arm', 'rocky-9-arm', 'rocky-10-arm', 'rhel-8-arm', 'rhel-9-arm', 'rhel-10-arm', 'debian-11-arm', 'debian-12-arm', 'debian-13-arm', 'ubuntu-jammy-arm', 'ubuntu-noble-arm', 'ubuntu-resolute-arm']
 }

--- a/vars/ppgOperatingSystemsSSL35.groovy
+++ b/vars/ppgOperatingSystemsSSL35.groovy
@@ -1,3 +1,3 @@
 def call() {
-  return ['debian-13', 'debian-13-arm']
+  return ['debian-13', 'debian-13-arm', 'ubuntu-resolute', 'ubuntu-resolute-arm']
 }

--- a/vars/ppgScenarios.groovy
+++ b/vars/ppgScenarios.groovy
@@ -1,8 +1,8 @@
 def call() {
   return [
-  'pg-13', 'pg-14', 'pg-15', 'pg-16', 'pg-17', 'pg-18',
-  'pg-13-meta-ha', 'pg-14-meta-ha', 'pg-15-meta-ha', 'pg-16-meta-ha',
-  'pg-17-meta-ha', 'pg-18-meta-ha','pg-13-meta-server', 'pg-14-meta-server',
+  'pg-14', 'pg-15', 'pg-16', 'pg-17', 'pg-18',
+  'pg-14-meta-ha', 'pg-15-meta-ha', 'pg-16-meta-ha',
+  'pg-17-meta-ha', 'pg-18-meta-ha', 'pg-14-meta-server',
   'pg-15-meta-server', 'pg-16-meta-server', 'pg-17-meta-server',
   'pg-18-meta-server'
   ]

--- a/vars/ppgUpgradeScenarios.groovy
+++ b/vars/ppgUpgradeScenarios.groovy
@@ -1,8 +1,8 @@
 def call() {
   return [
-  'pg-13-minor-upgrade', 'pg-14-minor-upgrade', 'pg-15-minor-upgrade',
+  'pg-14-minor-upgrade', 'pg-15-minor-upgrade',
   'pg-16-minor-upgrade', 'pg-17-minor-upgrade', 'pg-18-minor-upgrade',
-  'pg-13-major-upgrade', 'pg-14-major-upgrade', 'pg-15-major-upgrade',
+  'pg-14-major-upgrade', 'pg-15-major-upgrade',
   'pg-16-major-upgrade', 'pg-17-major-upgrade', 'pg-18-major-upgrade'
   ]
 }


### PR DESCRIPTION

- Add ubuntu-resolute and ubuntu-resolute-arm to all OS lists (ppgOperatingSystemsALL, AMD, ARM) and to ppgOperatingSystemsSSL35
- Extract shared AWS infrastructure config (AMI IDs, region, subnets, driver) into new vars/moleculeEnvPPG.groovy shared helper, removing ~30 lines of duplication from each of the four molecule vars files
- Drop pg-13 from ppgScenarios and ppgUpgradeScenarios (EOL)
- Update AMI IDs to the latest for all platforms