### PR TITLE
PMM-7 Rename agents

### DIFF
--- a/pmm/README.md
+++ b/pmm/README.md
@@ -8,7 +8,7 @@
 
 ## Agents
 
-We build the custom image for agents and you can find Packer and Ansible files in [pmm-](https://github.com/percona/pmm/tree/v3/build/packer) repo.
+We build the custom image for agents and you can find Packer and Ansible files in [pmm](https://github.com/percona/pmm/tree/v3/build/packer) repo.
 
 Use the following tags for agents:
 

--- a/pmm/README.md
+++ b/pmm/README.md
@@ -8,13 +8,13 @@
 
 ## Agents
 
-We build the custom image for agents and you can find Packer and Ansible files in [pmm-infra](https://github.com/percona/pmm-infra/tree/main/packer) repo.
+We build the custom image for agents and you can find Packer and Ansible files in [pmm-](https://github.com/percona/pmm/tree/v3/build/packer) repo.
 
-You can use the following tags for agents:
+Use the following tags for agents:
 
-- `agent-amd64-ol9` - short-lived agent based on Oracle Linux 9. After completing one task, the agent dies and a new one is started
-- `agent-arm64-ol9` - the same as previous but arm64 arch
-- `cli` - long-lived agents for tasks that do not require interaction with the file system. For example: run awc-cli command. These agents used ARM64 arch and read-only filesystem.
+- `agent-amd64` - short-lived agent based on Oracle Linux 9. After completing one task, the agent dies and a new one is started
+- `agent-arm64` - the same as previous but arm64 arch
+- `cli` - long-lived agents for tasks that do not require interaction with the file system. For example: run awc-cli command. These agents run on ARM64 arch.
 
 ## Tips
 

--- a/pmm/infrastructure/rpm-build.groovy
+++ b/pmm/infrastructure/rpm-build.groovy
@@ -1,6 +1,6 @@
 pipeline {
     agent {
-        label "agent-amd64-ol9"
+        label "agent-amd64"
     }
     parameters {
         string(

--- a/pmm/openshift/openshift_cluster_create.groovy
+++ b/pmm/openshift/openshift_cluster_create.groovy
@@ -145,7 +145,7 @@ def archiveClusterLogs() {
 
 pipeline {
     agent {
-        label 'agent-amd64-ol9'
+        label 'agent-amd64'
     }
 
     environment {

--- a/pmm/openshift/openshift_cluster_destroy.groovy
+++ b/pmm/openshift/openshift_cluster_destroy.groovy
@@ -6,7 +6,7 @@ import groovy.json.JsonSlurper
 
 pipeline {
     agent {
-        label 'agent-amd64-ol9'
+        label 'agent-amd64'
     }
 
     environment {

--- a/pmm/openshift/openshift_cluster_list.groovy
+++ b/pmm/openshift/openshift_cluster_list.groovy
@@ -3,7 +3,7 @@
 
 pipeline {
     agent {
-        label 'agent-amd64-ol9'
+        label 'agent-amd64'
     }
 
     environment {

--- a/pmm/v3/pmm3-ami-upgrade-tests.groovy
+++ b/pmm/v3/pmm3-ami-upgrade-tests.groovy
@@ -135,7 +135,7 @@ currentBuild.description = "AMI: $amiID"
 
 pipeline {
     agent {
-        label 'agent-amd64-ol9'
+        label 'agent-amd64'
     }
     environment {
         REMOTE_AWS_MYSQL_USER=credentials('pmm-dev-mysql-remote-user')

--- a/pmm/v3/pmm3-ami.groovy
+++ b/pmm/v3/pmm3-ami.groovy
@@ -1,6 +1,6 @@
 pipeline {
     agent {
-        label params.USE_ONDEMAND ? 'agent-amd64-ol9-ondemand' : 'agent-amd64-ol9'
+        label params.USE_ONDEMAND ? 'agent-amd64-ondemand' : 'agent-amd64'
     }
     parameters {
         string(

--- a/pmm/v3/pmm3-api-tests.groovy
+++ b/pmm/v3/pmm3-api-tests.groovy
@@ -5,7 +5,7 @@ library changelog: false, identifier: 'lib@master', retriever: modernSCM([
 
 pipeline {
     agent {
-        label 'agent-amd64-ol9'
+        label 'agent-amd64'
     }
     parameters {
         string(

--- a/pmm/v3/pmm3-aws-staging-start.groovy
+++ b/pmm/v3/pmm3-aws-staging-start.groovy
@@ -10,7 +10,7 @@ library changelog: false, identifier: 'v3lib@master', retriever: modernSCM(
 
 pipeline {
     agent {
-        label 'agent-amd64-ol9'
+        label 'agent-amd64'
     }
     parameters {
         string(

--- a/pmm/v3/pmm3-client-autobuild-amd.groovy
+++ b/pmm/v3/pmm3-client-autobuild-amd.groovy
@@ -10,7 +10,7 @@ library changelog: false, identifier: 'v3lib@master', retriever: modernSCM(
 
 pipeline {
     agent {
-        label params.USE_ONDEMAND ? 'agent-amd64-ol9-ondemand' : 'agent-amd64-ol9'
+        label params.USE_ONDEMAND ? 'agent-amd64-ondemand' : 'agent-amd64'
     }
     parameters {
         string(

--- a/pmm/v3/pmm3-client-autobuild-arm.groovy
+++ b/pmm/v3/pmm3-client-autobuild-arm.groovy
@@ -10,7 +10,7 @@ library changelog: false, identifier: 'v3lib@master', retriever: modernSCM(
 
 pipeline {
     agent {
-        label params.USE_ONDEMAND ? 'agent-arm64-ol9-ondemand' : 'agent-arm64-ol9'
+        label params.USE_ONDEMAND ? 'agent-arm64-ondemand' : 'agent-arm64'
     }
     parameters {
         string(

--- a/pmm/v3/pmm3-ha-eks-cleanup.groovy
+++ b/pmm/v3/pmm3-ha-eks-cleanup.groovy
@@ -1,6 +1,6 @@
 pipeline {
     agent {
-        label 'agent-amd64-ol9'
+        label 'agent-amd64'
     }
 
     triggers {

--- a/pmm/v3/pmm3-ha-eks.groovy
+++ b/pmm/v3/pmm3-ha-eks.groovy
@@ -17,7 +17,7 @@ def cleanupCluster() {
 
 pipeline {
     agent {
-        label 'agent-amd64-ol9'
+        label 'agent-amd64'
     }
 
     options {

--- a/pmm/v3/pmm3-ha-rosa-cleanup.groovy
+++ b/pmm/v3/pmm3-ha-rosa-cleanup.groovy
@@ -1,6 +1,6 @@
 pipeline {
     agent {
-        label 'agent-amd64-ol9'
+        label 'agent-amd64'
     }
 
     triggers {

--- a/pmm/v3/pmm3-ha-rosa.groovy
+++ b/pmm/v3/pmm3-ha-rosa.groovy
@@ -26,7 +26,7 @@ def cleanupCluster() {
 
 pipeline {
     agent {
-        label 'agent-amd64-ol9'
+        label 'agent-amd64'
     }
 
     options {

--- a/pmm/v3/pmm3-image-scanning.groovy
+++ b/pmm/v3/pmm3-image-scanning.groovy
@@ -4,7 +4,7 @@ This job helps run an image scan with Trivy
 
 pipeline {
     agent {
-        label params.USE_ONDEMAND ? 'agent-amd64-ol9-ondemand' : 'agent-amd64-ol9'
+        label params.USE_ONDEMAND ? 'agent-amd64-ondemand' : 'agent-amd64'
     }
     parameters {
         string(

--- a/pmm/v3/pmm3-migration-tests.groovy
+++ b/pmm/v3/pmm3-migration-tests.groovy
@@ -11,7 +11,7 @@ def getMinorVersion(VERSION) {
 
 pipeline {
     agent {
-        label 'agent-amd64-ol9'
+        label 'agent-amd64'
     }
     environment {
         REMOTE_AWS_MYSQL_USER=credentials('pmm-dev-mysql-remote-user')

--- a/pmm/v3/pmm3-ovf-upgrade-tests.groovy
+++ b/pmm/v3/pmm3-ovf-upgrade-tests.groovy
@@ -139,7 +139,7 @@ def versionsList = pmmVersion('ovf')
 
 pipeline {
     agent {
-        label 'agent-amd64-ol9'
+        label 'agent-amd64'
     }
     environment {
         REMOTE_AWS_MYSQL_USER=credentials('pmm-dev-mysql-remote-user')

--- a/pmm/v3/pmm3-package-testing-amd64.groovy
+++ b/pmm/v3/pmm3-package-testing-amd64.groovy
@@ -96,7 +96,7 @@ def latestVersion = pmmVersion('v3').last()
 
 pipeline {
     agent {
-        label 'agent-amd64-ol9'
+        label 'agent-amd64'
     }
     parameters {
         string(

--- a/pmm/v3/pmm3-package-testing-arm64.groovy
+++ b/pmm/v3/pmm3-package-testing-arm64.groovy
@@ -96,7 +96,7 @@ def latestVersion = pmmVersion('v3').last()
 
 pipeline {
     agent {
-        label 'agent-amd64-ol9'
+        label 'agent-amd64'
     }
     parameters {
         string(

--- a/pmm/v3/pmm3-release-candidate.groovy
+++ b/pmm/v3/pmm3-release-candidate.groovy
@@ -121,7 +121,7 @@ String DEFAULT_BRANCH = 'v3'
 
 pipeline {
     agent {
-        label 'agent-amd64-ol9-ondemand'
+        label 'agent-amd64-ondemand'
     }
     parameters {
         string(

--- a/pmm/v3/pmm3-server-autobuild.groovy
+++ b/pmm/v3/pmm3-server-autobuild.groovy
@@ -5,7 +5,7 @@ library changelog: false, identifier: 'lib@master', retriever: modernSCM([
 
 pipeline {
     agent {
-        label params.USE_ONDEMAND ? 'agent-amd64-ol9-ondemand' : 'agent-amd64-ol9'
+        label params.USE_ONDEMAND ? 'agent-amd64-ondemand' : 'agent-amd64'
     }
     parameters {
         string(

--- a/pmm/v3/pmm3-submodules.groovy
+++ b/pmm/v3/pmm3-submodules.groovy
@@ -24,7 +24,7 @@ void addComment(String COMMENT) {
 
 pipeline {
     agent {
-        label 'agent-amd64-ol9'
+        label 'agent-amd64'
     }
     parameters {
         string(

--- a/pmm/v3/pmm3-testsuite.groovy
+++ b/pmm/v3/pmm3-testsuite.groovy
@@ -115,7 +115,7 @@ def latestVersion = pmmVersion()
 
 pipeline {
     agent {
-        label 'agent-amd64-ol9'
+        label 'agent-amd64'
     }
     parameters {
         string(

--- a/pmm/v3/pmm3-ui-tests-matrix.groovy
+++ b/pmm/v3/pmm3-ui-tests-matrix.groovy
@@ -19,7 +19,7 @@ void runUITestsJob(String GIT_COMMIT_HASH, DOCKER_VERSION, CLIENT_VERSION, TAG, 
 
 pipeline {
     agent {
-        label 'agent-amd64-ol9'
+        label 'agent-amd64'
     }
     parameters {
         string(

--- a/pmm/v3/pmm3-ui-tests.groovy
+++ b/pmm/v3/pmm3-ui-tests.groovy
@@ -10,7 +10,7 @@ library changelog: false, identifier: 'v3lib@master', retriever: modernSCM(
 
 pipeline {
     agent {
-        label 'agent-amd64-ol9'
+        label 'agent-amd64'
     }
     environment {
         AZURE_CLIENT_ID=credentials('AZURE_CLIENT_ID');

--- a/pmm/v3/pmm3-upgrade-ami-test-runner.groovy
+++ b/pmm/v3/pmm3-upgrade-ami-test-runner.groovy
@@ -72,7 +72,7 @@ def upgradeVersion = versions[versions.size() - 2]
 
 pipeline {
     agent {
-        label 'agent-amd64-ol9'
+        label 'agent-amd64'
     }
     environment {
         REMOTE_AWS_MYSQL_USER=credentials('pmm-dev-mysql-remote-user')

--- a/pmm/v3/pmm3-upgrade-test-runner.groovy
+++ b/pmm/v3/pmm3-upgrade-test-runner.groovy
@@ -37,7 +37,7 @@ def latestVersion = versionsList.last()
 
 pipeline {
     agent {
-        label 'agent-amd64-ol9'
+        label 'agent-amd64'
     }
     environment {
         REMOTE_AWS_MYSQL_USER=credentials('pmm-dev-mysql-remote-user')

--- a/pmm/v3/pmm3-watchtower-autobuild.groovy
+++ b/pmm/v3/pmm3-watchtower-autobuild.groovy
@@ -5,7 +5,7 @@ library changelog: false, identifier: 'lib@master', retriever: modernSCM([
 
 pipeline {
     agent {
-        label params.USE_ONDEMAND ? 'agent-amd64-ol9-ondemand' : 'agent-amd64-ol9'
+        label params.USE_ONDEMAND ? 'agent-amd64-ondemand' : 'agent-amd64'
     }
     parameters {
         string(


### PR DESCRIPTION
This pull request updates the agent labels across multiple Jenkins pipeline files and improves documentation to reflect recent changes in agent image naming conventions. The main focus is to standardize agent labels by removing the `-ol9` suffix and to ensure documentation and pipelines are consistent with the new image tags.

**Agent label standardization:**

* Replaced all occurrences of `agent-amd64-ol9` with `agent-amd64`, and `agent-arm64-ol9` with `agent-arm64` in Jenkins pipeline files, ensuring pipelines use the updated agent image label.

* Updated parameterized agent labels in pipeline files to use `agent-amd64-ondemand` and `agent-arm64-ondemand` instead of their previous `-ol9` variants, aligning with the new naming convention.

**Documentation updates:**

* Revised the `pmm/README.md` to reference the correct location for agent image build files and updated the list of available agent tags to match the new naming scheme, removing references to `-ol9` and clarifying architecture and usage.