### PR TITLE
PKG-1329: fetch pxc.cd init.groovy.d files at CF bootstrap

### DIFF
--- a/IaC/pxc.cd/JenkinsStack.yml
+++ b/IaC/pxc.cd/JenkinsStack.yml
@@ -637,6 +637,11 @@ Resources:
                     https://raw.githubusercontent.com/Percona-Lab/jenkins-pipelines/master/IaC/init.groovy.d/plugins.groovy
                   sed -i 's/%LIST%/ec2 aws-sqs compress-buildlog google-login jobConfigHistory matrix-auth matrix-reloaded ssh-slaves template-project warnings ws-cleanup/' /mnt/$JENKINS_HOST/init.groovy.d/plugins.groovy
 
+                  wget -O /mnt/$JENKINS_HOST/init.groovy.d/cloud.groovy \
+                    https://raw.githubusercontent.com/Percona-Lab/jenkins-pipelines/master/IaC/pxc.cd/init.groovy.d/cloud.groovy
+                  wget -O /mnt/$JENKINS_HOST/init.groovy.d/matrix.groovy \
+                    https://raw.githubusercontent.com/Percona-Lab/jenkins-pipelines/master/IaC/pxc.cd/init.groovy.d/matrix.groovy
+
                   printf "127.0.0.1 $(hostname) $(hostname -A)\n10.30.6.220 vbox-01.ci.percona.com\n10.30.6.9 repo.ci.percona.com\n" \
                       | tee -a /etc/hosts
                   mkdir -p /etc/systemd/system/jenkins.service.d


### PR DESCRIPTION
Mirrors the existing `plugins.groovy` fetch pattern. Adds `wget` for `cloud.groovy` and `matrix.groovy` from the IaC repo so a fresh master bootstrap reconstructs the full `init.groovy.d` directory from git.

Without this, the [PR 4045](https://github.com/Percona-Lab/jenkins-pipelines/pull/4045) metal templates (and any future `cloud.groovy` edit) only persist on the live master's disk. An EC2 replacement brings up a master with no per-master `init.groovy.d` and zero EC2 templates.

Scoped to pxc.cd; fleet-wide equivalent is [PKG-1310](https://perconadev.atlassian.net/browse/PKG-1310).

Jira: [PKG-1329](https://perconadev.atlassian.net/browse/PKG-1329)

[PKG-1310]: https://perconadev.atlassian.net/browse/PKG-1310?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[PKG-1329]: https://perconadev.atlassian.net/browse/PKG-1329?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ