### PR TITLE
fix(pxb): add timeout and disableResume to innodb-rocksdb pipeline

### DIFF
--- a/pxb/jenkins/pxb-new-ps-innodb-rocksdb.groovy
+++ b/pxb/jenkins/pxb-new-ps-innodb-rocksdb.groovy
@@ -153,6 +153,8 @@ pipeline {
   options {
     withCredentials(moleculepxbJenkinsCreds())
     disableConcurrentBuilds()
+    disableResume()
+    timeout(time: 12, unit: 'HOURS')
   }
 
   stages {


### PR DESCRIPTION
## Why

Long PXB python runs were failing at ~7h. Root cause was a Jenkins master safe-restart landing mid-build, not a Hetzner cap. Both [build 23](https://pxb.cd.percona.com/job/pxb-new-ps-innodb-rocksdb/23/console) and [build 31](https://pxb.cd.percona.com/job/pxb-new-ps-innodb-rocksdb/31/console) hit `Pausing (shutting down)` then `Resuming after Jenkins restart`, then a 5-minute agent wait, then abort. The "~7h" was just (build start to restart) + 5 min.

Verified: Hetzner has no max-age, the `pxb-htz` plugin retention reaps only idle nodes, and the pipeline had no `timeout()`.

## What

```groovy
options {
    ...
    disableResume()
    timeout(time: 12, unit: 'HOURS')
}
```

- `disableResume()` aborts immediately on a master restart instead of resuming into a dead agent.
- 12h `timeout()` is the outer cap. Tighten or extend if full-suite runs need more.

Targets `tomislav-pxb-python` since that branch is where the job's `script_path` resolves from.