### PR TITLE
PMM-7 Fix dnf cache failure

### DIFF
--- a/pmm/v3/vars/setupPMM3Client.groovy
+++ b/pmm/v3/vars/setupPMM3Client.groovy
@@ -30,12 +30,11 @@ def call(String SERVER_IP, String CLIENT_VERSION, String PMM_VERSION, String ENA
                 export IP=192.168.0.1
             fi
 
+            sudo dnf clean expire-cache
             if ! command -v percona-release > /dev/null; then
                 curl -O https://repo.percona.com/yum/percona-release-latest.noarch.rpm
                 sudo dnf -y install ./percona-release-latest.noarch.rpm
                 rm -f percona-release-latest.noarch.rpm
-                sudo dnf clean all
-                sudo dnf makecache
             fi
 
             if [[ "${CLIENT_VERSION}" == "latest-tarball" ]]; then

--- a/vars/setupPMMClient.groovy
+++ b/vars/setupPMMClient.groovy
@@ -26,24 +26,24 @@ def call(String SERVER_IP, String CLIENT_VERSION, String PMM_VERSION, String ENA
 
             sudo dnf clean expire-cache
             if [ "${PMM_VERSION}" = pmm2 ]; then
-              echo exclude=mirror.es.its.nyu.edu | sudo tee -a /etc/yum/pluginconf.d/fastestmirror.conf
+              echo exclude=mirror.es.its.nyu.edu | sudo tee -a /etc/dnf/pluginconf.d/fastestmirror.conf
             fi
             if ! command -v percona-release > /dev/null; then
-                sudo yum -y install https://repo.percona.com/yum/percona-release-latest.noarch.rpm || true
+                sudo dnf -y install https://repo.percona.com/yum/percona-release-latest.noarch.rpm || true
             fi
 
             if [[ "$CLIENT_VERSION" =~ dev-latest|3-dev-latest ]]; then
                 sudo percona-release enable-only pmm2-client experimental
-                sudo yum -y install pmm2-client
+                sudo dnf -y install pmm2-client
             elif [[ "$CLIENT_VERSION" = pmm2-rc ]]; then
                 sudo percona-release enable-only pmm2-client testing
-                sudo yum -y install pmm2-client
+                sudo dnf -y install pmm2-client
             elif [[ "$CLIENT_VERSION" = pmm2-latest ]]; then
-                sudo yum -y install pmm2-client
-                sudo yum -y update
+                sudo dnf -y install pmm2-client
+                sudo dnf -y update
                 sudo percona-release enable-only pmm2-client experimental
             elif [[ "$CLIENT_VERSION" = 2* ]]; then
-                sudo yum -y install "pmm2-client-$CLIENT_VERSION-6.el9.x86_64"
+                sudo dnf -y install "pmm2-client-$CLIENT_VERSION-6.el9.x86_64"
                 if [[ "$ENABLE_TESTING_REPO" = yes ]]; then
                     sudo percona-release enable-only pmm2-client testing
                 elif [[ "$ENABLE_TESTING_REPO" = no ]] && [[ "$ENABLE_EXPERIMENTAL_REPO" = yes ]]; then

--- a/vars/setupPMMClient.groovy
+++ b/vars/setupPMMClient.groovy
@@ -24,13 +24,12 @@ def call(String SERVER_IP, String CLIENT_VERSION, String PMM_VERSION, String ENA
                 export ADMIN_PASSWORD=admin
             fi
 
+            sudo dnf clean expire-cache
             if [ "${PMM_VERSION}" = pmm2 ]; then
               echo exclude=mirror.es.its.nyu.edu | sudo tee -a /etc/yum/pluginconf.d/fastestmirror.conf
             fi
             if ! command -v percona-release > /dev/null; then
                 sudo yum -y install https://repo.percona.com/yum/percona-release-latest.noarch.rpm || true
-                sudo yum clean all
-                sudo yum makecache
             fi
 
             if [[ "$CLIENT_VERSION" =~ dev-latest|3-dev-latest ]]; then


### PR DESCRIPTION
This pull request updates the client setup scripts to improve package cache handling when installing the `percona-release` package. 

**Package manager cache handling:**

* Added `sudo dnf clean expire-cache` before checking for `percona-release` in both `setupPMM3Client.groovy` and `setupPMMClient.groovy` to ensure the package manager cache is up to date.
* Removed `sudo dnf/yum clean all` and `sudo dnf/yum makecache` after installing `percona-release`, since expiring the cache beforehand is sufficient and more efficient.