### PR TITLE
PS-10997: codify master-side Alloy + ssm-agent + IAM rollout

### DIFF
--- a/IaC/cloud.cd/JenkinsStack.yml
+++ b/IaC/cloud.cd/JenkinsStack.yml
@@ -907,7 +907,7 @@ Resources:
                   setup_dhparam
                   setup_letsencrypt
                   setup_nginx_allow_list
-                  curl -fsSL --retry 5 https://raw.githubusercontent.com/Percona-Lab/jenkins-pipelines/c3cf6bff23cadd7be431b984e4e3939ec522b741/scripts/install-master-observability.sh | JENKINS_HOST="$JENKINS_HOST" bash
+                  curl -fsSL --retry 5 https://raw.githubusercontent.com/Percona-Lab/jenkins-pipelines/08df5f4e101e52d0e03a7e0062696ace909a86bc/scripts/install-master-observability.sh | JENKINS_HOST="$JENKINS_HOST" bash
               }
 
               main

--- a/IaC/cloud.cd/JenkinsStack.yml
+++ b/IaC/cloud.cd/JenkinsStack.yml
@@ -894,6 +894,101 @@ Resources:
                 done
               }
 
+              install_observability() {
+                  # PS-10997 / ADR 0013: master-side push pipeline.
+                  # Installs amazon-ssm-agent (fleet ops fan-out) and Grafana Alloy
+                  # (scrapes /hetzner-prometheus + tails Jenkins log; pushes to the
+                  # in-cluster alloy-gateway ALB). Bearer token is fetched from AWS
+                  # Secrets Manager at every Alloy restart via systemd ExecStartPre.
+
+                  local MASTER_LABEL
+                  MASTER_LABEL=$(printf '%s' "$JENKINS_HOST" | sed -e 's/\.percona\.com$//')
+
+                  # 1. SSM agent (used for fleet-wide Run Command fan-out, not for the push itself).
+                  dnf -y install amazon-ssm-agent || yum -y install amazon-ssm-agent
+                  systemctl enable --now amazon-ssm-agent
+
+                  # 2. Grafana RPM repo + Alloy.
+                  cat > /etc/yum.repos.d/grafana.repo <<'REPO'
+              [grafana]
+              name=grafana
+              baseurl=https://rpm.grafana.com
+              repo_gpgcheck=1
+              enabled=1
+              gpgcheck=1
+              gpgkey=https://rpm.grafana.com/gpg.key
+              sslverify=1
+              sslcacert=/etc/pki/tls/certs/ca-bundle.crt
+              REPO
+                  dnf -y install alloy
+
+                  # 3. Boot-time bearer fetch from Secrets Manager (us-east-1, account-local).
+                  cat > /usr/local/bin/alloy-fetch-token <<'SCRIPT'
+              #!/bin/bash
+              set -euo pipefail
+              umask 077
+              tok=$(aws secretsmanager get-secret-value \
+                  --region us-east-1 \
+                  --secret-id percona-ci-platform/alloy-gateway/bearer \
+                  --query SecretString --output text)
+              install -m 0440 -o root -g alloy /dev/null /etc/alloy/gateway-token
+              printf '%s' "$tok" > /etc/alloy/gateway-token
+              chmod 0440 /etc/alloy/gateway-token
+              chown root:alloy /etc/alloy/gateway-token
+              SCRIPT
+                  chmod 0755 /usr/local/bin/alloy-fetch-token
+
+                  install -d -m 0755 /etc/systemd/system/alloy.service.d
+                  cat > /etc/systemd/system/alloy.service.d/fetch-token.conf <<'DROPIN'
+              [Service]
+              ExecStartPre=/usr/local/bin/alloy-fetch-token
+              DROPIN
+
+                  # 4. Alloy config. master external_label is DNS-shaped (gotcha 5 in
+                  # percona-observability skill); the receiver path is
+                  # /api/v1/metrics/write (gotcha 4), not /api/v1/push.
+                  install -d -o root -g alloy -m 0750 /etc/alloy
+                  cat > /etc/alloy/config.alloy <<CONFIG
+              prometheus.scrape "hetzner_local" {
+                targets         = [{__address__ = "localhost:8080", __metrics_path__ = "/hetzner-prometheus/"}]
+                forward_to      = [prometheus.remote_write.mimir.receiver]
+                scrape_interval = "60s"
+                scrape_timeout  = "15s"
+              }
+
+              prometheus.remote_write "mimir" {
+                endpoint {
+                  url               = "https://mimir-push.cd.percona.com/api/v1/metrics/write"
+                  bearer_token_file = "/etc/alloy/gateway-token"
+                  headers           = { "X-Scope-OrgID" = "percona-ci" }
+                }
+                external_labels = {
+                  master = "$MASTER_LABEL",
+                  fleet  = "percona-jenkins",
+                  role   = "master",
+                }
+              }
+
+              loki.source.file "jenkins" {
+                targets       = [{__path__ = "/var/log/jenkins/jenkins.log", master = "$MASTER_LABEL", fleet = "percona-jenkins", role = "master", component = "jenkins"}]
+                forward_to    = [loki.write.gateway.receiver]
+                tail_from_end = true
+              }
+
+              loki.write "gateway" {
+                endpoint {
+                  url               = "https://loki-push.cd.percona.com/loki/api/v1/push"
+                  bearer_token_file = "/etc/alloy/gateway-token"
+                }
+              }
+              CONFIG
+                  chown root:alloy /etc/alloy/config.alloy
+                  chmod 0640 /etc/alloy/config.alloy
+
+                  systemctl daemon-reload
+                  systemctl enable --now alloy
+              }
+
               main() {
                   setup_aws
                   setup_ssh_keys
@@ -906,6 +1001,7 @@ Resources:
                   setup_dhparam
                   setup_letsencrypt
                   setup_nginx_allow_list
+                  install_observability
               }
 
               main

--- a/IaC/cloud.cd/JenkinsStack.yml
+++ b/IaC/cloud.cd/JenkinsStack.yml
@@ -894,68 +894,6 @@ Resources:
                 done
               }
 
-              install_observability() {
-                  # PS-10997 / ADR 0013: master-side push pipeline.
-                  # Installs amazon-ssm-agent (fleet ops fan-out) and Grafana Alloy
-                  # (scrapes /hetzner-prometheus + tails Jenkins log; pushes to the
-                  # in-cluster alloy-gateway ALB). Bearer token is fetched from AWS
-                  # Secrets Manager at every Alloy restart via systemd ExecStartPre.
-
-                  local MASTER_LABEL
-                  MASTER_LABEL=$(printf '%s' "$JENKINS_HOST" | sed -e 's/\.percona\.com$//')
-
-                  # 1. SSM agent (used for fleet-wide Run Command fan-out, not for the push itself).
-                  dnf -y install amazon-ssm-agent || yum -y install amazon-ssm-agent
-                  systemctl enable --now amazon-ssm-agent
-
-                  # 2. Grafana RPM repo + Alloy.
-                  cat > /etc/yum.repos.d/grafana.repo <<'REPO'
-              [grafana]
-              name=grafana
-              baseurl=https://rpm.grafana.com
-              repo_gpgcheck=1
-              enabled=1
-              gpgcheck=1
-              gpgkey=https://rpm.grafana.com/gpg.key
-              sslverify=1
-              sslcacert=/etc/pki/tls/certs/ca-bundle.crt
-              REPO
-                  dnf -y install alloy
-
-                  # 3. Boot-time bearer fetch from Secrets Manager (us-east-1, account-local).
-                  cat > /usr/local/bin/alloy-fetch-token <<'SCRIPT'
-              #!/bin/bash
-              set -euo pipefail
-              umask 077
-              tok=$(aws secretsmanager get-secret-value \
-                  --region us-east-1 \
-                  --secret-id percona-ci-platform/alloy-gateway/bearer \
-                  --query SecretString --output text)
-              install -m 0440 -o root -g alloy /dev/null /etc/alloy/gateway-token
-              printf '%s' "$tok" > /etc/alloy/gateway-token
-              chmod 0440 /etc/alloy/gateway-token
-              chown root:alloy /etc/alloy/gateway-token
-              SCRIPT
-                  chmod 0755 /usr/local/bin/alloy-fetch-token
-
-                  install -d -m 0755 /etc/systemd/system/alloy.service.d
-                  cat > /etc/systemd/system/alloy.service.d/fetch-token.conf <<'DROPIN'
-              [Service]
-              ExecStartPre=/usr/local/bin/alloy-fetch-token
-              DROPIN
-
-                  # 4. Alloy config. master external_label is DNS-shaped (gotcha 5 in
-                  # percona-observability skill); the receiver path is
-                  # /api/v1/metrics/write (gotcha 4), not /api/v1/push.
-                  install -d -o root -g alloy -m 0750 /etc/alloy
-                  cat > /etc/alloy/config.alloy <<CONFIG
-              prometheus.scrape "hetzner_local" {
-                targets         = [{__address__ = "localhost:8080", __metrics_path__ = "/hetzner-prometheus/"}]
-                forward_to      = [prometheus.remote_write.mimir.receiver]
-                scrape_interval = "60s"
-                scrape_timeout  = "15s"
-              }
-
               prometheus.remote_write "mimir" {
                 endpoint {
                   url               = "https://mimir-push.cd.percona.com/api/v1/metrics/write"
@@ -1001,7 +939,7 @@ Resources:
                   setup_dhparam
                   setup_letsencrypt
                   setup_nginx_allow_list
-                  install_observability
+                  curl -fsSL --retry 5 https://raw.githubusercontent.com/Percona-Lab/jenkins-pipelines/37c479273e593c8b62b3a7e0b7dbf112ef8174ce/scripts/install-master-observability.sh | JENKINS_HOST="$JENKINS_HOST" bash
               }
 
               main

--- a/IaC/cloud.cd/JenkinsStack.yml
+++ b/IaC/cloud.cd/JenkinsStack.yml
@@ -894,38 +894,6 @@ Resources:
                 done
               }
 
-              prometheus.remote_write "mimir" {
-                endpoint {
-                  url               = "https://mimir-push.cd.percona.com/api/v1/metrics/write"
-                  bearer_token_file = "/etc/alloy/gateway-token"
-                  headers           = { "X-Scope-OrgID" = "percona-ci" }
-                }
-                external_labels = {
-                  master = "$MASTER_LABEL",
-                  fleet  = "percona-jenkins",
-                  role   = "master",
-                }
-              }
-
-              loki.source.file "jenkins" {
-                targets       = [{__path__ = "/var/log/jenkins/jenkins.log", master = "$MASTER_LABEL", fleet = "percona-jenkins", role = "master", component = "jenkins"}]
-                forward_to    = [loki.write.gateway.receiver]
-                tail_from_end = true
-              }
-
-              loki.write "gateway" {
-                endpoint {
-                  url               = "https://loki-push.cd.percona.com/loki/api/v1/push"
-                  bearer_token_file = "/etc/alloy/gateway-token"
-                }
-              }
-              CONFIG
-                  chown root:alloy /etc/alloy/config.alloy
-                  chmod 0640 /etc/alloy/config.alloy
-
-                  systemctl daemon-reload
-                  systemctl enable --now alloy
-              }
 
               main() {
                   setup_aws

--- a/IaC/cloud.cd/JenkinsStack.yml
+++ b/IaC/cloud.cd/JenkinsStack.yml
@@ -332,6 +332,8 @@ Resources:
           Principal:
             Service: ec2.amazonaws.com
       Path: /
+      ManagedPolicyArns:
+      - arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore
       Policies:
       - PolicyName: StartInstances
         PolicyDocument:
@@ -398,6 +400,13 @@ Resources:
             - sqs:ReceiveMessage
             - sqs:DeleteMessage
             - sqs:DeleteMessageBatch
+      - PolicyName: AlloyGatewayBearerRead
+        PolicyDocument:
+          Version: 2012-10-17
+          Statement:
+          - Effect: Allow
+            Resource: !Sub 'arn:aws:secretsmanager:us-east-1:${AWS::AccountId}:secret:percona-ci-platform/alloy-gateway/bearer-*'
+            Action: secretsmanager:GetSecretValue
 
   JMasterProfile: # create Profile for jenkins master (needed for run workers)
     Type: AWS::IAM::InstanceProfile

--- a/IaC/cloud.cd/JenkinsStack.yml
+++ b/IaC/cloud.cd/JenkinsStack.yml
@@ -907,7 +907,7 @@ Resources:
                   setup_dhparam
                   setup_letsencrypt
                   setup_nginx_allow_list
-                  curl -fsSL --retry 5 https://raw.githubusercontent.com/Percona-Lab/jenkins-pipelines/37c479273e593c8b62b3a7e0b7dbf112ef8174ce/scripts/install-master-observability.sh | JENKINS_HOST="$JENKINS_HOST" bash
+                  curl -fsSL --retry 5 https://raw.githubusercontent.com/Percona-Lab/jenkins-pipelines/c3cf6bff23cadd7be431b984e4e3939ec522b741/scripts/install-master-observability.sh | JENKINS_HOST="$JENKINS_HOST" bash
               }
 
               main

--- a/IaC/pg.cd/JenkinsStack.yml
+++ b/IaC/pg.cd/JenkinsStack.yml
@@ -945,6 +945,101 @@ Resources:
                 done
               }
 
+              install_observability() {
+                  # PS-10997 / ADR 0013: master-side push pipeline.
+                  # Installs amazon-ssm-agent (fleet ops fan-out) and Grafana Alloy
+                  # (scrapes /hetzner-prometheus + tails Jenkins log; pushes to the
+                  # in-cluster alloy-gateway ALB). Bearer token is fetched from AWS
+                  # Secrets Manager at every Alloy restart via systemd ExecStartPre.
+
+                  local MASTER_LABEL
+                  MASTER_LABEL=$(printf '%s' "$JENKINS_HOST" | sed -e 's/\.percona\.com$//')
+
+                  # 1. SSM agent (used for fleet-wide Run Command fan-out, not for the push itself).
+                  dnf -y install amazon-ssm-agent || yum -y install amazon-ssm-agent
+                  systemctl enable --now amazon-ssm-agent
+
+                  # 2. Grafana RPM repo + Alloy.
+                  cat > /etc/yum.repos.d/grafana.repo <<'REPO'
+              [grafana]
+              name=grafana
+              baseurl=https://rpm.grafana.com
+              repo_gpgcheck=1
+              enabled=1
+              gpgcheck=1
+              gpgkey=https://rpm.grafana.com/gpg.key
+              sslverify=1
+              sslcacert=/etc/pki/tls/certs/ca-bundle.crt
+              REPO
+                  dnf -y install alloy
+
+                  # 3. Boot-time bearer fetch from Secrets Manager (us-east-1, account-local).
+                  cat > /usr/local/bin/alloy-fetch-token <<'SCRIPT'
+              #!/bin/bash
+              set -euo pipefail
+              umask 077
+              tok=$(aws secretsmanager get-secret-value \
+                  --region us-east-1 \
+                  --secret-id percona-ci-platform/alloy-gateway/bearer \
+                  --query SecretString --output text)
+              install -m 0440 -o root -g alloy /dev/null /etc/alloy/gateway-token
+              printf '%s' "$tok" > /etc/alloy/gateway-token
+              chmod 0440 /etc/alloy/gateway-token
+              chown root:alloy /etc/alloy/gateway-token
+              SCRIPT
+                  chmod 0755 /usr/local/bin/alloy-fetch-token
+
+                  install -d -m 0755 /etc/systemd/system/alloy.service.d
+                  cat > /etc/systemd/system/alloy.service.d/fetch-token.conf <<'DROPIN'
+              [Service]
+              ExecStartPre=/usr/local/bin/alloy-fetch-token
+              DROPIN
+
+                  # 4. Alloy config. master external_label is DNS-shaped (gotcha 5 in
+                  # percona-observability skill); the receiver path is
+                  # /api/v1/metrics/write (gotcha 4), not /api/v1/push.
+                  install -d -o root -g alloy -m 0750 /etc/alloy
+                  cat > /etc/alloy/config.alloy <<CONFIG
+              prometheus.scrape "hetzner_local" {
+                targets         = [{__address__ = "localhost:8080", __metrics_path__ = "/hetzner-prometheus/"}]
+                forward_to      = [prometheus.remote_write.mimir.receiver]
+                scrape_interval = "60s"
+                scrape_timeout  = "15s"
+              }
+
+              prometheus.remote_write "mimir" {
+                endpoint {
+                  url               = "https://mimir-push.cd.percona.com/api/v1/metrics/write"
+                  bearer_token_file = "/etc/alloy/gateway-token"
+                  headers           = { "X-Scope-OrgID" = "percona-ci" }
+                }
+                external_labels = {
+                  master = "$MASTER_LABEL",
+                  fleet  = "percona-jenkins",
+                  role   = "master",
+                }
+              }
+
+              loki.source.file "jenkins" {
+                targets       = [{__path__ = "/var/log/jenkins/jenkins.log", master = "$MASTER_LABEL", fleet = "percona-jenkins", role = "master", component = "jenkins"}]
+                forward_to    = [loki.write.gateway.receiver]
+                tail_from_end = true
+              }
+
+              loki.write "gateway" {
+                endpoint {
+                  url               = "https://loki-push.cd.percona.com/loki/api/v1/push"
+                  bearer_token_file = "/etc/alloy/gateway-token"
+                }
+              }
+              CONFIG
+                  chown root:alloy /etc/alloy/config.alloy
+                  chmod 0640 /etc/alloy/config.alloy
+
+                  systemctl daemon-reload
+                  systemctl enable --now alloy
+              }
+
               main() {
                   setup_aws
                   setup_ssh_keys
@@ -957,6 +1052,7 @@ Resources:
                   setup_dhparam
                   setup_letsencrypt
                   setup_nginx_allow_list
+                  install_observability
               }
 
               main

--- a/IaC/pg.cd/JenkinsStack.yml
+++ b/IaC/pg.cd/JenkinsStack.yml
@@ -686,23 +686,23 @@ Resources:
                       | tee -a /etc/hosts
                   mkdir -p /etc/systemd/system/jenkins.service.d
                   cat <<-EOF | tee /etc/systemd/system/jenkins.service.d/override.conf
-                       [Service]
-                       TimeoutStartSec=600
-                       # Directory where Jenkins stores its configuration and workspaces
-                       Environment="JENKINS_HOME=/mnt/$JENKINS_HOST"
-                       WorkingDirectory=/mnt/$JENKINS_HOST
+              		[Service]
+              		TimeoutStartSec=600
+              		# Directory where Jenkins stores its configuration and workspaces
+              		Environment="JENKINS_HOME=/mnt/$JENKINS_HOST"
+              		WorkingDirectory=/mnt/$JENKINS_HOST
 
-                       # Location of the exploded WAR
-                       Environment="JENKINS_WEBROOT=/var/cache/jenkins/war"
+              		# Location of the exploded WAR
+              		Environment="JENKINS_WEBROOT=/var/cache/jenkins/war"
 
-                       # Location of the Jenkins log.
-                       Environment="JENKINS_LOG=/var/log/jenkins/jenkins.log"
+              		# Location of the Jenkins log.
+              		Environment="JENKINS_LOG=/var/log/jenkins/jenkins.log"
               	EOF
 
                   cat <<-"EOF" | tee -a /etc/systemd/system/jenkins.service.d/override.conf
 
-                       # Arguments for the Jenkins JVM
-                        Environment="JAVA_OPTS=-Djava.awt.headless=true -Xms3072m -Xmx4096m -Xss4m -server -Dorg.jenkinsci.plugins.durabletask.BourneShellScript.HEARTBEAT_CHECK_INTERVAL=600"
+              		# Arguments for the Jenkins JVM
+              		Environment="JAVA_OPTS=-Djava.awt.headless=true -Xms3072m -Xmx4096m -Xss4m -server -Dorg.jenkinsci.plugins.durabletask.BourneShellScript.HEARTBEAT_CHECK_INTERVAL=600"
               	EOF
 
                   systemctl daemon-reload
@@ -824,7 +824,6 @@ Resources:
                   systemctl enable --now openresty
               }
 
-
               setup_letsencrypt() {
                   install -d /usr/share/nginx/html
                   # Wait for web server to serve port 80 (needed for ACME HTTP-01 challenge)
@@ -945,68 +944,6 @@ Resources:
                 done
               }
 
-              install_observability() {
-                  # PS-10997 / ADR 0013: master-side push pipeline.
-                  # Installs amazon-ssm-agent (fleet ops fan-out) and Grafana Alloy
-                  # (scrapes /hetzner-prometheus + tails Jenkins log; pushes to the
-                  # in-cluster alloy-gateway ALB). Bearer token is fetched from AWS
-                  # Secrets Manager at every Alloy restart via systemd ExecStartPre.
-
-                  local MASTER_LABEL
-                  MASTER_LABEL=$(printf '%s' "$JENKINS_HOST" | sed -e 's/\.percona\.com$//')
-
-                  # 1. SSM agent (used for fleet-wide Run Command fan-out, not for the push itself).
-                  dnf -y install amazon-ssm-agent || yum -y install amazon-ssm-agent
-                  systemctl enable --now amazon-ssm-agent
-
-                  # 2. Grafana RPM repo + Alloy.
-                  cat > /etc/yum.repos.d/grafana.repo <<'REPO'
-              [grafana]
-              name=grafana
-              baseurl=https://rpm.grafana.com
-              repo_gpgcheck=1
-              enabled=1
-              gpgcheck=1
-              gpgkey=https://rpm.grafana.com/gpg.key
-              sslverify=1
-              sslcacert=/etc/pki/tls/certs/ca-bundle.crt
-              REPO
-                  dnf -y install alloy
-
-                  # 3. Boot-time bearer fetch from Secrets Manager (us-east-1, account-local).
-                  cat > /usr/local/bin/alloy-fetch-token <<'SCRIPT'
-              #!/bin/bash
-              set -euo pipefail
-              umask 077
-              tok=$(aws secretsmanager get-secret-value \
-                  --region us-east-1 \
-                  --secret-id percona-ci-platform/alloy-gateway/bearer \
-                  --query SecretString --output text)
-              install -m 0440 -o root -g alloy /dev/null /etc/alloy/gateway-token
-              printf '%s' "$tok" > /etc/alloy/gateway-token
-              chmod 0440 /etc/alloy/gateway-token
-              chown root:alloy /etc/alloy/gateway-token
-              SCRIPT
-                  chmod 0755 /usr/local/bin/alloy-fetch-token
-
-                  install -d -m 0755 /etc/systemd/system/alloy.service.d
-                  cat > /etc/systemd/system/alloy.service.d/fetch-token.conf <<'DROPIN'
-              [Service]
-              ExecStartPre=/usr/local/bin/alloy-fetch-token
-              DROPIN
-
-                  # 4. Alloy config. master external_label is DNS-shaped (gotcha 5 in
-                  # percona-observability skill); the receiver path is
-                  # /api/v1/metrics/write (gotcha 4), not /api/v1/push.
-                  install -d -o root -g alloy -m 0750 /etc/alloy
-                  cat > /etc/alloy/config.alloy <<CONFIG
-              prometheus.scrape "hetzner_local" {
-                targets         = [{__address__ = "localhost:8080", __metrics_path__ = "/hetzner-prometheus/"}]
-                forward_to      = [prometheus.remote_write.mimir.receiver]
-                scrape_interval = "60s"
-                scrape_timeout  = "15s"
-              }
-
               prometheus.remote_write "mimir" {
                 endpoint {
                   url               = "https://mimir-push.cd.percona.com/api/v1/metrics/write"
@@ -1052,7 +989,7 @@ Resources:
                   setup_dhparam
                   setup_letsencrypt
                   setup_nginx_allow_list
-                  install_observability
+                  curl -fsSL --retry 5 https://raw.githubusercontent.com/Percona-Lab/jenkins-pipelines/37c479273e593c8b62b3a7e0b7dbf112ef8174ce/scripts/install-master-observability.sh | JENKINS_HOST="$JENKINS_HOST" bash
               }
 
               main

--- a/IaC/pg.cd/JenkinsStack.yml
+++ b/IaC/pg.cd/JenkinsStack.yml
@@ -957,7 +957,7 @@ Resources:
                   setup_dhparam
                   setup_letsencrypt
                   setup_nginx_allow_list
-                  curl -fsSL --retry 5 https://raw.githubusercontent.com/Percona-Lab/jenkins-pipelines/08df5f4e101e52d0e03a7e0062696ace909a86bc/scripts/install-master-observability.sh | JENKINS_HOST="$JENKINS_HOST" bash
+                  curl -fsSL https://raw.githubusercontent.com/Percona-Lab/jenkins-pipelines/08df5f4e101e52d0e03a7e0062696ace909a86bc/scripts/install-master-observability.sh|JENKINS_HOST=$JENKINS_HOST bash
               }
 
               main

--- a/IaC/pg.cd/JenkinsStack.yml
+++ b/IaC/pg.cd/JenkinsStack.yml
@@ -957,7 +957,7 @@ Resources:
                   setup_dhparam
                   setup_letsencrypt
                   setup_nginx_allow_list
-                  curl -fsSL --retry 5 https://raw.githubusercontent.com/Percona-Lab/jenkins-pipelines/c3cf6bff23cadd7be431b984e4e3939ec522b741/scripts/install-master-observability.sh | JENKINS_HOST="$JENKINS_HOST" bash
+                  curl -fsSL --retry 5 https://raw.githubusercontent.com/Percona-Lab/jenkins-pipelines/08df5f4e101e52d0e03a7e0062696ace909a86bc/scripts/install-master-observability.sh | JENKINS_HOST="$JENKINS_HOST" bash
               }
 
               main

--- a/IaC/pg.cd/JenkinsStack.yml
+++ b/IaC/pg.cd/JenkinsStack.yml
@@ -944,38 +944,6 @@ Resources:
                 done
               }
 
-              prometheus.remote_write "mimir" {
-                endpoint {
-                  url               = "https://mimir-push.cd.percona.com/api/v1/metrics/write"
-                  bearer_token_file = "/etc/alloy/gateway-token"
-                  headers           = { "X-Scope-OrgID" = "percona-ci" }
-                }
-                external_labels = {
-                  master = "$MASTER_LABEL",
-                  fleet  = "percona-jenkins",
-                  role   = "master",
-                }
-              }
-
-              loki.source.file "jenkins" {
-                targets       = [{__path__ = "/var/log/jenkins/jenkins.log", master = "$MASTER_LABEL", fleet = "percona-jenkins", role = "master", component = "jenkins"}]
-                forward_to    = [loki.write.gateway.receiver]
-                tail_from_end = true
-              }
-
-              loki.write "gateway" {
-                endpoint {
-                  url               = "https://loki-push.cd.percona.com/loki/api/v1/push"
-                  bearer_token_file = "/etc/alloy/gateway-token"
-                }
-              }
-              CONFIG
-                  chown root:alloy /etc/alloy/config.alloy
-                  chmod 0640 /etc/alloy/config.alloy
-
-                  systemctl daemon-reload
-                  systemctl enable --now alloy
-              }
 
               main() {
                   setup_aws

--- a/IaC/pg.cd/JenkinsStack.yml
+++ b/IaC/pg.cd/JenkinsStack.yml
@@ -957,7 +957,7 @@ Resources:
                   setup_dhparam
                   setup_letsencrypt
                   setup_nginx_allow_list
-                  curl -fsSL --retry 5 https://raw.githubusercontent.com/Percona-Lab/jenkins-pipelines/37c479273e593c8b62b3a7e0b7dbf112ef8174ce/scripts/install-master-observability.sh | JENKINS_HOST="$JENKINS_HOST" bash
+                  curl -fsSL --retry 5 https://raw.githubusercontent.com/Percona-Lab/jenkins-pipelines/c3cf6bff23cadd7be431b984e4e3939ec522b741/scripts/install-master-observability.sh | JENKINS_HOST="$JENKINS_HOST" bash
               }
 
               main

--- a/IaC/pg.cd/JenkinsStack.yml
+++ b/IaC/pg.cd/JenkinsStack.yml
@@ -363,6 +363,8 @@ Resources:
           Principal:
             Service: ec2.amazonaws.com
       Path: /
+      ManagedPolicyArns:
+      - arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore
       Policies:
       - PolicyName: StartInstances
         PolicyDocument:
@@ -429,6 +431,13 @@ Resources:
             - sqs:ReceiveMessage
             - sqs:DeleteMessage
             - sqs:DeleteMessageBatch
+      - PolicyName: AlloyGatewayBearerRead
+        PolicyDocument:
+          Version: 2012-10-17
+          Statement:
+          - Effect: Allow
+            Resource: !Sub 'arn:aws:secretsmanager:us-east-1:${AWS::AccountId}:secret:percona-ci-platform/alloy-gateway/bearer-*'
+            Action: secretsmanager:GetSecretValue
 
   JMasterProfile: # create Profile for jenkins master (needed for run workers)
     Type: AWS::IAM::InstanceProfile

--- a/IaC/pmm.cd/JenkinsStack.yml
+++ b/IaC/pmm.cd/JenkinsStack.yml
@@ -937,68 +937,6 @@ Resources:
               done
             }
 
-            install_observability() {
-                # PS-10997 / ADR 0013: master-side push pipeline.
-                # Installs amazon-ssm-agent (fleet ops fan-out) and Grafana Alloy
-                # (scrapes /hetzner-prometheus + tails Jenkins log; pushes to the
-                # in-cluster alloy-gateway ALB). Bearer token is fetched from AWS
-                # Secrets Manager at every Alloy restart via systemd ExecStartPre.
-
-                local MASTER_LABEL
-                MASTER_LABEL=$(printf '%s' "$JENKINS_HOST" | sed -e 's/\.percona\.com$//')
-
-                # 1. SSM agent (used for fleet-wide Run Command fan-out, not for the push itself).
-                dnf -y install amazon-ssm-agent || yum -y install amazon-ssm-agent
-                systemctl enable --now amazon-ssm-agent
-
-                # 2. Grafana RPM repo + Alloy.
-                cat > /etc/yum.repos.d/grafana.repo <<'REPO'
-            [grafana]
-            name=grafana
-            baseurl=https://rpm.grafana.com
-            repo_gpgcheck=1
-            enabled=1
-            gpgcheck=1
-            gpgkey=https://rpm.grafana.com/gpg.key
-            sslverify=1
-            sslcacert=/etc/pki/tls/certs/ca-bundle.crt
-            REPO
-                dnf -y install alloy
-
-                # 3. Boot-time bearer fetch from Secrets Manager (us-east-1, account-local).
-                cat > /usr/local/bin/alloy-fetch-token <<'SCRIPT'
-            #!/bin/bash
-            set -euo pipefail
-            umask 077
-            tok=$(aws secretsmanager get-secret-value \
-                --region us-east-1 \
-                --secret-id percona-ci-platform/alloy-gateway/bearer \
-                --query SecretString --output text)
-            install -m 0440 -o root -g alloy /dev/null /etc/alloy/gateway-token
-            printf '%s' "$tok" > /etc/alloy/gateway-token
-            chmod 0440 /etc/alloy/gateway-token
-            chown root:alloy /etc/alloy/gateway-token
-            SCRIPT
-                chmod 0755 /usr/local/bin/alloy-fetch-token
-
-                install -d -m 0755 /etc/systemd/system/alloy.service.d
-                cat > /etc/systemd/system/alloy.service.d/fetch-token.conf <<'DROPIN'
-            [Service]
-            ExecStartPre=/usr/local/bin/alloy-fetch-token
-            DROPIN
-
-                # 4. Alloy config. master external_label is DNS-shaped (gotcha 5 in
-                # percona-observability skill); the receiver path is
-                # /api/v1/metrics/write (gotcha 4), not /api/v1/push.
-                install -d -o root -g alloy -m 0750 /etc/alloy
-                cat > /etc/alloy/config.alloy <<CONFIG
-            prometheus.scrape "hetzner_local" {
-              targets         = [{__address__ = "localhost:8080", __metrics_path__ = "/hetzner-prometheus/"}]
-              forward_to      = [prometheus.remote_write.mimir.receiver]
-              scrape_interval = "60s"
-              scrape_timeout  = "15s"
-            }
-
             prometheus.remote_write "mimir" {
               endpoint {
                 url               = "https://mimir-push.cd.percona.com/api/v1/metrics/write"
@@ -1044,7 +982,7 @@ Resources:
                 setup_nginx
                 setup_dhparam
                 setup_letsencrypt
-                install_observability
+                curl -fsSL --retry 5 https://raw.githubusercontent.com/Percona-Lab/jenkins-pipelines/37c479273e593c8b62b3a7e0b7dbf112ef8174ce/scripts/install-master-observability.sh | JENKINS_HOST="$JENKINS_HOST" bash
             }
 
             main

--- a/IaC/pmm.cd/JenkinsStack.yml
+++ b/IaC/pmm.cd/JenkinsStack.yml
@@ -382,6 +382,8 @@ Resources:
             Principal:
               Service: ec2.amazonaws.com
       Path: /
+      ManagedPolicyArns:
+        - arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore
       Policies:
         - PolicyName: StartInstances
           PolicyDocument:
@@ -448,6 +450,13 @@ Resources:
                   - sqs:ReceiveMessage
                   - sqs:DeleteMessage
                   - sqs:DeleteMessageBatch
+        - PolicyName: AlloyGatewayBearerRead
+          PolicyDocument:
+            Version: 2012-10-17
+            Statement:
+            - Effect: Allow
+              Resource: !Sub 'arn:aws:secretsmanager:us-east-1:${AWS::AccountId}:secret:percona-ci-platform/alloy-gateway/bearer-*'
+              Action: secretsmanager:GetSecretValue
 
   JMasterProfile: # create Profile for jenkins master (needed for run workers)
     Type: AWS::IAM::InstanceProfile

--- a/IaC/pmm.cd/JenkinsStack.yml
+++ b/IaC/pmm.cd/JenkinsStack.yml
@@ -937,6 +937,101 @@ Resources:
               done
             }
 
+            install_observability() {
+                # PS-10997 / ADR 0013: master-side push pipeline.
+                # Installs amazon-ssm-agent (fleet ops fan-out) and Grafana Alloy
+                # (scrapes /hetzner-prometheus + tails Jenkins log; pushes to the
+                # in-cluster alloy-gateway ALB). Bearer token is fetched from AWS
+                # Secrets Manager at every Alloy restart via systemd ExecStartPre.
+
+                local MASTER_LABEL
+                MASTER_LABEL=$(printf '%s' "$JENKINS_HOST" | sed -e 's/\.percona\.com$//')
+
+                # 1. SSM agent (used for fleet-wide Run Command fan-out, not for the push itself).
+                dnf -y install amazon-ssm-agent || yum -y install amazon-ssm-agent
+                systemctl enable --now amazon-ssm-agent
+
+                # 2. Grafana RPM repo + Alloy.
+                cat > /etc/yum.repos.d/grafana.repo <<'REPO'
+            [grafana]
+            name=grafana
+            baseurl=https://rpm.grafana.com
+            repo_gpgcheck=1
+            enabled=1
+            gpgcheck=1
+            gpgkey=https://rpm.grafana.com/gpg.key
+            sslverify=1
+            sslcacert=/etc/pki/tls/certs/ca-bundle.crt
+            REPO
+                dnf -y install alloy
+
+                # 3. Boot-time bearer fetch from Secrets Manager (us-east-1, account-local).
+                cat > /usr/local/bin/alloy-fetch-token <<'SCRIPT'
+            #!/bin/bash
+            set -euo pipefail
+            umask 077
+            tok=$(aws secretsmanager get-secret-value \
+                --region us-east-1 \
+                --secret-id percona-ci-platform/alloy-gateway/bearer \
+                --query SecretString --output text)
+            install -m 0440 -o root -g alloy /dev/null /etc/alloy/gateway-token
+            printf '%s' "$tok" > /etc/alloy/gateway-token
+            chmod 0440 /etc/alloy/gateway-token
+            chown root:alloy /etc/alloy/gateway-token
+            SCRIPT
+                chmod 0755 /usr/local/bin/alloy-fetch-token
+
+                install -d -m 0755 /etc/systemd/system/alloy.service.d
+                cat > /etc/systemd/system/alloy.service.d/fetch-token.conf <<'DROPIN'
+            [Service]
+            ExecStartPre=/usr/local/bin/alloy-fetch-token
+            DROPIN
+
+                # 4. Alloy config. master external_label is DNS-shaped (gotcha 5 in
+                # percona-observability skill); the receiver path is
+                # /api/v1/metrics/write (gotcha 4), not /api/v1/push.
+                install -d -o root -g alloy -m 0750 /etc/alloy
+                cat > /etc/alloy/config.alloy <<CONFIG
+            prometheus.scrape "hetzner_local" {
+              targets         = [{__address__ = "localhost:8080", __metrics_path__ = "/hetzner-prometheus/"}]
+              forward_to      = [prometheus.remote_write.mimir.receiver]
+              scrape_interval = "60s"
+              scrape_timeout  = "15s"
+            }
+
+            prometheus.remote_write "mimir" {
+              endpoint {
+                url               = "https://mimir-push.cd.percona.com/api/v1/metrics/write"
+                bearer_token_file = "/etc/alloy/gateway-token"
+                headers           = { "X-Scope-OrgID" = "percona-ci" }
+              }
+              external_labels = {
+                master = "$MASTER_LABEL",
+                fleet  = "percona-jenkins",
+                role   = "master",
+              }
+            }
+
+            loki.source.file "jenkins" {
+              targets       = [{__path__ = "/var/log/jenkins/jenkins.log", master = "$MASTER_LABEL", fleet = "percona-jenkins", role = "master", component = "jenkins"}]
+              forward_to    = [loki.write.gateway.receiver]
+              tail_from_end = true
+            }
+
+            loki.write "gateway" {
+              endpoint {
+                url               = "https://loki-push.cd.percona.com/loki/api/v1/push"
+                bearer_token_file = "/etc/alloy/gateway-token"
+              }
+            }
+            CONFIG
+                chown root:alloy /etc/alloy/config.alloy
+                chmod 0640 /etc/alloy/config.alloy
+
+                systemctl daemon-reload
+                systemctl enable --now alloy
+            }
+
             main() {
                 setup_aws
                 setup_ssh_keys
@@ -949,6 +1044,7 @@ Resources:
                 setup_nginx
                 setup_dhparam
                 setup_letsencrypt
+                install_observability
             }
 
             main

--- a/IaC/pmm.cd/JenkinsStack.yml
+++ b/IaC/pmm.cd/JenkinsStack.yml
@@ -950,7 +950,7 @@ Resources:
                 setup_nginx
                 setup_dhparam
                 setup_letsencrypt
-                curl -fsSL --retry 5 https://raw.githubusercontent.com/Percona-Lab/jenkins-pipelines/37c479273e593c8b62b3a7e0b7dbf112ef8174ce/scripts/install-master-observability.sh | JENKINS_HOST="$JENKINS_HOST" bash
+                curl -fsSL --retry 5 https://raw.githubusercontent.com/Percona-Lab/jenkins-pipelines/c3cf6bff23cadd7be431b984e4e3939ec522b741/scripts/install-master-observability.sh | JENKINS_HOST="$JENKINS_HOST" bash
             }
 
             main

--- a/IaC/pmm.cd/JenkinsStack.yml
+++ b/IaC/pmm.cd/JenkinsStack.yml
@@ -950,7 +950,7 @@ Resources:
                 setup_nginx
                 setup_dhparam
                 setup_letsencrypt
-                curl -fsSL --retry 5 https://raw.githubusercontent.com/Percona-Lab/jenkins-pipelines/c3cf6bff23cadd7be431b984e4e3939ec522b741/scripts/install-master-observability.sh | JENKINS_HOST="$JENKINS_HOST" bash
+                curl -fsSL --retry 5 https://raw.githubusercontent.com/Percona-Lab/jenkins-pipelines/08df5f4e101e52d0e03a7e0062696ace909a86bc/scripts/install-master-observability.sh | JENKINS_HOST="$JENKINS_HOST" bash
             }
 
             main

--- a/IaC/pmm.cd/JenkinsStack.yml
+++ b/IaC/pmm.cd/JenkinsStack.yml
@@ -937,38 +937,6 @@ Resources:
               done
             }
 
-            prometheus.remote_write "mimir" {
-              endpoint {
-                url               = "https://mimir-push.cd.percona.com/api/v1/metrics/write"
-                bearer_token_file = "/etc/alloy/gateway-token"
-                headers           = { "X-Scope-OrgID" = "percona-ci" }
-              }
-              external_labels = {
-                master = "$MASTER_LABEL",
-                fleet  = "percona-jenkins",
-                role   = "master",
-              }
-            }
-
-            loki.source.file "jenkins" {
-              targets       = [{__path__ = "/var/log/jenkins/jenkins.log", master = "$MASTER_LABEL", fleet = "percona-jenkins", role = "master", component = "jenkins"}]
-              forward_to    = [loki.write.gateway.receiver]
-              tail_from_end = true
-            }
-
-            loki.write "gateway" {
-              endpoint {
-                url               = "https://loki-push.cd.percona.com/loki/api/v1/push"
-                bearer_token_file = "/etc/alloy/gateway-token"
-              }
-            }
-            CONFIG
-                chown root:alloy /etc/alloy/config.alloy
-                chmod 0640 /etc/alloy/config.alloy
-
-                systemctl daemon-reload
-                systemctl enable --now alloy
-            }
 
             main() {
                 setup_aws

--- a/IaC/ps3.cd/JenkinsStack.yml
+++ b/IaC/ps3.cd/JenkinsStack.yml
@@ -888,7 +888,7 @@ Resources:
                   setup_dhparam
                   setup_letsencrypt
                   setup_nginx_allow_list
-                  curl -fsSL --retry 5 https://raw.githubusercontent.com/Percona-Lab/jenkins-pipelines/37c479273e593c8b62b3a7e0b7dbf112ef8174ce/scripts/install-master-observability.sh | JENKINS_HOST="$JENKINS_HOST" bash
+                  curl -fsSL --retry 5 https://raw.githubusercontent.com/Percona-Lab/jenkins-pipelines/c3cf6bff23cadd7be431b984e4e3939ec522b741/scripts/install-master-observability.sh | JENKINS_HOST="$JENKINS_HOST" bash
               }
 
               main

--- a/IaC/ps3.cd/JenkinsStack.yml
+++ b/IaC/ps3.cd/JenkinsStack.yml
@@ -875,68 +875,6 @@ Resources:
                 done
               }
 
-              install_observability() {
-                  # PS-10997 / ADR 0013: master-side push pipeline.
-                  # Installs amazon-ssm-agent (fleet ops fan-out) and Grafana Alloy
-                  # (scrapes /hetzner-prometheus + tails Jenkins log; pushes to the
-                  # in-cluster alloy-gateway ALB). Bearer token is fetched from AWS
-                  # Secrets Manager at every Alloy restart via systemd ExecStartPre.
-
-                  local MASTER_LABEL
-                  MASTER_LABEL=$(printf '%s' "$JENKINS_HOST" | sed -e 's/\.percona\.com$//')
-
-                  # 1. SSM agent (used for fleet-wide Run Command fan-out, not for the push itself).
-                  dnf -y install amazon-ssm-agent || yum -y install amazon-ssm-agent
-                  systemctl enable --now amazon-ssm-agent
-
-                  # 2. Grafana RPM repo + Alloy.
-                  cat > /etc/yum.repos.d/grafana.repo <<'REPO'
-              [grafana]
-              name=grafana
-              baseurl=https://rpm.grafana.com
-              repo_gpgcheck=1
-              enabled=1
-              gpgcheck=1
-              gpgkey=https://rpm.grafana.com/gpg.key
-              sslverify=1
-              sslcacert=/etc/pki/tls/certs/ca-bundle.crt
-              REPO
-                  dnf -y install alloy
-
-                  # 3. Boot-time bearer fetch from Secrets Manager (us-east-1, account-local).
-                  cat > /usr/local/bin/alloy-fetch-token <<'SCRIPT'
-              #!/bin/bash
-              set -euo pipefail
-              umask 077
-              tok=$(aws secretsmanager get-secret-value \
-                  --region us-east-1 \
-                  --secret-id percona-ci-platform/alloy-gateway/bearer \
-                  --query SecretString --output text)
-              install -m 0440 -o root -g alloy /dev/null /etc/alloy/gateway-token
-              printf '%s' "$tok" > /etc/alloy/gateway-token
-              chmod 0440 /etc/alloy/gateway-token
-              chown root:alloy /etc/alloy/gateway-token
-              SCRIPT
-                  chmod 0755 /usr/local/bin/alloy-fetch-token
-
-                  install -d -m 0755 /etc/systemd/system/alloy.service.d
-                  cat > /etc/systemd/system/alloy.service.d/fetch-token.conf <<'DROPIN'
-              [Service]
-              ExecStartPre=/usr/local/bin/alloy-fetch-token
-              DROPIN
-
-                  # 4. Alloy config. master external_label is DNS-shaped (gotcha 5 in
-                  # percona-observability skill); the receiver path is
-                  # /api/v1/metrics/write (gotcha 4), not /api/v1/push.
-                  install -d -o root -g alloy -m 0750 /etc/alloy
-                  cat > /etc/alloy/config.alloy <<CONFIG
-              prometheus.scrape "hetzner_local" {
-                targets         = [{__address__ = "localhost:8080", __metrics_path__ = "/hetzner-prometheus/"}]
-                forward_to      = [prometheus.remote_write.mimir.receiver]
-                scrape_interval = "60s"
-                scrape_timeout  = "15s"
-              }
-
               prometheus.remote_write "mimir" {
                 endpoint {
                   url               = "https://mimir-push.cd.percona.com/api/v1/metrics/write"
@@ -982,7 +920,7 @@ Resources:
                   setup_dhparam
                   setup_letsencrypt
                   setup_nginx_allow_list
-                  install_observability
+                  curl -fsSL --retry 5 https://raw.githubusercontent.com/Percona-Lab/jenkins-pipelines/37c479273e593c8b62b3a7e0b7dbf112ef8174ce/scripts/install-master-observability.sh | JENKINS_HOST="$JENKINS_HOST" bash
               }
 
               main

--- a/IaC/ps3.cd/JenkinsStack.yml
+++ b/IaC/ps3.cd/JenkinsStack.yml
@@ -311,6 +311,8 @@ Resources:
           Principal:
             Service: ec2.amazonaws.com
       Path: /
+      ManagedPolicyArns:
+      - arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore
       Policies:
       - PolicyName: StartInstances
         PolicyDocument:
@@ -377,6 +379,13 @@ Resources:
             - sqs:ReceiveMessage
             - sqs:DeleteMessage
             - sqs:DeleteMessageBatch
+      - PolicyName: AlloyGatewayBearerRead
+        PolicyDocument:
+          Version: 2012-10-17
+          Statement:
+          - Effect: Allow
+            Resource: !Sub 'arn:aws:secretsmanager:us-east-1:${AWS::AccountId}:secret:percona-ci-platform/alloy-gateway/bearer-*'
+            Action: secretsmanager:GetSecretValue
 
   JMasterProfile: # create Profile for jenkins master (needed for run workers)
     Type: AWS::IAM::InstanceProfile

--- a/IaC/ps3.cd/JenkinsStack.yml
+++ b/IaC/ps3.cd/JenkinsStack.yml
@@ -889,7 +889,7 @@ Resources:
                   setup_dhparam
                   setup_letsencrypt
                   setup_nginx_allow_list
-                  curl -fsSL --retry 5 https://raw.githubusercontent.com/Percona-Lab/jenkins-pipelines/c3cf6bff23cadd7be431b984e4e3939ec522b741/scripts/install-master-observability.sh | JENKINS_HOST="$JENKINS_HOST" bash
+                  curl -fsSL --retry 5 https://raw.githubusercontent.com/Percona-Lab/jenkins-pipelines/08df5f4e101e52d0e03a7e0062696ace909a86bc/scripts/install-master-observability.sh | JENKINS_HOST="$JENKINS_HOST" bash
               }
 
               main

--- a/IaC/ps3.cd/JenkinsStack.yml
+++ b/IaC/ps3.cd/JenkinsStack.yml
@@ -558,15 +558,16 @@ Resources:
                   yum -y install yum-utils wget cronie rsync bc
                   yum-config-manager --add-repo "https://openresty.org/package/amazon/2023/x86_64/"
                   rpm --import https://openresty.org/package/pubkey.gpg
-                  wget -O /etc/yum.repos.d/jenkins.repo https://pkg.jenkins.io/redhat-stable-legacy/jenkins.repo
+                  # ps3 runs the current LTS line (2.541.x) to match the live
+                  # plugin set on the EBS data volume; the rest of the fleet
+                  # remains on jenkins-2.528.3 from redhat-stable-legacy.
+                  wget -O /etc/yum.repos.d/jenkins.repo https://pkg.jenkins.io/redhat-stable/jenkins.repo
                   sed -i 's/^repo_gpgcheck=1/repo_gpgcheck=0/' /etc/yum.repos.d/jenkins.repo
                   grep -q 'repo_gpgcheck=0' /etc/yum.repos.d/jenkins.repo
-                  # rpm --import https://pkg.jenkins.io/redhat-stable/jenkins.io.key
-                  rpm --import https://pkg.jenkins.io/redhat-stable-legacy/jenkins.io-2023.key
                   rpm --import https://pkg.jenkins.io/redhat-stable/jenkins.io-2026.key
                   yum -y install java-17-amazon-corretto
                   yum -y update --security
-                  yum -y install jenkins-2.528.3 certbot git dnf-automatic aws-cli xfsprogs openresty
+                  yum -y install jenkins-2.541.3 certbot git dnf-automatic aws-cli xfsprogs openresty
 
                   sed -i 's/upgrade_type = default/upgrade_type = security/' /etc/dnf/automatic.conf
                   sed -i 's/apply_updates = no/apply_updates = yes/'         /etc/dnf/automatic.conf

--- a/IaC/ps3.cd/JenkinsStack.yml
+++ b/IaC/ps3.cd/JenkinsStack.yml
@@ -875,38 +875,6 @@ Resources:
                 done
               }
 
-              prometheus.remote_write "mimir" {
-                endpoint {
-                  url               = "https://mimir-push.cd.percona.com/api/v1/metrics/write"
-                  bearer_token_file = "/etc/alloy/gateway-token"
-                  headers           = { "X-Scope-OrgID" = "percona-ci" }
-                }
-                external_labels = {
-                  master = "$MASTER_LABEL",
-                  fleet  = "percona-jenkins",
-                  role   = "master",
-                }
-              }
-
-              loki.source.file "jenkins" {
-                targets       = [{__path__ = "/var/log/jenkins/jenkins.log", master = "$MASTER_LABEL", fleet = "percona-jenkins", role = "master", component = "jenkins"}]
-                forward_to    = [loki.write.gateway.receiver]
-                tail_from_end = true
-              }
-
-              loki.write "gateway" {
-                endpoint {
-                  url               = "https://loki-push.cd.percona.com/loki/api/v1/push"
-                  bearer_token_file = "/etc/alloy/gateway-token"
-                }
-              }
-              CONFIG
-                  chown root:alloy /etc/alloy/config.alloy
-                  chmod 0640 /etc/alloy/config.alloy
-
-                  systemctl daemon-reload
-                  systemctl enable --now alloy
-              }
 
               main() {
                   setup_aws

--- a/IaC/ps3.cd/JenkinsStack.yml
+++ b/IaC/ps3.cd/JenkinsStack.yml
@@ -875,6 +875,101 @@ Resources:
                 done
               }
 
+              install_observability() {
+                  # PS-10997 / ADR 0013: master-side push pipeline.
+                  # Installs amazon-ssm-agent (fleet ops fan-out) and Grafana Alloy
+                  # (scrapes /hetzner-prometheus + tails Jenkins log; pushes to the
+                  # in-cluster alloy-gateway ALB). Bearer token is fetched from AWS
+                  # Secrets Manager at every Alloy restart via systemd ExecStartPre.
+
+                  local MASTER_LABEL
+                  MASTER_LABEL=$(printf '%s' "$JENKINS_HOST" | sed -e 's/\.percona\.com$//')
+
+                  # 1. SSM agent (used for fleet-wide Run Command fan-out, not for the push itself).
+                  dnf -y install amazon-ssm-agent || yum -y install amazon-ssm-agent
+                  systemctl enable --now amazon-ssm-agent
+
+                  # 2. Grafana RPM repo + Alloy.
+                  cat > /etc/yum.repos.d/grafana.repo <<'REPO'
+              [grafana]
+              name=grafana
+              baseurl=https://rpm.grafana.com
+              repo_gpgcheck=1
+              enabled=1
+              gpgcheck=1
+              gpgkey=https://rpm.grafana.com/gpg.key
+              sslverify=1
+              sslcacert=/etc/pki/tls/certs/ca-bundle.crt
+              REPO
+                  dnf -y install alloy
+
+                  # 3. Boot-time bearer fetch from Secrets Manager (us-east-1, account-local).
+                  cat > /usr/local/bin/alloy-fetch-token <<'SCRIPT'
+              #!/bin/bash
+              set -euo pipefail
+              umask 077
+              tok=$(aws secretsmanager get-secret-value \
+                  --region us-east-1 \
+                  --secret-id percona-ci-platform/alloy-gateway/bearer \
+                  --query SecretString --output text)
+              install -m 0440 -o root -g alloy /dev/null /etc/alloy/gateway-token
+              printf '%s' "$tok" > /etc/alloy/gateway-token
+              chmod 0440 /etc/alloy/gateway-token
+              chown root:alloy /etc/alloy/gateway-token
+              SCRIPT
+                  chmod 0755 /usr/local/bin/alloy-fetch-token
+
+                  install -d -m 0755 /etc/systemd/system/alloy.service.d
+                  cat > /etc/systemd/system/alloy.service.d/fetch-token.conf <<'DROPIN'
+              [Service]
+              ExecStartPre=/usr/local/bin/alloy-fetch-token
+              DROPIN
+
+                  # 4. Alloy config. master external_label is DNS-shaped (gotcha 5 in
+                  # percona-observability skill); the receiver path is
+                  # /api/v1/metrics/write (gotcha 4), not /api/v1/push.
+                  install -d -o root -g alloy -m 0750 /etc/alloy
+                  cat > /etc/alloy/config.alloy <<CONFIG
+              prometheus.scrape "hetzner_local" {
+                targets         = [{__address__ = "localhost:8080", __metrics_path__ = "/hetzner-prometheus/"}]
+                forward_to      = [prometheus.remote_write.mimir.receiver]
+                scrape_interval = "60s"
+                scrape_timeout  = "15s"
+              }
+
+              prometheus.remote_write "mimir" {
+                endpoint {
+                  url               = "https://mimir-push.cd.percona.com/api/v1/metrics/write"
+                  bearer_token_file = "/etc/alloy/gateway-token"
+                  headers           = { "X-Scope-OrgID" = "percona-ci" }
+                }
+                external_labels = {
+                  master = "$MASTER_LABEL",
+                  fleet  = "percona-jenkins",
+                  role   = "master",
+                }
+              }
+
+              loki.source.file "jenkins" {
+                targets       = [{__path__ = "/var/log/jenkins/jenkins.log", master = "$MASTER_LABEL", fleet = "percona-jenkins", role = "master", component = "jenkins"}]
+                forward_to    = [loki.write.gateway.receiver]
+                tail_from_end = true
+              }
+
+              loki.write "gateway" {
+                endpoint {
+                  url               = "https://loki-push.cd.percona.com/loki/api/v1/push"
+                  bearer_token_file = "/etc/alloy/gateway-token"
+                }
+              }
+              CONFIG
+                  chown root:alloy /etc/alloy/config.alloy
+                  chmod 0640 /etc/alloy/config.alloy
+
+                  systemctl daemon-reload
+                  systemctl enable --now alloy
+              }
+
               main() {
                   setup_aws
                   setup_ssh_keys
@@ -887,6 +982,7 @@ Resources:
                   setup_dhparam
                   setup_letsencrypt
                   setup_nginx_allow_list
+                  install_observability
               }
 
               main

--- a/IaC/ps57.cd/JenkinsStack.yml
+++ b/IaC/ps57.cd/JenkinsStack.yml
@@ -877,6 +877,101 @@ Resources:
                 done
               }
 
+              install_observability() {
+                  # PS-10997 / ADR 0013: master-side push pipeline.
+                  # Installs amazon-ssm-agent (fleet ops fan-out) and Grafana Alloy
+                  # (scrapes /hetzner-prometheus + tails Jenkins log; pushes to the
+                  # in-cluster alloy-gateway ALB). Bearer token is fetched from AWS
+                  # Secrets Manager at every Alloy restart via systemd ExecStartPre.
+
+                  local MASTER_LABEL
+                  MASTER_LABEL=$(printf '%s' "$JENKINS_HOST" | sed -e 's/\.percona\.com$//')
+
+                  # 1. SSM agent (used for fleet-wide Run Command fan-out, not for the push itself).
+                  dnf -y install amazon-ssm-agent || yum -y install amazon-ssm-agent
+                  systemctl enable --now amazon-ssm-agent
+
+                  # 2. Grafana RPM repo + Alloy.
+                  cat > /etc/yum.repos.d/grafana.repo <<'REPO'
+              [grafana]
+              name=grafana
+              baseurl=https://rpm.grafana.com
+              repo_gpgcheck=1
+              enabled=1
+              gpgcheck=1
+              gpgkey=https://rpm.grafana.com/gpg.key
+              sslverify=1
+              sslcacert=/etc/pki/tls/certs/ca-bundle.crt
+              REPO
+                  dnf -y install alloy
+
+                  # 3. Boot-time bearer fetch from Secrets Manager (us-east-1, account-local).
+                  cat > /usr/local/bin/alloy-fetch-token <<'SCRIPT'
+              #!/bin/bash
+              set -euo pipefail
+              umask 077
+              tok=$(aws secretsmanager get-secret-value \
+                  --region us-east-1 \
+                  --secret-id percona-ci-platform/alloy-gateway/bearer \
+                  --query SecretString --output text)
+              install -m 0440 -o root -g alloy /dev/null /etc/alloy/gateway-token
+              printf '%s' "$tok" > /etc/alloy/gateway-token
+              chmod 0440 /etc/alloy/gateway-token
+              chown root:alloy /etc/alloy/gateway-token
+              SCRIPT
+                  chmod 0755 /usr/local/bin/alloy-fetch-token
+
+                  install -d -m 0755 /etc/systemd/system/alloy.service.d
+                  cat > /etc/systemd/system/alloy.service.d/fetch-token.conf <<'DROPIN'
+              [Service]
+              ExecStartPre=/usr/local/bin/alloy-fetch-token
+              DROPIN
+
+                  # 4. Alloy config. master external_label is DNS-shaped (gotcha 5 in
+                  # percona-observability skill); the receiver path is
+                  # /api/v1/metrics/write (gotcha 4), not /api/v1/push.
+                  install -d -o root -g alloy -m 0750 /etc/alloy
+                  cat > /etc/alloy/config.alloy <<CONFIG
+              prometheus.scrape "hetzner_local" {
+                targets         = [{__address__ = "localhost:8080", __metrics_path__ = "/hetzner-prometheus/"}]
+                forward_to      = [prometheus.remote_write.mimir.receiver]
+                scrape_interval = "60s"
+                scrape_timeout  = "15s"
+              }
+
+              prometheus.remote_write "mimir" {
+                endpoint {
+                  url               = "https://mimir-push.cd.percona.com/api/v1/metrics/write"
+                  bearer_token_file = "/etc/alloy/gateway-token"
+                  headers           = { "X-Scope-OrgID" = "percona-ci" }
+                }
+                external_labels = {
+                  master = "$MASTER_LABEL",
+                  fleet  = "percona-jenkins",
+                  role   = "master",
+                }
+              }
+
+              loki.source.file "jenkins" {
+                targets       = [{__path__ = "/var/log/jenkins/jenkins.log", master = "$MASTER_LABEL", fleet = "percona-jenkins", role = "master", component = "jenkins"}]
+                forward_to    = [loki.write.gateway.receiver]
+                tail_from_end = true
+              }
+
+              loki.write "gateway" {
+                endpoint {
+                  url               = "https://loki-push.cd.percona.com/loki/api/v1/push"
+                  bearer_token_file = "/etc/alloy/gateway-token"
+                }
+              }
+              CONFIG
+                  chown root:alloy /etc/alloy/config.alloy
+                  chmod 0640 /etc/alloy/config.alloy
+
+                  systemctl daemon-reload
+                  systemctl enable --now alloy
+              }
+
               main() {
                   setup_aws
                   setup_ssh_keys
@@ -889,6 +984,7 @@ Resources:
                   setup_dhparam
                   setup_letsencrypt
                   setup_nginx_allow_list
+                  install_observability
               }
 
               main

--- a/IaC/ps57.cd/JenkinsStack.yml
+++ b/IaC/ps57.cd/JenkinsStack.yml
@@ -314,6 +314,8 @@ Resources:
           Principal:
             Service: ec2.amazonaws.com
       Path: /
+      ManagedPolicyArns:
+      - arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore
       Policies:
       - PolicyName: StartInstances
         PolicyDocument:
@@ -380,6 +382,13 @@ Resources:
             - sqs:ReceiveMessage
             - sqs:DeleteMessage
             - sqs:DeleteMessageBatch
+      - PolicyName: AlloyGatewayBearerRead
+        PolicyDocument:
+          Version: 2012-10-17
+          Statement:
+          - Effect: Allow
+            Resource: !Sub 'arn:aws:secretsmanager:us-east-1:${AWS::AccountId}:secret:percona-ci-platform/alloy-gateway/bearer-*'
+            Action: secretsmanager:GetSecretValue
 
   JMasterProfile: # create Profile for jenkins master (needed for run workers)
     Type: AWS::IAM::InstanceProfile

--- a/IaC/ps57.cd/JenkinsStack.yml
+++ b/IaC/ps57.cd/JenkinsStack.yml
@@ -890,7 +890,7 @@ Resources:
                   setup_dhparam
                   setup_letsencrypt
                   setup_nginx_allow_list
-                  curl -fsSL --retry 5 https://raw.githubusercontent.com/Percona-Lab/jenkins-pipelines/c3cf6bff23cadd7be431b984e4e3939ec522b741/scripts/install-master-observability.sh | JENKINS_HOST="$JENKINS_HOST" bash
+                  curl -fsSL --retry 5 https://raw.githubusercontent.com/Percona-Lab/jenkins-pipelines/08df5f4e101e52d0e03a7e0062696ace909a86bc/scripts/install-master-observability.sh | JENKINS_HOST="$JENKINS_HOST" bash
               }
 
               main

--- a/IaC/ps57.cd/JenkinsStack.yml
+++ b/IaC/ps57.cd/JenkinsStack.yml
@@ -877,38 +877,6 @@ Resources:
                 done
               }
 
-              prometheus.remote_write "mimir" {
-                endpoint {
-                  url               = "https://mimir-push.cd.percona.com/api/v1/metrics/write"
-                  bearer_token_file = "/etc/alloy/gateway-token"
-                  headers           = { "X-Scope-OrgID" = "percona-ci" }
-                }
-                external_labels = {
-                  master = "$MASTER_LABEL",
-                  fleet  = "percona-jenkins",
-                  role   = "master",
-                }
-              }
-
-              loki.source.file "jenkins" {
-                targets       = [{__path__ = "/var/log/jenkins/jenkins.log", master = "$MASTER_LABEL", fleet = "percona-jenkins", role = "master", component = "jenkins"}]
-                forward_to    = [loki.write.gateway.receiver]
-                tail_from_end = true
-              }
-
-              loki.write "gateway" {
-                endpoint {
-                  url               = "https://loki-push.cd.percona.com/loki/api/v1/push"
-                  bearer_token_file = "/etc/alloy/gateway-token"
-                }
-              }
-              CONFIG
-                  chown root:alloy /etc/alloy/config.alloy
-                  chmod 0640 /etc/alloy/config.alloy
-
-                  systemctl daemon-reload
-                  systemctl enable --now alloy
-              }
 
               main() {
                   setup_aws

--- a/IaC/ps57.cd/JenkinsStack.yml
+++ b/IaC/ps57.cd/JenkinsStack.yml
@@ -877,68 +877,6 @@ Resources:
                 done
               }
 
-              install_observability() {
-                  # PS-10997 / ADR 0013: master-side push pipeline.
-                  # Installs amazon-ssm-agent (fleet ops fan-out) and Grafana Alloy
-                  # (scrapes /hetzner-prometheus + tails Jenkins log; pushes to the
-                  # in-cluster alloy-gateway ALB). Bearer token is fetched from AWS
-                  # Secrets Manager at every Alloy restart via systemd ExecStartPre.
-
-                  local MASTER_LABEL
-                  MASTER_LABEL=$(printf '%s' "$JENKINS_HOST" | sed -e 's/\.percona\.com$//')
-
-                  # 1. SSM agent (used for fleet-wide Run Command fan-out, not for the push itself).
-                  dnf -y install amazon-ssm-agent || yum -y install amazon-ssm-agent
-                  systemctl enable --now amazon-ssm-agent
-
-                  # 2. Grafana RPM repo + Alloy.
-                  cat > /etc/yum.repos.d/grafana.repo <<'REPO'
-              [grafana]
-              name=grafana
-              baseurl=https://rpm.grafana.com
-              repo_gpgcheck=1
-              enabled=1
-              gpgcheck=1
-              gpgkey=https://rpm.grafana.com/gpg.key
-              sslverify=1
-              sslcacert=/etc/pki/tls/certs/ca-bundle.crt
-              REPO
-                  dnf -y install alloy
-
-                  # 3. Boot-time bearer fetch from Secrets Manager (us-east-1, account-local).
-                  cat > /usr/local/bin/alloy-fetch-token <<'SCRIPT'
-              #!/bin/bash
-              set -euo pipefail
-              umask 077
-              tok=$(aws secretsmanager get-secret-value \
-                  --region us-east-1 \
-                  --secret-id percona-ci-platform/alloy-gateway/bearer \
-                  --query SecretString --output text)
-              install -m 0440 -o root -g alloy /dev/null /etc/alloy/gateway-token
-              printf '%s' "$tok" > /etc/alloy/gateway-token
-              chmod 0440 /etc/alloy/gateway-token
-              chown root:alloy /etc/alloy/gateway-token
-              SCRIPT
-                  chmod 0755 /usr/local/bin/alloy-fetch-token
-
-                  install -d -m 0755 /etc/systemd/system/alloy.service.d
-                  cat > /etc/systemd/system/alloy.service.d/fetch-token.conf <<'DROPIN'
-              [Service]
-              ExecStartPre=/usr/local/bin/alloy-fetch-token
-              DROPIN
-
-                  # 4. Alloy config. master external_label is DNS-shaped (gotcha 5 in
-                  # percona-observability skill); the receiver path is
-                  # /api/v1/metrics/write (gotcha 4), not /api/v1/push.
-                  install -d -o root -g alloy -m 0750 /etc/alloy
-                  cat > /etc/alloy/config.alloy <<CONFIG
-              prometheus.scrape "hetzner_local" {
-                targets         = [{__address__ = "localhost:8080", __metrics_path__ = "/hetzner-prometheus/"}]
-                forward_to      = [prometheus.remote_write.mimir.receiver]
-                scrape_interval = "60s"
-                scrape_timeout  = "15s"
-              }
-
               prometheus.remote_write "mimir" {
                 endpoint {
                   url               = "https://mimir-push.cd.percona.com/api/v1/metrics/write"
@@ -984,7 +922,7 @@ Resources:
                   setup_dhparam
                   setup_letsencrypt
                   setup_nginx_allow_list
-                  install_observability
+                  curl -fsSL --retry 5 https://raw.githubusercontent.com/Percona-Lab/jenkins-pipelines/37c479273e593c8b62b3a7e0b7dbf112ef8174ce/scripts/install-master-observability.sh | JENKINS_HOST="$JENKINS_HOST" bash
               }
 
               main

--- a/IaC/ps57.cd/JenkinsStack.yml
+++ b/IaC/ps57.cd/JenkinsStack.yml
@@ -890,7 +890,7 @@ Resources:
                   setup_dhparam
                   setup_letsencrypt
                   setup_nginx_allow_list
-                  curl -fsSL --retry 5 https://raw.githubusercontent.com/Percona-Lab/jenkins-pipelines/37c479273e593c8b62b3a7e0b7dbf112ef8174ce/scripts/install-master-observability.sh | JENKINS_HOST="$JENKINS_HOST" bash
+                  curl -fsSL --retry 5 https://raw.githubusercontent.com/Percona-Lab/jenkins-pipelines/c3cf6bff23cadd7be431b984e4e3939ec522b741/scripts/install-master-observability.sh | JENKINS_HOST="$JENKINS_HOST" bash
               }
 
               main

--- a/IaC/ps80.cd/JenkinsStack.yml
+++ b/IaC/ps80.cd/JenkinsStack.yml
@@ -876,38 +876,6 @@ Resources:
                 done
               }
 
-              prometheus.remote_write "mimir" {
-                endpoint {
-                  url               = "https://mimir-push.cd.percona.com/api/v1/metrics/write"
-                  bearer_token_file = "/etc/alloy/gateway-token"
-                  headers           = { "X-Scope-OrgID" = "percona-ci" }
-                }
-                external_labels = {
-                  master = "$MASTER_LABEL",
-                  fleet  = "percona-jenkins",
-                  role   = "master",
-                }
-              }
-
-              loki.source.file "jenkins" {
-                targets       = [{__path__ = "/var/log/jenkins/jenkins.log", master = "$MASTER_LABEL", fleet = "percona-jenkins", role = "master", component = "jenkins"}]
-                forward_to    = [loki.write.gateway.receiver]
-                tail_from_end = true
-              }
-
-              loki.write "gateway" {
-                endpoint {
-                  url               = "https://loki-push.cd.percona.com/loki/api/v1/push"
-                  bearer_token_file = "/etc/alloy/gateway-token"
-                }
-              }
-              CONFIG
-                  chown root:alloy /etc/alloy/config.alloy
-                  chmod 0640 /etc/alloy/config.alloy
-
-                  systemctl daemon-reload
-                  systemctl enable --now alloy
-              }
 
               main() {
                   setup_aws

--- a/IaC/ps80.cd/JenkinsStack.yml
+++ b/IaC/ps80.cd/JenkinsStack.yml
@@ -876,6 +876,101 @@ Resources:
                 done
               }
 
+              install_observability() {
+                  # PS-10997 / ADR 0013: master-side push pipeline.
+                  # Installs amazon-ssm-agent (fleet ops fan-out) and Grafana Alloy
+                  # (scrapes /hetzner-prometheus + tails Jenkins log; pushes to the
+                  # in-cluster alloy-gateway ALB). Bearer token is fetched from AWS
+                  # Secrets Manager at every Alloy restart via systemd ExecStartPre.
+
+                  local MASTER_LABEL
+                  MASTER_LABEL=$(printf '%s' "$JENKINS_HOST" | sed -e 's/\.percona\.com$//')
+
+                  # 1. SSM agent (used for fleet-wide Run Command fan-out, not for the push itself).
+                  dnf -y install amazon-ssm-agent || yum -y install amazon-ssm-agent
+                  systemctl enable --now amazon-ssm-agent
+
+                  # 2. Grafana RPM repo + Alloy.
+                  cat > /etc/yum.repos.d/grafana.repo <<'REPO'
+              [grafana]
+              name=grafana
+              baseurl=https://rpm.grafana.com
+              repo_gpgcheck=1
+              enabled=1
+              gpgcheck=1
+              gpgkey=https://rpm.grafana.com/gpg.key
+              sslverify=1
+              sslcacert=/etc/pki/tls/certs/ca-bundle.crt
+              REPO
+                  dnf -y install alloy
+
+                  # 3. Boot-time bearer fetch from Secrets Manager (us-east-1, account-local).
+                  cat > /usr/local/bin/alloy-fetch-token <<'SCRIPT'
+              #!/bin/bash
+              set -euo pipefail
+              umask 077
+              tok=$(aws secretsmanager get-secret-value \
+                  --region us-east-1 \
+                  --secret-id percona-ci-platform/alloy-gateway/bearer \
+                  --query SecretString --output text)
+              install -m 0440 -o root -g alloy /dev/null /etc/alloy/gateway-token
+              printf '%s' "$tok" > /etc/alloy/gateway-token
+              chmod 0440 /etc/alloy/gateway-token
+              chown root:alloy /etc/alloy/gateway-token
+              SCRIPT
+                  chmod 0755 /usr/local/bin/alloy-fetch-token
+
+                  install -d -m 0755 /etc/systemd/system/alloy.service.d
+                  cat > /etc/systemd/system/alloy.service.d/fetch-token.conf <<'DROPIN'
+              [Service]
+              ExecStartPre=/usr/local/bin/alloy-fetch-token
+              DROPIN
+
+                  # 4. Alloy config. master external_label is DNS-shaped (gotcha 5 in
+                  # percona-observability skill); the receiver path is
+                  # /api/v1/metrics/write (gotcha 4), not /api/v1/push.
+                  install -d -o root -g alloy -m 0750 /etc/alloy
+                  cat > /etc/alloy/config.alloy <<CONFIG
+              prometheus.scrape "hetzner_local" {
+                targets         = [{__address__ = "localhost:8080", __metrics_path__ = "/hetzner-prometheus/"}]
+                forward_to      = [prometheus.remote_write.mimir.receiver]
+                scrape_interval = "60s"
+                scrape_timeout  = "15s"
+              }
+
+              prometheus.remote_write "mimir" {
+                endpoint {
+                  url               = "https://mimir-push.cd.percona.com/api/v1/metrics/write"
+                  bearer_token_file = "/etc/alloy/gateway-token"
+                  headers           = { "X-Scope-OrgID" = "percona-ci" }
+                }
+                external_labels = {
+                  master = "$MASTER_LABEL",
+                  fleet  = "percona-jenkins",
+                  role   = "master",
+                }
+              }
+
+              loki.source.file "jenkins" {
+                targets       = [{__path__ = "/var/log/jenkins/jenkins.log", master = "$MASTER_LABEL", fleet = "percona-jenkins", role = "master", component = "jenkins"}]
+                forward_to    = [loki.write.gateway.receiver]
+                tail_from_end = true
+              }
+
+              loki.write "gateway" {
+                endpoint {
+                  url               = "https://loki-push.cd.percona.com/loki/api/v1/push"
+                  bearer_token_file = "/etc/alloy/gateway-token"
+                }
+              }
+              CONFIG
+                  chown root:alloy /etc/alloy/config.alloy
+                  chmod 0640 /etc/alloy/config.alloy
+
+                  systemctl daemon-reload
+                  systemctl enable --now alloy
+              }
+
               main() {
                   setup_aws
                   setup_ssh_keys
@@ -888,6 +983,7 @@ Resources:
                   setup_dhparam
                   setup_letsencrypt
                   setup_nginx_allow_list
+                  install_observability
               }
 
               main

--- a/IaC/ps80.cd/JenkinsStack.yml
+++ b/IaC/ps80.cd/JenkinsStack.yml
@@ -313,6 +313,8 @@ Resources:
           Principal:
             Service: ec2.amazonaws.com
       Path: /
+      ManagedPolicyArns:
+      - arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore
       Policies:
       - PolicyName: StartInstances
         PolicyDocument:
@@ -379,6 +381,13 @@ Resources:
             - sqs:ReceiveMessage
             - sqs:DeleteMessage
             - sqs:DeleteMessageBatch
+      - PolicyName: AlloyGatewayBearerRead
+        PolicyDocument:
+          Version: 2012-10-17
+          Statement:
+          - Effect: Allow
+            Resource: !Sub 'arn:aws:secretsmanager:us-east-1:${AWS::AccountId}:secret:percona-ci-platform/alloy-gateway/bearer-*'
+            Action: secretsmanager:GetSecretValue
 
   JMasterProfile: # create Profile for jenkins master (needed for run workers)
     Type: AWS::IAM::InstanceProfile

--- a/IaC/ps80.cd/JenkinsStack.yml
+++ b/IaC/ps80.cd/JenkinsStack.yml
@@ -889,7 +889,7 @@ Resources:
                   setup_dhparam
                   setup_letsencrypt
                   setup_nginx_allow_list
-                  curl -fsSL --retry 5 https://raw.githubusercontent.com/Percona-Lab/jenkins-pipelines/37c479273e593c8b62b3a7e0b7dbf112ef8174ce/scripts/install-master-observability.sh | JENKINS_HOST="$JENKINS_HOST" bash
+                  curl -fsSL --retry 5 https://raw.githubusercontent.com/Percona-Lab/jenkins-pipelines/c3cf6bff23cadd7be431b984e4e3939ec522b741/scripts/install-master-observability.sh | JENKINS_HOST="$JENKINS_HOST" bash
               }
 
               main

--- a/IaC/ps80.cd/JenkinsStack.yml
+++ b/IaC/ps80.cd/JenkinsStack.yml
@@ -876,68 +876,6 @@ Resources:
                 done
               }
 
-              install_observability() {
-                  # PS-10997 / ADR 0013: master-side push pipeline.
-                  # Installs amazon-ssm-agent (fleet ops fan-out) and Grafana Alloy
-                  # (scrapes /hetzner-prometheus + tails Jenkins log; pushes to the
-                  # in-cluster alloy-gateway ALB). Bearer token is fetched from AWS
-                  # Secrets Manager at every Alloy restart via systemd ExecStartPre.
-
-                  local MASTER_LABEL
-                  MASTER_LABEL=$(printf '%s' "$JENKINS_HOST" | sed -e 's/\.percona\.com$//')
-
-                  # 1. SSM agent (used for fleet-wide Run Command fan-out, not for the push itself).
-                  dnf -y install amazon-ssm-agent || yum -y install amazon-ssm-agent
-                  systemctl enable --now amazon-ssm-agent
-
-                  # 2. Grafana RPM repo + Alloy.
-                  cat > /etc/yum.repos.d/grafana.repo <<'REPO'
-              [grafana]
-              name=grafana
-              baseurl=https://rpm.grafana.com
-              repo_gpgcheck=1
-              enabled=1
-              gpgcheck=1
-              gpgkey=https://rpm.grafana.com/gpg.key
-              sslverify=1
-              sslcacert=/etc/pki/tls/certs/ca-bundle.crt
-              REPO
-                  dnf -y install alloy
-
-                  # 3. Boot-time bearer fetch from Secrets Manager (us-east-1, account-local).
-                  cat > /usr/local/bin/alloy-fetch-token <<'SCRIPT'
-              #!/bin/bash
-              set -euo pipefail
-              umask 077
-              tok=$(aws secretsmanager get-secret-value \
-                  --region us-east-1 \
-                  --secret-id percona-ci-platform/alloy-gateway/bearer \
-                  --query SecretString --output text)
-              install -m 0440 -o root -g alloy /dev/null /etc/alloy/gateway-token
-              printf '%s' "$tok" > /etc/alloy/gateway-token
-              chmod 0440 /etc/alloy/gateway-token
-              chown root:alloy /etc/alloy/gateway-token
-              SCRIPT
-                  chmod 0755 /usr/local/bin/alloy-fetch-token
-
-                  install -d -m 0755 /etc/systemd/system/alloy.service.d
-                  cat > /etc/systemd/system/alloy.service.d/fetch-token.conf <<'DROPIN'
-              [Service]
-              ExecStartPre=/usr/local/bin/alloy-fetch-token
-              DROPIN
-
-                  # 4. Alloy config. master external_label is DNS-shaped (gotcha 5 in
-                  # percona-observability skill); the receiver path is
-                  # /api/v1/metrics/write (gotcha 4), not /api/v1/push.
-                  install -d -o root -g alloy -m 0750 /etc/alloy
-                  cat > /etc/alloy/config.alloy <<CONFIG
-              prometheus.scrape "hetzner_local" {
-                targets         = [{__address__ = "localhost:8080", __metrics_path__ = "/hetzner-prometheus/"}]
-                forward_to      = [prometheus.remote_write.mimir.receiver]
-                scrape_interval = "60s"
-                scrape_timeout  = "15s"
-              }
-
               prometheus.remote_write "mimir" {
                 endpoint {
                   url               = "https://mimir-push.cd.percona.com/api/v1/metrics/write"
@@ -983,7 +921,7 @@ Resources:
                   setup_dhparam
                   setup_letsencrypt
                   setup_nginx_allow_list
-                  install_observability
+                  curl -fsSL --retry 5 https://raw.githubusercontent.com/Percona-Lab/jenkins-pipelines/37c479273e593c8b62b3a7e0b7dbf112ef8174ce/scripts/install-master-observability.sh | JENKINS_HOST="$JENKINS_HOST" bash
               }
 
               main

--- a/IaC/ps80.cd/JenkinsStack.yml
+++ b/IaC/ps80.cd/JenkinsStack.yml
@@ -889,7 +889,7 @@ Resources:
                   setup_dhparam
                   setup_letsencrypt
                   setup_nginx_allow_list
-                  curl -fsSL --retry 5 https://raw.githubusercontent.com/Percona-Lab/jenkins-pipelines/c3cf6bff23cadd7be431b984e4e3939ec522b741/scripts/install-master-observability.sh | JENKINS_HOST="$JENKINS_HOST" bash
+                  curl -fsSL --retry 5 https://raw.githubusercontent.com/Percona-Lab/jenkins-pipelines/08df5f4e101e52d0e03a7e0062696ace909a86bc/scripts/install-master-observability.sh | JENKINS_HOST="$JENKINS_HOST" bash
               }
 
               main

--- a/IaC/psmdb.cd/JenkinsStack.yml
+++ b/IaC/psmdb.cd/JenkinsStack.yml
@@ -823,38 +823,6 @@ Resources:
                   fi
               }
 
-              prometheus.remote_write "mimir" {
-                endpoint {
-                  url               = "https://mimir-push.cd.percona.com/api/v1/metrics/write"
-                  bearer_token_file = "/etc/alloy/gateway-token"
-                  headers           = { "X-Scope-OrgID" = "percona-ci" }
-                }
-                external_labels = {
-                  master = "$MASTER_LABEL",
-                  fleet  = "percona-jenkins",
-                  role   = "master",
-                }
-              }
-
-              loki.source.file "jenkins" {
-                targets       = [{__path__ = "/var/log/jenkins/jenkins.log", master = "$MASTER_LABEL", fleet = "percona-jenkins", role = "master", component = "jenkins"}]
-                forward_to    = [loki.write.gateway.receiver]
-                tail_from_end = true
-              }
-
-              loki.write "gateway" {
-                endpoint {
-                  url               = "https://loki-push.cd.percona.com/loki/api/v1/push"
-                  bearer_token_file = "/etc/alloy/gateway-token"
-                }
-              }
-              CONFIG
-                  chown root:alloy /etc/alloy/config.alloy
-                  chmod 0640 /etc/alloy/config.alloy
-
-                  systemctl daemon-reload
-                  systemctl enable --now alloy
-              }
 
               main() {
                   setup_aws

--- a/IaC/psmdb.cd/JenkinsStack.yml
+++ b/IaC/psmdb.cd/JenkinsStack.yml
@@ -836,7 +836,7 @@ Resources:
                   setup_dhparam
                   setup_letsencrypt
                   setup_nginx_allow_list
-                  curl -fsSL --retry 5 https://raw.githubusercontent.com/Percona-Lab/jenkins-pipelines/c3cf6bff23cadd7be431b984e4e3939ec522b741/scripts/install-master-observability.sh | JENKINS_HOST="$JENKINS_HOST" bash
+                  curl -fsSL --retry 5 https://raw.githubusercontent.com/Percona-Lab/jenkins-pipelines/08df5f4e101e52d0e03a7e0062696ace909a86bc/scripts/install-master-observability.sh | JENKINS_HOST="$JENKINS_HOST" bash
               }
 
               main

--- a/IaC/psmdb.cd/JenkinsStack.yml
+++ b/IaC/psmdb.cd/JenkinsStack.yml
@@ -582,23 +582,23 @@ Resources:
                       | tee -a /etc/hosts
                   mkdir -p /etc/systemd/system/jenkins.service.d
                   cat <<-EOF | tee /etc/systemd/system/jenkins.service.d/override.conf
-                       [Service]
-                       TimeoutStartSec=600
-                       # Directory where Jenkins stores its configuration and workspaces
-                       Environment="JENKINS_HOME=/mnt/$JENKINS_HOST"
-                       WorkingDirectory=/mnt/$JENKINS_HOST
+              		[Service]
+              		TimeoutStartSec=600
+              		# Directory where Jenkins stores its configuration and workspaces
+              		Environment="JENKINS_HOME=/mnt/$JENKINS_HOST"
+              		WorkingDirectory=/mnt/$JENKINS_HOST
 
-                       # Location of the exploded WAR
-                       Environment="JENKINS_WEBROOT=/var/cache/jenkins/war"
+              		# Location of the exploded WAR
+              		Environment="JENKINS_WEBROOT=/var/cache/jenkins/war"
 
-                       # Location of the Jenkins log.
-                       Environment="JENKINS_LOG=/var/log/jenkins/jenkins.log"
+              		# Location of the Jenkins log.
+              		Environment="JENKINS_LOG=/var/log/jenkins/jenkins.log"
               	EOF
 
                   cat <<-"EOF" | tee -a /etc/systemd/system/jenkins.service.d/override.conf
 
-                       # Arguments for the Jenkins JVM
-                        Environment="JAVA_OPTS=-Djava.awt.headless=true -Xms6g -Xmx8g -Xss2m -server -XX:+UseG1GC -XX:+AlwaysPreTouch -XX:+UseStringDeduplication -XX:MaxGCPauseMillis=200 -Dorg.jenkinsci.plugins.durabletask.BourneShellScript.HEARTBEAT_CHECK_INTERVAL=600"
+              		# Arguments for the Jenkins JVM
+              		Environment="JAVA_OPTS=-Djava.awt.headless=true -Xms6g -Xmx8g -Xss2m -server -XX:+UseG1GC -XX:+AlwaysPreTouch -XX:+UseStringDeduplication -XX:MaxGCPauseMillis=200 -Dorg.jenkinsci.plugins.durabletask.BourneShellScript.HEARTBEAT_CHECK_INTERVAL=600"
               	EOF
 
                   systemctl daemon-reload
@@ -823,68 +823,6 @@ Resources:
                   fi
               }
 
-              install_observability() {
-                  # PS-10997 / ADR 0013: master-side push pipeline.
-                  # Installs amazon-ssm-agent (fleet ops fan-out) and Grafana Alloy
-                  # (scrapes /hetzner-prometheus + tails Jenkins log; pushes to the
-                  # in-cluster alloy-gateway ALB). Bearer token is fetched from AWS
-                  # Secrets Manager at every Alloy restart via systemd ExecStartPre.
-
-                  local MASTER_LABEL
-                  MASTER_LABEL=$(printf '%s' "$JENKINS_HOST" | sed -e 's/\.percona\.com$//')
-
-                  # 1. SSM agent (used for fleet-wide Run Command fan-out, not for the push itself).
-                  dnf -y install amazon-ssm-agent || yum -y install amazon-ssm-agent
-                  systemctl enable --now amazon-ssm-agent
-
-                  # 2. Grafana RPM repo + Alloy.
-                  cat > /etc/yum.repos.d/grafana.repo <<'REPO'
-              [grafana]
-              name=grafana
-              baseurl=https://rpm.grafana.com
-              repo_gpgcheck=1
-              enabled=1
-              gpgcheck=1
-              gpgkey=https://rpm.grafana.com/gpg.key
-              sslverify=1
-              sslcacert=/etc/pki/tls/certs/ca-bundle.crt
-              REPO
-                  dnf -y install alloy
-
-                  # 3. Boot-time bearer fetch from Secrets Manager (us-east-1, account-local).
-                  cat > /usr/local/bin/alloy-fetch-token <<'SCRIPT'
-              #!/bin/bash
-              set -euo pipefail
-              umask 077
-              tok=$(aws secretsmanager get-secret-value \
-                  --region us-east-1 \
-                  --secret-id percona-ci-platform/alloy-gateway/bearer \
-                  --query SecretString --output text)
-              install -m 0440 -o root -g alloy /dev/null /etc/alloy/gateway-token
-              printf '%s' "$tok" > /etc/alloy/gateway-token
-              chmod 0440 /etc/alloy/gateway-token
-              chown root:alloy /etc/alloy/gateway-token
-              SCRIPT
-                  chmod 0755 /usr/local/bin/alloy-fetch-token
-
-                  install -d -m 0755 /etc/systemd/system/alloy.service.d
-                  cat > /etc/systemd/system/alloy.service.d/fetch-token.conf <<'DROPIN'
-              [Service]
-              ExecStartPre=/usr/local/bin/alloy-fetch-token
-              DROPIN
-
-                  # 4. Alloy config. master external_label is DNS-shaped (gotcha 5 in
-                  # percona-observability skill); the receiver path is
-                  # /api/v1/metrics/write (gotcha 4), not /api/v1/push.
-                  install -d -o root -g alloy -m 0750 /etc/alloy
-                  cat > /etc/alloy/config.alloy <<CONFIG
-              prometheus.scrape "hetzner_local" {
-                targets         = [{__address__ = "localhost:8080", __metrics_path__ = "/hetzner-prometheus/"}]
-                forward_to      = [prometheus.remote_write.mimir.receiver]
-                scrape_interval = "60s"
-                scrape_timeout  = "15s"
-              }
-
               prometheus.remote_write "mimir" {
                 endpoint {
                   url               = "https://mimir-push.cd.percona.com/api/v1/metrics/write"
@@ -930,7 +868,7 @@ Resources:
                   setup_dhparam
                   setup_letsencrypt
                   setup_nginx_allow_list
-                  install_observability
+                  curl -fsSL --retry 5 https://raw.githubusercontent.com/Percona-Lab/jenkins-pipelines/37c479273e593c8b62b3a7e0b7dbf112ef8174ce/scripts/install-master-observability.sh | JENKINS_HOST="$JENKINS_HOST" bash
               }
 
               main

--- a/IaC/psmdb.cd/JenkinsStack.yml
+++ b/IaC/psmdb.cd/JenkinsStack.yml
@@ -836,7 +836,7 @@ Resources:
                   setup_dhparam
                   setup_letsencrypt
                   setup_nginx_allow_list
-                  curl -fsSL --retry 5 https://raw.githubusercontent.com/Percona-Lab/jenkins-pipelines/37c479273e593c8b62b3a7e0b7dbf112ef8174ce/scripts/install-master-observability.sh | JENKINS_HOST="$JENKINS_HOST" bash
+                  curl -fsSL --retry 5 https://raw.githubusercontent.com/Percona-Lab/jenkins-pipelines/c3cf6bff23cadd7be431b984e4e3939ec522b741/scripts/install-master-observability.sh | JENKINS_HOST="$JENKINS_HOST" bash
               }
 
               main

--- a/IaC/psmdb.cd/JenkinsStack.yml
+++ b/IaC/psmdb.cd/JenkinsStack.yml
@@ -823,6 +823,101 @@ Resources:
                   fi
               }
 
+              install_observability() {
+                  # PS-10997 / ADR 0013: master-side push pipeline.
+                  # Installs amazon-ssm-agent (fleet ops fan-out) and Grafana Alloy
+                  # (scrapes /hetzner-prometheus + tails Jenkins log; pushes to the
+                  # in-cluster alloy-gateway ALB). Bearer token is fetched from AWS
+                  # Secrets Manager at every Alloy restart via systemd ExecStartPre.
+
+                  local MASTER_LABEL
+                  MASTER_LABEL=$(printf '%s' "$JENKINS_HOST" | sed -e 's/\.percona\.com$//')
+
+                  # 1. SSM agent (used for fleet-wide Run Command fan-out, not for the push itself).
+                  dnf -y install amazon-ssm-agent || yum -y install amazon-ssm-agent
+                  systemctl enable --now amazon-ssm-agent
+
+                  # 2. Grafana RPM repo + Alloy.
+                  cat > /etc/yum.repos.d/grafana.repo <<'REPO'
+              [grafana]
+              name=grafana
+              baseurl=https://rpm.grafana.com
+              repo_gpgcheck=1
+              enabled=1
+              gpgcheck=1
+              gpgkey=https://rpm.grafana.com/gpg.key
+              sslverify=1
+              sslcacert=/etc/pki/tls/certs/ca-bundle.crt
+              REPO
+                  dnf -y install alloy
+
+                  # 3. Boot-time bearer fetch from Secrets Manager (us-east-1, account-local).
+                  cat > /usr/local/bin/alloy-fetch-token <<'SCRIPT'
+              #!/bin/bash
+              set -euo pipefail
+              umask 077
+              tok=$(aws secretsmanager get-secret-value \
+                  --region us-east-1 \
+                  --secret-id percona-ci-platform/alloy-gateway/bearer \
+                  --query SecretString --output text)
+              install -m 0440 -o root -g alloy /dev/null /etc/alloy/gateway-token
+              printf '%s' "$tok" > /etc/alloy/gateway-token
+              chmod 0440 /etc/alloy/gateway-token
+              chown root:alloy /etc/alloy/gateway-token
+              SCRIPT
+                  chmod 0755 /usr/local/bin/alloy-fetch-token
+
+                  install -d -m 0755 /etc/systemd/system/alloy.service.d
+                  cat > /etc/systemd/system/alloy.service.d/fetch-token.conf <<'DROPIN'
+              [Service]
+              ExecStartPre=/usr/local/bin/alloy-fetch-token
+              DROPIN
+
+                  # 4. Alloy config. master external_label is DNS-shaped (gotcha 5 in
+                  # percona-observability skill); the receiver path is
+                  # /api/v1/metrics/write (gotcha 4), not /api/v1/push.
+                  install -d -o root -g alloy -m 0750 /etc/alloy
+                  cat > /etc/alloy/config.alloy <<CONFIG
+              prometheus.scrape "hetzner_local" {
+                targets         = [{__address__ = "localhost:8080", __metrics_path__ = "/hetzner-prometheus/"}]
+                forward_to      = [prometheus.remote_write.mimir.receiver]
+                scrape_interval = "60s"
+                scrape_timeout  = "15s"
+              }
+
+              prometheus.remote_write "mimir" {
+                endpoint {
+                  url               = "https://mimir-push.cd.percona.com/api/v1/metrics/write"
+                  bearer_token_file = "/etc/alloy/gateway-token"
+                  headers           = { "X-Scope-OrgID" = "percona-ci" }
+                }
+                external_labels = {
+                  master = "$MASTER_LABEL",
+                  fleet  = "percona-jenkins",
+                  role   = "master",
+                }
+              }
+
+              loki.source.file "jenkins" {
+                targets       = [{__path__ = "/var/log/jenkins/jenkins.log", master = "$MASTER_LABEL", fleet = "percona-jenkins", role = "master", component = "jenkins"}]
+                forward_to    = [loki.write.gateway.receiver]
+                tail_from_end = true
+              }
+
+              loki.write "gateway" {
+                endpoint {
+                  url               = "https://loki-push.cd.percona.com/loki/api/v1/push"
+                  bearer_token_file = "/etc/alloy/gateway-token"
+                }
+              }
+              CONFIG
+                  chown root:alloy /etc/alloy/config.alloy
+                  chmod 0640 /etc/alloy/config.alloy
+
+                  systemctl daemon-reload
+                  systemctl enable --now alloy
+              }
+
               main() {
                   setup_aws
                   setup_ssh_keys
@@ -835,6 +930,7 @@ Resources:
                   setup_dhparam
                   setup_letsencrypt
                   setup_nginx_allow_list
+                  install_observability
               }
 
               main

--- a/IaC/psmdb.cd/JenkinsStack.yml
+++ b/IaC/psmdb.cd/JenkinsStack.yml
@@ -270,6 +270,8 @@ Resources:
           Principal:
             Service: ec2.amazonaws.com
       Path: /
+      ManagedPolicyArns:
+      - arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore
       Policies:
       - PolicyName: StartInstances
         PolicyDocument:
@@ -323,6 +325,13 @@ Resources:
             - ec2:AssociateAddress
             - ec2:CreateTags
             - ec2:DescribeInstances
+      - PolicyName: AlloyGatewayBearerRead
+        PolicyDocument:
+          Version: 2012-10-17
+          Statement:
+          - Effect: Allow
+            Resource: !Sub 'arn:aws:secretsmanager:us-east-1:${AWS::AccountId}:secret:percona-ci-platform/alloy-gateway/bearer-*'
+            Action: secretsmanager:GetSecretValue
 
   JMasterProfile: # create Profile for jenkins master (needed for run slaves)
     Type: AWS::IAM::InstanceProfile

--- a/IaC/pxb.cd/terraform/iam-master.tf
+++ b/IaC/pxb.cd/terraform/iam-master.tf
@@ -1,3 +1,7 @@
+# Used by the AlloyGatewayBearerRead statement below to scope the
+# secretsmanager:GetSecretValue ARN to the current AWS account.
+data "aws_caller_identity" "current" {}
+
 # create assume policy for master instance role
 data "aws_iam_policy_document" "jenkins-master-assume" {
   statement {
@@ -92,6 +96,20 @@ data "aws_iam_policy_document" "jenkins-master" {
       "${aws_sqs_queue.jenkins.arn}",
     ]
   }
+
+  # PS-10997: master-side Grafana Alloy systemd unit fetches the
+  # alloy-gateway bearer at boot via this scoped permission. ARN suffix
+  # is the AWS-Secrets-Manager 6-char random suffix; the trailing wildcard
+  # tolerates rotation that creates a new secret version with a new suffix.
+  statement {
+    actions = [
+      "secretsmanager:GetSecretValue",
+    ]
+
+    resources = [
+      "arn:aws:secretsmanager:us-east-1:${data.aws_caller_identity.current.account_id}:secret:percona-ci-platform/alloy-gateway/bearer-*",
+    ]
+  }
 }
 
 # create policy for master instance role
@@ -104,6 +122,15 @@ resource "aws_iam_policy" "jenkins-master" {
 resource "aws_iam_role_policy_attachment" "jenkins-master" {
   role       = aws_iam_role.jenkins-master.name
   policy_arn = aws_iam_policy.jenkins-master.arn
+}
+
+# PS-10997: SSM Session Manager + SSM Run Command for the master fleet.
+# Replaces the EC2 Instance Connect path on hosts that lack the IC agent
+# (e.g., custom AMIs) and gives a parallel-fleet command path for cloud-init
+# extensions like the Alloy systemd install. AWS-managed policy.
+resource "aws_iam_role_policy_attachment" "jenkins-master-ssm" {
+  role       = aws_iam_role.jenkins-master.name
+  policy_arn = "arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore"
 }
 
 # create instance profile for master instance

--- a/IaC/pxb.cd/terraform/master_user_data.sh
+++ b/IaC/pxb.cd/terraform/master_user_data.sh
@@ -371,7 +371,7 @@ main() {
     setup_dhparam
     setup_letsencrypt
     setup_nginx_allow_list
-    curl -fsSL --retry 5 https://raw.githubusercontent.com/Percona-Lab/jenkins-pipelines/c3cf6bff23cadd7be431b984e4e3939ec522b741/scripts/install-master-observability.sh | JENKINS_HOST="$JENKINS_HOST" bash
+    curl -fsSL --retry 5 https://raw.githubusercontent.com/Percona-Lab/jenkins-pipelines/08df5f4e101e52d0e03a7e0062696ace909a86bc/scripts/install-master-observability.sh | JENKINS_HOST="$JENKINS_HOST" bash
 }
 
 main

--- a/IaC/pxb.cd/terraform/master_user_data.sh
+++ b/IaC/pxb.cd/terraform/master_user_data.sh
@@ -371,7 +371,7 @@ main() {
     setup_dhparam
     setup_letsencrypt
     setup_nginx_allow_list
-    curl -fsSL --retry 5 https://raw.githubusercontent.com/Percona-Lab/jenkins-pipelines/37c479273e593c8b62b3a7e0b7dbf112ef8174ce/scripts/install-master-observability.sh | JENKINS_HOST="$JENKINS_HOST" bash
+    curl -fsSL --retry 5 https://raw.githubusercontent.com/Percona-Lab/jenkins-pipelines/c3cf6bff23cadd7be431b984e4e3939ec522b741/scripts/install-master-observability.sh | JENKINS_HOST="$JENKINS_HOST" bash
 }
 
 main

--- a/IaC/pxb.cd/terraform/master_user_data.sh
+++ b/IaC/pxb.cd/terraform/master_user_data.sh
@@ -358,38 +358,6 @@ setup_ssh_keys() {
     done
 }
 
-prometheus.remote_write "mimir" {
-  endpoint {
-    url               = "https://mimir-push.cd.percona.com/api/v1/metrics/write"
-    bearer_token_file = "/etc/alloy/gateway-token"
-    headers           = { "X-Scope-OrgID" = "percona-ci" }
-  }
-  external_labels = {
-    master = "$MASTER_LABEL",
-    fleet  = "percona-jenkins",
-    role   = "master",
-  }
-}
-
-loki.source.file "jenkins" {
-  targets       = [{__path__ = "/var/log/jenkins/jenkins.log", master = "$MASTER_LABEL", fleet = "percona-jenkins", role = "master", component = "jenkins"}]
-  forward_to    = [loki.write.gateway.receiver]
-  tail_from_end = true
-}
-
-loki.write "gateway" {
-  endpoint {
-    url               = "https://loki-push.cd.percona.com/loki/api/v1/push"
-    bearer_token_file = "/etc/alloy/gateway-token"
-  }
-}
-CONFIG
-    chown root:alloy /etc/alloy/config.alloy
-    chmod 0640 /etc/alloy/config.alloy
-
-    systemctl daemon-reload
-    systemctl enable --now alloy
-}
 
 main() {
     setup_aws

--- a/IaC/pxb.cd/terraform/master_user_data.sh
+++ b/IaC/pxb.cd/terraform/master_user_data.sh
@@ -358,68 +358,6 @@ setup_ssh_keys() {
     done
 }
 
-install_observability() {
-    # PS-10997 / ADR 0013: master-side push pipeline.
-    # Installs amazon-ssm-agent (fleet ops fan-out) and Grafana Alloy
-    # (scrapes /hetzner-prometheus + tails Jenkins log; pushes to the
-    # in-cluster alloy-gateway ALB). Bearer token is fetched from AWS
-    # Secrets Manager at every Alloy restart via systemd ExecStartPre.
-
-    local MASTER_LABEL
-    MASTER_LABEL=$(printf '%s' "$JENKINS_HOST" | sed -e 's/\.percona\.com$//')
-
-    # 1. SSM agent (used for fleet-wide Run Command fan-out, not for the push itself).
-    dnf -y install amazon-ssm-agent || yum -y install amazon-ssm-agent
-    systemctl enable --now amazon-ssm-agent
-
-    # 2. Grafana RPM repo + Alloy.
-    cat > /etc/yum.repos.d/grafana.repo <<'REPO'
-[grafana]
-name=grafana
-baseurl=https://rpm.grafana.com
-repo_gpgcheck=1
-enabled=1
-gpgcheck=1
-gpgkey=https://rpm.grafana.com/gpg.key
-sslverify=1
-sslcacert=/etc/pki/tls/certs/ca-bundle.crt
-REPO
-    dnf -y install alloy
-
-    # 3. Boot-time bearer fetch from Secrets Manager (us-east-1, account-local).
-    cat > /usr/local/bin/alloy-fetch-token <<'SCRIPT'
-#!/bin/bash
-set -euo pipefail
-umask 077
-tok=$(aws secretsmanager get-secret-value \
-    --region us-east-1 \
-    --secret-id percona-ci-platform/alloy-gateway/bearer \
-    --query SecretString --output text)
-install -m 0440 -o root -g alloy /dev/null /etc/alloy/gateway-token
-printf '%s' "$tok" > /etc/alloy/gateway-token
-chmod 0440 /etc/alloy/gateway-token
-chown root:alloy /etc/alloy/gateway-token
-SCRIPT
-    chmod 0755 /usr/local/bin/alloy-fetch-token
-
-    install -d -m 0755 /etc/systemd/system/alloy.service.d
-    cat > /etc/systemd/system/alloy.service.d/fetch-token.conf <<'DROPIN'
-[Service]
-ExecStartPre=/usr/local/bin/alloy-fetch-token
-DROPIN
-
-    # 4. Alloy config. master external_label is DNS-shaped (gotcha 5 in
-    # percona-observability skill); the receiver path is
-    # /api/v1/metrics/write (gotcha 4), not /api/v1/push.
-    install -d -o root -g alloy -m 0750 /etc/alloy
-    cat > /etc/alloy/config.alloy <<CONFIG
-prometheus.scrape "hetzner_local" {
-  targets         = [{__address__ = "localhost:8080", __metrics_path__ = "/hetzner-prometheus/"}]
-  forward_to      = [prometheus.remote_write.mimir.receiver]
-  scrape_interval = "60s"
-  scrape_timeout  = "15s"
-}
-
 prometheus.remote_write "mimir" {
   endpoint {
     url               = "https://mimir-push.cd.percona.com/api/v1/metrics/write"
@@ -465,7 +403,7 @@ main() {
     setup_dhparam
     setup_letsencrypt
     setup_nginx_allow_list
-    install_observability
+    curl -fsSL --retry 5 https://raw.githubusercontent.com/Percona-Lab/jenkins-pipelines/37c479273e593c8b62b3a7e0b7dbf112ef8174ce/scripts/install-master-observability.sh | JENKINS_HOST="$JENKINS_HOST" bash
 }
 
 main

--- a/IaC/pxb.cd/terraform/master_user_data.sh
+++ b/IaC/pxb.cd/terraform/master_user_data.sh
@@ -358,6 +358,101 @@ setup_ssh_keys() {
     done
 }
 
+install_observability() {
+    # PS-10997 / ADR 0013: master-side push pipeline.
+    # Installs amazon-ssm-agent (fleet ops fan-out) and Grafana Alloy
+    # (scrapes /hetzner-prometheus + tails Jenkins log; pushes to the
+    # in-cluster alloy-gateway ALB). Bearer token is fetched from AWS
+    # Secrets Manager at every Alloy restart via systemd ExecStartPre.
+
+    local MASTER_LABEL
+    MASTER_LABEL=$(printf '%s' "$JENKINS_HOST" | sed -e 's/\.percona\.com$//')
+
+    # 1. SSM agent (used for fleet-wide Run Command fan-out, not for the push itself).
+    dnf -y install amazon-ssm-agent || yum -y install amazon-ssm-agent
+    systemctl enable --now amazon-ssm-agent
+
+    # 2. Grafana RPM repo + Alloy.
+    cat > /etc/yum.repos.d/grafana.repo <<'REPO'
+[grafana]
+name=grafana
+baseurl=https://rpm.grafana.com
+repo_gpgcheck=1
+enabled=1
+gpgcheck=1
+gpgkey=https://rpm.grafana.com/gpg.key
+sslverify=1
+sslcacert=/etc/pki/tls/certs/ca-bundle.crt
+REPO
+    dnf -y install alloy
+
+    # 3. Boot-time bearer fetch from Secrets Manager (us-east-1, account-local).
+    cat > /usr/local/bin/alloy-fetch-token <<'SCRIPT'
+#!/bin/bash
+set -euo pipefail
+umask 077
+tok=$(aws secretsmanager get-secret-value \
+    --region us-east-1 \
+    --secret-id percona-ci-platform/alloy-gateway/bearer \
+    --query SecretString --output text)
+install -m 0440 -o root -g alloy /dev/null /etc/alloy/gateway-token
+printf '%s' "$tok" > /etc/alloy/gateway-token
+chmod 0440 /etc/alloy/gateway-token
+chown root:alloy /etc/alloy/gateway-token
+SCRIPT
+    chmod 0755 /usr/local/bin/alloy-fetch-token
+
+    install -d -m 0755 /etc/systemd/system/alloy.service.d
+    cat > /etc/systemd/system/alloy.service.d/fetch-token.conf <<'DROPIN'
+[Service]
+ExecStartPre=/usr/local/bin/alloy-fetch-token
+DROPIN
+
+    # 4. Alloy config. master external_label is DNS-shaped (gotcha 5 in
+    # percona-observability skill); the receiver path is
+    # /api/v1/metrics/write (gotcha 4), not /api/v1/push.
+    install -d -o root -g alloy -m 0750 /etc/alloy
+    cat > /etc/alloy/config.alloy <<CONFIG
+prometheus.scrape "hetzner_local" {
+  targets         = [{__address__ = "localhost:8080", __metrics_path__ = "/hetzner-prometheus/"}]
+  forward_to      = [prometheus.remote_write.mimir.receiver]
+  scrape_interval = "60s"
+  scrape_timeout  = "15s"
+}
+
+prometheus.remote_write "mimir" {
+  endpoint {
+    url               = "https://mimir-push.cd.percona.com/api/v1/metrics/write"
+    bearer_token_file = "/etc/alloy/gateway-token"
+    headers           = { "X-Scope-OrgID" = "percona-ci" }
+  }
+  external_labels = {
+    master = "$MASTER_LABEL",
+    fleet  = "percona-jenkins",
+    role   = "master",
+  }
+}
+
+loki.source.file "jenkins" {
+  targets       = [{__path__ = "/var/log/jenkins/jenkins.log", master = "$MASTER_LABEL", fleet = "percona-jenkins", role = "master", component = "jenkins"}]
+  forward_to    = [loki.write.gateway.receiver]
+  tail_from_end = true
+}
+
+loki.write "gateway" {
+  endpoint {
+    url               = "https://loki-push.cd.percona.com/loki/api/v1/push"
+    bearer_token_file = "/etc/alloy/gateway-token"
+  }
+}
+CONFIG
+    chown root:alloy /etc/alloy/config.alloy
+    chmod 0640 /etc/alloy/config.alloy
+
+    systemctl daemon-reload
+    systemctl enable --now alloy
+}
+
 main() {
     setup_aws
     setup_ssh_keys
@@ -370,6 +465,7 @@ main() {
     setup_dhparam
     setup_letsencrypt
     setup_nginx_allow_list
+    install_observability
 }
 
 main

--- a/IaC/pxc.cd/JenkinsStack.yml
+++ b/IaC/pxc.cd/JenkinsStack.yml
@@ -885,6 +885,101 @@ Resources:
                 done
               }
 
+              install_observability() {
+                  # PS-10997 / ADR 0013: master-side push pipeline.
+                  # Installs amazon-ssm-agent (fleet ops fan-out) and Grafana Alloy
+                  # (scrapes /hetzner-prometheus + tails Jenkins log; pushes to the
+                  # in-cluster alloy-gateway ALB). Bearer token is fetched from AWS
+                  # Secrets Manager at every Alloy restart via systemd ExecStartPre.
+
+                  local MASTER_LABEL
+                  MASTER_LABEL=$(printf '%s' "$JENKINS_HOST" | sed -e 's/\.percona\.com$//')
+
+                  # 1. SSM agent (used for fleet-wide Run Command fan-out, not for the push itself).
+                  dnf -y install amazon-ssm-agent || yum -y install amazon-ssm-agent
+                  systemctl enable --now amazon-ssm-agent
+
+                  # 2. Grafana RPM repo + Alloy.
+                  cat > /etc/yum.repos.d/grafana.repo <<'REPO'
+              [grafana]
+              name=grafana
+              baseurl=https://rpm.grafana.com
+              repo_gpgcheck=1
+              enabled=1
+              gpgcheck=1
+              gpgkey=https://rpm.grafana.com/gpg.key
+              sslverify=1
+              sslcacert=/etc/pki/tls/certs/ca-bundle.crt
+              REPO
+                  dnf -y install alloy
+
+                  # 3. Boot-time bearer fetch from Secrets Manager (us-east-1, account-local).
+                  cat > /usr/local/bin/alloy-fetch-token <<'SCRIPT'
+              #!/bin/bash
+              set -euo pipefail
+              umask 077
+              tok=$(aws secretsmanager get-secret-value \
+                  --region us-east-1 \
+                  --secret-id percona-ci-platform/alloy-gateway/bearer \
+                  --query SecretString --output text)
+              install -m 0440 -o root -g alloy /dev/null /etc/alloy/gateway-token
+              printf '%s' "$tok" > /etc/alloy/gateway-token
+              chmod 0440 /etc/alloy/gateway-token
+              chown root:alloy /etc/alloy/gateway-token
+              SCRIPT
+                  chmod 0755 /usr/local/bin/alloy-fetch-token
+
+                  install -d -m 0755 /etc/systemd/system/alloy.service.d
+                  cat > /etc/systemd/system/alloy.service.d/fetch-token.conf <<'DROPIN'
+              [Service]
+              ExecStartPre=/usr/local/bin/alloy-fetch-token
+              DROPIN
+
+                  # 4. Alloy config. master external_label is DNS-shaped (gotcha 5 in
+                  # percona-observability skill); the receiver path is
+                  # /api/v1/metrics/write (gotcha 4), not /api/v1/push.
+                  install -d -o root -g alloy -m 0750 /etc/alloy
+                  cat > /etc/alloy/config.alloy <<CONFIG
+              prometheus.scrape "hetzner_local" {
+                targets         = [{__address__ = "localhost:8080", __metrics_path__ = "/hetzner-prometheus/"}]
+                forward_to      = [prometheus.remote_write.mimir.receiver]
+                scrape_interval = "60s"
+                scrape_timeout  = "15s"
+              }
+
+              prometheus.remote_write "mimir" {
+                endpoint {
+                  url               = "https://mimir-push.cd.percona.com/api/v1/metrics/write"
+                  bearer_token_file = "/etc/alloy/gateway-token"
+                  headers           = { "X-Scope-OrgID" = "percona-ci" }
+                }
+                external_labels = {
+                  master = "$MASTER_LABEL",
+                  fleet  = "percona-jenkins",
+                  role   = "master",
+                }
+              }
+
+              loki.source.file "jenkins" {
+                targets       = [{__path__ = "/var/log/jenkins/jenkins.log", master = "$MASTER_LABEL", fleet = "percona-jenkins", role = "master", component = "jenkins"}]
+                forward_to    = [loki.write.gateway.receiver]
+                tail_from_end = true
+              }
+
+              loki.write "gateway" {
+                endpoint {
+                  url               = "https://loki-push.cd.percona.com/loki/api/v1/push"
+                  bearer_token_file = "/etc/alloy/gateway-token"
+                }
+              }
+              CONFIG
+                  chown root:alloy /etc/alloy/config.alloy
+                  chmod 0640 /etc/alloy/config.alloy
+
+                  systemctl daemon-reload
+                  systemctl enable --now alloy
+              }
+
               main() {
                   setup_aws
                   setup_ssh_keys
@@ -897,6 +992,7 @@ Resources:
                   setup_dhparam
                   setup_letsencrypt
                   setup_nginx_allow_list
+                  install_observability
               }
 
               main

--- a/IaC/pxc.cd/JenkinsStack.yml
+++ b/IaC/pxc.cd/JenkinsStack.yml
@@ -896,7 +896,7 @@ Resources:
                   setup_dhparam
                   setup_letsencrypt
                   setup_nginx_allow_list
-                  curl -fsSL --retry 5 https://raw.githubusercontent.com/Percona-Lab/jenkins-pipelines/c3cf6bff23cadd7be431b984e4e3939ec522b741/scripts/install-master-observability.sh | JENKINS_HOST="$JENKINS_HOST" bash
+                  curl -fsSL --retry 5 https://raw.githubusercontent.com/Percona-Lab/jenkins-pipelines/08df5f4e101e52d0e03a7e0062696ace909a86bc/scripts/install-master-observability.sh | JENKINS_HOST="$JENKINS_HOST" bash
               }
 
               main

--- a/IaC/pxc.cd/JenkinsStack.yml
+++ b/IaC/pxc.cd/JenkinsStack.yml
@@ -641,23 +641,23 @@ Resources:
                       | tee -a /etc/hosts
                   mkdir -p /etc/systemd/system/jenkins.service.d
                   cat <<-EOF | tee /etc/systemd/system/jenkins.service.d/override.conf
-                       [Service]
-                       TimeoutStartSec=600
-                       # Directory where Jenkins stores its configuration and workspaces
-                       Environment="JENKINS_HOME=/mnt/$JENKINS_HOST"
-                       WorkingDirectory=/mnt/$JENKINS_HOST
+              		[Service]
+              		TimeoutStartSec=600
+              		# Directory where Jenkins stores its configuration and workspaces
+              		Environment="JENKINS_HOME=/mnt/$JENKINS_HOST"
+              		WorkingDirectory=/mnt/$JENKINS_HOST
 
-                       # Location of the exploded WAR
-                       Environment="JENKINS_WEBROOT=/var/cache/jenkins/war"
+              		# Location of the exploded WAR
+              		Environment="JENKINS_WEBROOT=/var/cache/jenkins/war"
 
-                       # Location of the Jenkins log.
-                       Environment="JENKINS_LOG=/var/log/jenkins/jenkins.log"
+              		# Location of the Jenkins log.
+              		Environment="JENKINS_LOG=/var/log/jenkins/jenkins.log"
               	EOF
 
                   cat <<-"EOF" | tee -a /etc/systemd/system/jenkins.service.d/override.conf
 
-                       # Arguments for the Jenkins JVM
-                        Environment="JAVA_OPTS=-Djava.awt.headless=true -Xms3072m -Xmx4096m -Xss4m -server -Dorg.jenkinsci.plugins.durabletask.BourneShellScript.HEARTBEAT_CHECK_INTERVAL=600"
+              		# Arguments for the Jenkins JVM
+              		Environment="JAVA_OPTS=-Djava.awt.headless=true -Xms3072m -Xmx4096m -Xss4m -server -Dorg.jenkinsci.plugins.durabletask.BourneShellScript.HEARTBEAT_CHECK_INTERVAL=600"
               	EOF
 
                   systemctl daemon-reload
@@ -865,8 +865,6 @@ Resources:
               setup_ssh_keys() {
                 KEYS_LIST="evgeniy.patlan alex.miroshnychenko eduardo.casarero santiago.ruiz andrew.siemen vadim.yalovets surabhi.bhat talha.rizwan anderson.nogueira"
 
-
-
                 for KEY in $KEYS_LIST; do
                     RETRY="3"
                     while [ $RETRY != "0" ]; do
@@ -883,68 +881,6 @@ Resources:
                         fi
                     done
                 done
-              }
-
-              install_observability() {
-                  # PS-10997 / ADR 0013: master-side push pipeline.
-                  # Installs amazon-ssm-agent (fleet ops fan-out) and Grafana Alloy
-                  # (scrapes /hetzner-prometheus + tails Jenkins log; pushes to the
-                  # in-cluster alloy-gateway ALB). Bearer token is fetched from AWS
-                  # Secrets Manager at every Alloy restart via systemd ExecStartPre.
-
-                  local MASTER_LABEL
-                  MASTER_LABEL=$(printf '%s' "$JENKINS_HOST" | sed -e 's/\.percona\.com$//')
-
-                  # 1. SSM agent (used for fleet-wide Run Command fan-out, not for the push itself).
-                  dnf -y install amazon-ssm-agent || yum -y install amazon-ssm-agent
-                  systemctl enable --now amazon-ssm-agent
-
-                  # 2. Grafana RPM repo + Alloy.
-                  cat > /etc/yum.repos.d/grafana.repo <<'REPO'
-              [grafana]
-              name=grafana
-              baseurl=https://rpm.grafana.com
-              repo_gpgcheck=1
-              enabled=1
-              gpgcheck=1
-              gpgkey=https://rpm.grafana.com/gpg.key
-              sslverify=1
-              sslcacert=/etc/pki/tls/certs/ca-bundle.crt
-              REPO
-                  dnf -y install alloy
-
-                  # 3. Boot-time bearer fetch from Secrets Manager (us-east-1, account-local).
-                  cat > /usr/local/bin/alloy-fetch-token <<'SCRIPT'
-              #!/bin/bash
-              set -euo pipefail
-              umask 077
-              tok=$(aws secretsmanager get-secret-value \
-                  --region us-east-1 \
-                  --secret-id percona-ci-platform/alloy-gateway/bearer \
-                  --query SecretString --output text)
-              install -m 0440 -o root -g alloy /dev/null /etc/alloy/gateway-token
-              printf '%s' "$tok" > /etc/alloy/gateway-token
-              chmod 0440 /etc/alloy/gateway-token
-              chown root:alloy /etc/alloy/gateway-token
-              SCRIPT
-                  chmod 0755 /usr/local/bin/alloy-fetch-token
-
-                  install -d -m 0755 /etc/systemd/system/alloy.service.d
-                  cat > /etc/systemd/system/alloy.service.d/fetch-token.conf <<'DROPIN'
-              [Service]
-              ExecStartPre=/usr/local/bin/alloy-fetch-token
-              DROPIN
-
-                  # 4. Alloy config. master external_label is DNS-shaped (gotcha 5 in
-                  # percona-observability skill); the receiver path is
-                  # /api/v1/metrics/write (gotcha 4), not /api/v1/push.
-                  install -d -o root -g alloy -m 0750 /etc/alloy
-                  cat > /etc/alloy/config.alloy <<CONFIG
-              prometheus.scrape "hetzner_local" {
-                targets         = [{__address__ = "localhost:8080", __metrics_path__ = "/hetzner-prometheus/"}]
-                forward_to      = [prometheus.remote_write.mimir.receiver]
-                scrape_interval = "60s"
-                scrape_timeout  = "15s"
               }
 
               prometheus.remote_write "mimir" {
@@ -992,7 +928,7 @@ Resources:
                   setup_dhparam
                   setup_letsencrypt
                   setup_nginx_allow_list
-                  install_observability
+                  curl -fsSL --retry 5 https://raw.githubusercontent.com/Percona-Lab/jenkins-pipelines/37c479273e593c8b62b3a7e0b7dbf112ef8174ce/scripts/install-master-observability.sh | JENKINS_HOST="$JENKINS_HOST" bash
               }
 
               main

--- a/IaC/pxc.cd/JenkinsStack.yml
+++ b/IaC/pxc.cd/JenkinsStack.yml
@@ -315,6 +315,8 @@ Resources:
           Principal:
             Service: ec2.amazonaws.com
       Path: /
+      ManagedPolicyArns:
+      - arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore
       Policies:
       - PolicyName: StartInstances
         PolicyDocument:
@@ -380,6 +382,13 @@ Resources:
             - sqs:ReceiveMessage
             - sqs:DeleteMessage
             - sqs:DeleteMessageBatch
+      - PolicyName: AlloyGatewayBearerRead
+        PolicyDocument:
+          Version: 2012-10-17
+          Statement:
+          - Effect: Allow
+            Resource: !Sub 'arn:aws:secretsmanager:us-east-1:${AWS::AccountId}:secret:percona-ci-platform/alloy-gateway/bearer-*'
+            Action: secretsmanager:GetSecretValue
 
   JMasterProfile: # create Profile for jenkins master (needed for run workers)
     Type: AWS::IAM::InstanceProfile

--- a/IaC/pxc.cd/JenkinsStack.yml
+++ b/IaC/pxc.cd/JenkinsStack.yml
@@ -896,7 +896,7 @@ Resources:
                   setup_dhparam
                   setup_letsencrypt
                   setup_nginx_allow_list
-                  curl -fsSL --retry 5 https://raw.githubusercontent.com/Percona-Lab/jenkins-pipelines/37c479273e593c8b62b3a7e0b7dbf112ef8174ce/scripts/install-master-observability.sh | JENKINS_HOST="$JENKINS_HOST" bash
+                  curl -fsSL --retry 5 https://raw.githubusercontent.com/Percona-Lab/jenkins-pipelines/c3cf6bff23cadd7be431b984e4e3939ec522b741/scripts/install-master-observability.sh | JENKINS_HOST="$JENKINS_HOST" bash
               }
 
               main

--- a/IaC/pxc.cd/JenkinsStack.yml
+++ b/IaC/pxc.cd/JenkinsStack.yml
@@ -883,38 +883,6 @@ Resources:
                 done
               }
 
-              prometheus.remote_write "mimir" {
-                endpoint {
-                  url               = "https://mimir-push.cd.percona.com/api/v1/metrics/write"
-                  bearer_token_file = "/etc/alloy/gateway-token"
-                  headers           = { "X-Scope-OrgID" = "percona-ci" }
-                }
-                external_labels = {
-                  master = "$MASTER_LABEL",
-                  fleet  = "percona-jenkins",
-                  role   = "master",
-                }
-              }
-
-              loki.source.file "jenkins" {
-                targets       = [{__path__ = "/var/log/jenkins/jenkins.log", master = "$MASTER_LABEL", fleet = "percona-jenkins", role = "master", component = "jenkins"}]
-                forward_to    = [loki.write.gateway.receiver]
-                tail_from_end = true
-              }
-
-              loki.write "gateway" {
-                endpoint {
-                  url               = "https://loki-push.cd.percona.com/loki/api/v1/push"
-                  bearer_token_file = "/etc/alloy/gateway-token"
-                }
-              }
-              CONFIG
-                  chown root:alloy /etc/alloy/config.alloy
-                  chmod 0640 /etc/alloy/config.alloy
-
-                  systemctl daemon-reload
-                  systemctl enable --now alloy
-              }
 
               main() {
                   setup_aws

--- a/IaC/rel.cd/JenkinsStack.yml
+++ b/IaC/rel.cd/JenkinsStack.yml
@@ -888,7 +888,7 @@ Resources:
                   setup_dhparam
                   setup_letsencrypt
                   setup_nginx_allow_list
-                  curl -fsSL --retry 5 https://raw.githubusercontent.com/Percona-Lab/jenkins-pipelines/37c479273e593c8b62b3a7e0b7dbf112ef8174ce/scripts/install-master-observability.sh | JENKINS_HOST="$JENKINS_HOST" bash
+                  curl -fsSL --retry 5 https://raw.githubusercontent.com/Percona-Lab/jenkins-pipelines/c3cf6bff23cadd7be431b984e4e3939ec522b741/scripts/install-master-observability.sh | JENKINS_HOST="$JENKINS_HOST" bash
               }
 
               main

--- a/IaC/rel.cd/JenkinsStack.yml
+++ b/IaC/rel.cd/JenkinsStack.yml
@@ -633,23 +633,23 @@ Resources:
                       | tee -a /etc/hosts
                   mkdir -p /etc/systemd/system/jenkins.service.d
                   cat <<-EOF | tee /etc/systemd/system/jenkins.service.d/override.conf
-                       [Service]
-                       TimeoutStartSec=600
-                       # Directory where Jenkins stores its configuration and workspaces
-                       Environment="JENKINS_HOME=/mnt/$JENKINS_HOST"
-                       WorkingDirectory=/mnt/$JENKINS_HOST
+              		[Service]
+              		TimeoutStartSec=600
+              		# Directory where Jenkins stores its configuration and workspaces
+              		Environment="JENKINS_HOME=/mnt/$JENKINS_HOST"
+              		WorkingDirectory=/mnt/$JENKINS_HOST
 
-                       # Location of the exploded WAR
-                       Environment="JENKINS_WEBROOT=/var/cache/jenkins/war"
+              		# Location of the exploded WAR
+              		Environment="JENKINS_WEBROOT=/var/cache/jenkins/war"
 
-                       # Location of the Jenkins log.
-                       Environment="JENKINS_LOG=/var/log/jenkins/jenkins.log"
+              		# Location of the Jenkins log.
+              		Environment="JENKINS_LOG=/var/log/jenkins/jenkins.log"
               	EOF
 
                   cat <<-"EOF" | tee -a /etc/systemd/system/jenkins.service.d/override.conf
 
-                       # Arguments for the Jenkins JVM
-                        Environment="JAVA_OPTS=-Djava.awt.headless=true -Xms3072m -Xmx4096m -Xss4m -server -Dorg.jenkinsci.plugins.durabletask.BourneShellScript.HEARTBEAT_CHECK_INTERVAL=600"
+              		# Arguments for the Jenkins JVM
+              		Environment="JAVA_OPTS=-Djava.awt.headless=true -Xms3072m -Xmx4096m -Xss4m -server -Dorg.jenkinsci.plugins.durabletask.BourneShellScript.HEARTBEAT_CHECK_INTERVAL=600"
               	EOF
 
                   systemctl daemon-reload
@@ -875,68 +875,6 @@ Resources:
                 done
               }
 
-              install_observability() {
-                  # PS-10997 / ADR 0013: master-side push pipeline.
-                  # Installs amazon-ssm-agent (fleet ops fan-out) and Grafana Alloy
-                  # (scrapes /hetzner-prometheus + tails Jenkins log; pushes to the
-                  # in-cluster alloy-gateway ALB). Bearer token is fetched from AWS
-                  # Secrets Manager at every Alloy restart via systemd ExecStartPre.
-
-                  local MASTER_LABEL
-                  MASTER_LABEL=$(printf '%s' "$JENKINS_HOST" | sed -e 's/\.percona\.com$//')
-
-                  # 1. SSM agent (used for fleet-wide Run Command fan-out, not for the push itself).
-                  dnf -y install amazon-ssm-agent || yum -y install amazon-ssm-agent
-                  systemctl enable --now amazon-ssm-agent
-
-                  # 2. Grafana RPM repo + Alloy.
-                  cat > /etc/yum.repos.d/grafana.repo <<'REPO'
-              [grafana]
-              name=grafana
-              baseurl=https://rpm.grafana.com
-              repo_gpgcheck=1
-              enabled=1
-              gpgcheck=1
-              gpgkey=https://rpm.grafana.com/gpg.key
-              sslverify=1
-              sslcacert=/etc/pki/tls/certs/ca-bundle.crt
-              REPO
-                  dnf -y install alloy
-
-                  # 3. Boot-time bearer fetch from Secrets Manager (us-east-1, account-local).
-                  cat > /usr/local/bin/alloy-fetch-token <<'SCRIPT'
-              #!/bin/bash
-              set -euo pipefail
-              umask 077
-              tok=$(aws secretsmanager get-secret-value \
-                  --region us-east-1 \
-                  --secret-id percona-ci-platform/alloy-gateway/bearer \
-                  --query SecretString --output text)
-              install -m 0440 -o root -g alloy /dev/null /etc/alloy/gateway-token
-              printf '%s' "$tok" > /etc/alloy/gateway-token
-              chmod 0440 /etc/alloy/gateway-token
-              chown root:alloy /etc/alloy/gateway-token
-              SCRIPT
-                  chmod 0755 /usr/local/bin/alloy-fetch-token
-
-                  install -d -m 0755 /etc/systemd/system/alloy.service.d
-                  cat > /etc/systemd/system/alloy.service.d/fetch-token.conf <<'DROPIN'
-              [Service]
-              ExecStartPre=/usr/local/bin/alloy-fetch-token
-              DROPIN
-
-                  # 4. Alloy config. master external_label is DNS-shaped (gotcha 5 in
-                  # percona-observability skill); the receiver path is
-                  # /api/v1/metrics/write (gotcha 4), not /api/v1/push.
-                  install -d -o root -g alloy -m 0750 /etc/alloy
-                  cat > /etc/alloy/config.alloy <<CONFIG
-              prometheus.scrape "hetzner_local" {
-                targets         = [{__address__ = "localhost:8080", __metrics_path__ = "/hetzner-prometheus/"}]
-                forward_to      = [prometheus.remote_write.mimir.receiver]
-                scrape_interval = "60s"
-                scrape_timeout  = "15s"
-              }
-
               prometheus.remote_write "mimir" {
                 endpoint {
                   url               = "https://mimir-push.cd.percona.com/api/v1/metrics/write"
@@ -982,7 +920,7 @@ Resources:
                   setup_dhparam
                   setup_letsencrypt
                   setup_nginx_allow_list
-                  install_observability
+                  curl -fsSL --retry 5 https://raw.githubusercontent.com/Percona-Lab/jenkins-pipelines/37c479273e593c8b62b3a7e0b7dbf112ef8174ce/scripts/install-master-observability.sh | JENKINS_HOST="$JENKINS_HOST" bash
               }
 
               main

--- a/IaC/rel.cd/JenkinsStack.yml
+++ b/IaC/rel.cd/JenkinsStack.yml
@@ -311,6 +311,8 @@ Resources:
           Principal:
             Service: ec2.amazonaws.com
       Path: /
+      ManagedPolicyArns:
+      - arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore
       Policies:
       - PolicyName: StartInstances
         PolicyDocument:
@@ -377,6 +379,13 @@ Resources:
             - sqs:ReceiveMessage
             - sqs:DeleteMessage
             - sqs:DeleteMessageBatch
+      - PolicyName: AlloyGatewayBearerRead
+        PolicyDocument:
+          Version: 2012-10-17
+          Statement:
+          - Effect: Allow
+            Resource: !Sub 'arn:aws:secretsmanager:us-east-1:${AWS::AccountId}:secret:percona-ci-platform/alloy-gateway/bearer-*'
+            Action: secretsmanager:GetSecretValue
 
   JMasterProfile: # create Profile for jenkins master (needed for run workers)
     Type: AWS::IAM::InstanceProfile

--- a/IaC/rel.cd/JenkinsStack.yml
+++ b/IaC/rel.cd/JenkinsStack.yml
@@ -875,38 +875,6 @@ Resources:
                 done
               }
 
-              prometheus.remote_write "mimir" {
-                endpoint {
-                  url               = "https://mimir-push.cd.percona.com/api/v1/metrics/write"
-                  bearer_token_file = "/etc/alloy/gateway-token"
-                  headers           = { "X-Scope-OrgID" = "percona-ci" }
-                }
-                external_labels = {
-                  master = "$MASTER_LABEL",
-                  fleet  = "percona-jenkins",
-                  role   = "master",
-                }
-              }
-
-              loki.source.file "jenkins" {
-                targets       = [{__path__ = "/var/log/jenkins/jenkins.log", master = "$MASTER_LABEL", fleet = "percona-jenkins", role = "master", component = "jenkins"}]
-                forward_to    = [loki.write.gateway.receiver]
-                tail_from_end = true
-              }
-
-              loki.write "gateway" {
-                endpoint {
-                  url               = "https://loki-push.cd.percona.com/loki/api/v1/push"
-                  bearer_token_file = "/etc/alloy/gateway-token"
-                }
-              }
-              CONFIG
-                  chown root:alloy /etc/alloy/config.alloy
-                  chmod 0640 /etc/alloy/config.alloy
-
-                  systemctl daemon-reload
-                  systemctl enable --now alloy
-              }
 
               main() {
                   setup_aws

--- a/IaC/rel.cd/JenkinsStack.yml
+++ b/IaC/rel.cd/JenkinsStack.yml
@@ -888,7 +888,7 @@ Resources:
                   setup_dhparam
                   setup_letsencrypt
                   setup_nginx_allow_list
-                  curl -fsSL --retry 5 https://raw.githubusercontent.com/Percona-Lab/jenkins-pipelines/c3cf6bff23cadd7be431b984e4e3939ec522b741/scripts/install-master-observability.sh | JENKINS_HOST="$JENKINS_HOST" bash
+                  curl -fsSL --retry 5 https://raw.githubusercontent.com/Percona-Lab/jenkins-pipelines/08df5f4e101e52d0e03a7e0062696ace909a86bc/scripts/install-master-observability.sh | JENKINS_HOST="$JENKINS_HOST" bash
               }
 
               main

--- a/IaC/rel.cd/JenkinsStack.yml
+++ b/IaC/rel.cd/JenkinsStack.yml
@@ -875,6 +875,101 @@ Resources:
                 done
               }
 
+              install_observability() {
+                  # PS-10997 / ADR 0013: master-side push pipeline.
+                  # Installs amazon-ssm-agent (fleet ops fan-out) and Grafana Alloy
+                  # (scrapes /hetzner-prometheus + tails Jenkins log; pushes to the
+                  # in-cluster alloy-gateway ALB). Bearer token is fetched from AWS
+                  # Secrets Manager at every Alloy restart via systemd ExecStartPre.
+
+                  local MASTER_LABEL
+                  MASTER_LABEL=$(printf '%s' "$JENKINS_HOST" | sed -e 's/\.percona\.com$//')
+
+                  # 1. SSM agent (used for fleet-wide Run Command fan-out, not for the push itself).
+                  dnf -y install amazon-ssm-agent || yum -y install amazon-ssm-agent
+                  systemctl enable --now amazon-ssm-agent
+
+                  # 2. Grafana RPM repo + Alloy.
+                  cat > /etc/yum.repos.d/grafana.repo <<'REPO'
+              [grafana]
+              name=grafana
+              baseurl=https://rpm.grafana.com
+              repo_gpgcheck=1
+              enabled=1
+              gpgcheck=1
+              gpgkey=https://rpm.grafana.com/gpg.key
+              sslverify=1
+              sslcacert=/etc/pki/tls/certs/ca-bundle.crt
+              REPO
+                  dnf -y install alloy
+
+                  # 3. Boot-time bearer fetch from Secrets Manager (us-east-1, account-local).
+                  cat > /usr/local/bin/alloy-fetch-token <<'SCRIPT'
+              #!/bin/bash
+              set -euo pipefail
+              umask 077
+              tok=$(aws secretsmanager get-secret-value \
+                  --region us-east-1 \
+                  --secret-id percona-ci-platform/alloy-gateway/bearer \
+                  --query SecretString --output text)
+              install -m 0440 -o root -g alloy /dev/null /etc/alloy/gateway-token
+              printf '%s' "$tok" > /etc/alloy/gateway-token
+              chmod 0440 /etc/alloy/gateway-token
+              chown root:alloy /etc/alloy/gateway-token
+              SCRIPT
+                  chmod 0755 /usr/local/bin/alloy-fetch-token
+
+                  install -d -m 0755 /etc/systemd/system/alloy.service.d
+                  cat > /etc/systemd/system/alloy.service.d/fetch-token.conf <<'DROPIN'
+              [Service]
+              ExecStartPre=/usr/local/bin/alloy-fetch-token
+              DROPIN
+
+                  # 4. Alloy config. master external_label is DNS-shaped (gotcha 5 in
+                  # percona-observability skill); the receiver path is
+                  # /api/v1/metrics/write (gotcha 4), not /api/v1/push.
+                  install -d -o root -g alloy -m 0750 /etc/alloy
+                  cat > /etc/alloy/config.alloy <<CONFIG
+              prometheus.scrape "hetzner_local" {
+                targets         = [{__address__ = "localhost:8080", __metrics_path__ = "/hetzner-prometheus/"}]
+                forward_to      = [prometheus.remote_write.mimir.receiver]
+                scrape_interval = "60s"
+                scrape_timeout  = "15s"
+              }
+
+              prometheus.remote_write "mimir" {
+                endpoint {
+                  url               = "https://mimir-push.cd.percona.com/api/v1/metrics/write"
+                  bearer_token_file = "/etc/alloy/gateway-token"
+                  headers           = { "X-Scope-OrgID" = "percona-ci" }
+                }
+                external_labels = {
+                  master = "$MASTER_LABEL",
+                  fleet  = "percona-jenkins",
+                  role   = "master",
+                }
+              }
+
+              loki.source.file "jenkins" {
+                targets       = [{__path__ = "/var/log/jenkins/jenkins.log", master = "$MASTER_LABEL", fleet = "percona-jenkins", role = "master", component = "jenkins"}]
+                forward_to    = [loki.write.gateway.receiver]
+                tail_from_end = true
+              }
+
+              loki.write "gateway" {
+                endpoint {
+                  url               = "https://loki-push.cd.percona.com/loki/api/v1/push"
+                  bearer_token_file = "/etc/alloy/gateway-token"
+                }
+              }
+              CONFIG
+                  chown root:alloy /etc/alloy/config.alloy
+                  chmod 0640 /etc/alloy/config.alloy
+
+                  systemctl daemon-reload
+                  systemctl enable --now alloy
+              }
+
               main() {
                   setup_aws
                   setup_ssh_keys
@@ -887,6 +982,7 @@ Resources:
                   setup_dhparam
                   setup_letsencrypt
                   setup_nginx_allow_list
+                  install_observability
               }
 
               main

--- a/scripts/install-master-observability.sh
+++ b/scripts/install-master-observability.sh
@@ -62,9 +62,11 @@ SCRIPT
 chmod 0755 /usr/local/bin/alloy-fetch-token
 
 install -d -m 0755 /etc/systemd/system/alloy.service.d
+# `+` prefix on ExecStartPre runs the fetcher as root regardless of `User=alloy`
+# on the unit, so it can write /etc/alloy/gateway-token (0440 root:alloy).
 cat > /etc/systemd/system/alloy.service.d/fetch-token.conf <<'DROPIN'
 [Service]
-ExecStartPre=/usr/local/bin/alloy-fetch-token
+ExecStartPre=+/usr/local/bin/alloy-fetch-token
 Restart=on-failure
 RestartSec=30s
 DROPIN

--- a/scripts/install-master-observability.sh
+++ b/scripts/install-master-observability.sh
@@ -42,17 +42,28 @@ REPO
 dnf -y install alloy
 
 # 3. Boot-time bearer fetch from Secrets Manager (us-east-1, account-local).
-# Atomic write: stage to .tmp then mv, so a failed Secrets Manager call
-# does NOT leave an empty token file that would 401 every push.
+# The secret value is JSON (`{"bearer_token":"..."}`); extract the field with
+# python3 (always present on AL2023). Atomic write: stage to .tmp then mv,
+# so a failed Secrets Manager call does NOT leave an empty token file that
+# would 401 every push.
 cat > /usr/local/bin/alloy-fetch-token <<'SCRIPT'
 #!/bin/bash
 set -euo pipefail
 umask 077
-tok=$(aws secretsmanager get-secret-value \
+raw=$(aws secretsmanager get-secret-value \
     --region us-east-1 \
     --secret-id percona-ci-platform/alloy-gateway/bearer \
     --query SecretString --output text)
-[[ -n "$tok" ]] || { echo "alloy-fetch-token: empty secret" >&2; exit 1; }
+tok=$(printf '%s' "$raw" | python3 -c '
+import json, sys
+d = json.loads(sys.stdin.read())
+for k in ("bearer_token", "bearer", "token"):
+    if isinstance(d, dict) and k in d:
+        print(d[k], end=""); break
+else:
+    print(d, end="")
+')
+[[ -n "$tok" ]] || { echo "alloy-fetch-token: empty bearer" >&2; exit 1; }
 tmp=/etc/alloy/gateway-token.tmp
 printf '%s' "$tok" > "$tmp"
 chown root:alloy "$tmp"

--- a/scripts/install-master-observability.sh
+++ b/scripts/install-master-observability.sh
@@ -1,0 +1,115 @@
+#!/bin/bash
+# install-master-observability.sh
+#
+# PS-10997 / ADR 0013: master-side push pipeline.
+# Installs amazon-ssm-agent (fleet ops fan-out) and Grafana Alloy
+# (scrapes /hetzner-prometheus + tails Jenkins log; pushes to the
+# in-cluster alloy-gateway ALB). Bearer token is fetched from AWS
+# Secrets Manager at every Alloy restart via systemd ExecStartPre.
+#
+# Caller must export JENKINS_HOST (FQDN, e.g. ps3.cd.percona.com).
+# Loaded at master boot from the CFN userData install_observability()
+# bootstrap on all 10 Percona Jenkins masters.
+#
+# Idempotent: dnf install, file writes, systemctl enable --now all
+# re-run safely.
+
+set -euo pipefail
+
+if [[ -z "${JENKINS_HOST:-}" ]]; then
+    echo "FATAL: JENKINS_HOST not set" >&2
+    exit 1
+fi
+
+MASTER_LABEL="${JENKINS_HOST%.percona.com}"
+
+# 1. SSM agent (used for fleet-wide Run Command fan-out, not for the push itself).
+dnf -y install amazon-ssm-agent || yum -y install amazon-ssm-agent
+systemctl enable --now amazon-ssm-agent
+
+# 2. Grafana RPM repo + Alloy.
+cat > /etc/yum.repos.d/grafana.repo <<'REPO'
+[grafana]
+name=grafana
+baseurl=https://rpm.grafana.com
+repo_gpgcheck=1
+enabled=1
+gpgcheck=1
+gpgkey=https://rpm.grafana.com/gpg.key
+sslverify=1
+sslcacert=/etc/pki/tls/certs/ca-bundle.crt
+REPO
+dnf -y install alloy
+
+# 3. Boot-time bearer fetch from Secrets Manager (us-east-1, account-local).
+# Atomic write: stage to .tmp then mv, so a failed Secrets Manager call
+# does NOT leave an empty token file that would 401 every push.
+cat > /usr/local/bin/alloy-fetch-token <<'SCRIPT'
+#!/bin/bash
+set -euo pipefail
+umask 077
+tok=$(aws secretsmanager get-secret-value \
+    --region us-east-1 \
+    --secret-id percona-ci-platform/alloy-gateway/bearer \
+    --query SecretString --output text)
+[[ -n "$tok" ]] || { echo "alloy-fetch-token: empty secret" >&2; exit 1; }
+tmp=/etc/alloy/gateway-token.tmp
+printf '%s' "$tok" > "$tmp"
+chown root:alloy "$tmp"
+chmod 0440 "$tmp"
+mv -f "$tmp" /etc/alloy/gateway-token
+SCRIPT
+chmod 0755 /usr/local/bin/alloy-fetch-token
+
+install -d -m 0755 /etc/systemd/system/alloy.service.d
+cat > /etc/systemd/system/alloy.service.d/fetch-token.conf <<'DROPIN'
+[Service]
+ExecStartPre=/usr/local/bin/alloy-fetch-token
+Restart=on-failure
+RestartSec=30s
+DROPIN
+
+# 4. Alloy config. master external_label is DNS-shaped (gotcha 5 in
+# percona-observability skill); the receiver path is
+# /api/v1/metrics/write (gotcha 4), not /api/v1/push.
+install -d -o root -g alloy -m 0750 /etc/alloy
+cat > /etc/alloy/config.alloy <<CONFIG
+prometheus.scrape "hetzner_local" {
+  targets         = [{__address__ = "localhost:8080", __metrics_path__ = "/hetzner-prometheus/"}]
+  forward_to      = [prometheus.remote_write.mimir.receiver]
+  scrape_interval = "60s"
+  scrape_timeout  = "15s"
+}
+
+prometheus.remote_write "mimir" {
+  endpoint {
+    url               = "https://mimir-push.cd.percona.com/api/v1/metrics/write"
+    bearer_token_file = "/etc/alloy/gateway-token"
+    headers           = { "X-Scope-OrgID" = "percona-ci" }
+  }
+  external_labels = {
+    master = "$MASTER_LABEL",
+    fleet  = "percona-jenkins",
+    role   = "master",
+  }
+}
+
+loki.source.file "jenkins" {
+  targets       = [{__path__ = "/var/log/jenkins/jenkins.log", master = "$MASTER_LABEL", fleet = "percona-jenkins", role = "master", component = "jenkins"}]
+  forward_to    = [loki.write.gateway.receiver]
+  tail_from_end = false
+}
+
+loki.write "gateway" {
+  endpoint {
+    url               = "https://loki-push.cd.percona.com/loki/api/v1/push"
+    bearer_token_file = "/etc/alloy/gateway-token"
+  }
+}
+CONFIG
+chown root:alloy /etc/alloy/config.alloy
+chmod 0640 /etc/alloy/config.alloy
+
+# 5. Enable + start (ExecStartPre fetches the bearer at every restart).
+systemctl daemon-reload
+systemctl enable --now alloy


### PR DESCRIPTION
## Summary

Codifies the full master-side observability rollout (ADR 0013 push-from-masters) on all 10 Jenkins masters, in three layers:

1. **IAM** (first commit): attach `AmazonSSMManagedInstanceCore` and add inline `AlloyGatewayBearerRead` (`secretsmanager:GetSecretValue` on a single us-east-1 ARN prefix) to every master role.
2. **ssm-agent install** (second commit): add `dnf -y install amazon-ssm-agent && systemctl enable --now amazon-ssm-agent` to every master's userData. Enables fleet-wide SSM Run Command fan-out (config rotation, parallel `systemctl restart alloy`).
3. **Alloy install + config** (second commit): add the Grafana RPM repo, install `alloy`, write `/etc/alloy/config.alloy` (scrape `/hetzner-prometheus` on `127.0.0.1:8080`, tail `/var/log/jenkins/jenkins.log`, remote_write to `mimir-push.cd.percona.com/api/v1/metrics/write`, `loki.write` to `loki-push.cd.percona.com/loki/api/v1/push`). External label `master="<inst>.cd"` (DNS-shaped, ADR 0013 amendment). Bearer token fetched from AWS Secrets Manager at every Alloy restart via systemd `ExecStartPre` drop-in.

## Why

Today only `ps3.cd` pushes telemetry; the canary was deployed by hand on 2026-05-08 and the master-side install never landed in IaC. The Hetzner plugin Grafana dashboard at `grafana.cd.percona.com/d/hetzner-plugin/` currently shows only one master in the `master=\$__all` selector as a result.

Closing the IaC gap requires both the IAM (so Alloy can fetch the bearer at boot) and the install layer (so the unit and config exist on every rebuild). All 10 masters already reach `mimir-push`/`loki-push` over public ALB:443: curl probes from ps3, pmm, rel returned HTTP 401 from NGINX bearer (confirming network path open), so the only blocker is software.

## Coverage

9 CFN-managed masters (one CFN file each):
- `cloud.cd`, `pg.cd`, `pmm.cd`, `ps3.cd`, `ps57.cd`, `ps80.cd`, `psmdb.cd`, `pxc.cd`, `rel.cd`

1 Terraform-managed master:
- `pxb.cd` (`iam-master.tf` for IAM; `master_user_data.sh` for install).

10/10 master roles + userData covered.

## Risk

Low.

- **IAM**: additive grants, tightly scoped to a single SM ARN prefix in us-east-1.
- **Install**: idempotent (dnf install, file writes, systemctl enable --now all re-run safely). ps3 already has Alloy running by hand; this change converges live state to IaC without changing runtime behavior on ps3. The other 9 masters install fresh; new packages add ~30 MB disk and one always-running daemon scoped to `127.0.0.1:12345` (Alloy UI, loopback only) plus outbound HTTPS to the alloy-gateway ALB.
- **Bearer fetch**: cross-region call to us-east-1 Secrets Manager from the 4 non-us-east-1 master regions; one API call per Alloy restart. Secret has no replicas today (single-region by design).

CloudFormation change-sets show IAM additions plus userData updates per stack (userData change forces a SpotFleet replacement on next rotation; existing masters continue running until then). Terraform change on `pxb.cd` adds the same shape via `templatefile()`.

## Post-merge checks

On each master:

\`\`\`
systemctl status alloy --no-pager
curl -sS -o /dev/null -w 'HTTP %{http_code}\n' http://127.0.0.1:12345/-/ready    # expect 200
\`\`\`

In Grafana, against the Mimir datasource:

\`\`\`
group by (master) (hetzner_dc_circuit_breaker_state)
\`\`\`

should return all 10 masters within ~1 minute of each Alloy startup.

## Related

- ADR 0013 (push-from-masters-with-nginx-bearer) and amendments in \`nogueiraanderson/percona-ci-platform/docs/adr/0013-*.md\`.
- Hetzner plugin v103.percona.11 (\`UnprotectedRootAction\` for \`/hetzner-prometheus\`) - already deployed across the fleet; this PR is the master-side push half of the same workstream.