### PR TITLE
Update component versions in ppg release test pipelines.

### DIFF
--- a/ppg/component-multi-parallel.groovy
+++ b/ppg/component-multi-parallel.groovy
@@ -14,20 +14,20 @@ pipeline {
 
     parameters {
         choice(name: 'REPO', description: 'Repo for testing', choices: repoList())
-        string(defaultValue: 'ppg-18.3', description: 'PPG version for test', name: 'VERSION')
+        string(defaultValue: 'ppg-18.4', description: 'PPG version for test', name: 'VERSION')
         string(defaultValue: 'main', description: 'Base branch for ppg-testing repo', name: 'TESTING_BRANCH')
         string(defaultValue: '2.3.2', description: 'PGSM version', name: 'PGSM_VERSION')
-        string(defaultValue: '4.7.0', description: 'pgpool version', name: 'PGPOOL_VERSION')
-        string(defaultValue: '3.5.5', description: 'postgis version', name: 'POSTGIS_VERSION')
+        string(defaultValue: '4.7.1', description: 'pgpool version', name: 'PGPOOL_VERSION')
+        string(defaultValue: '3.5.6', description: 'postgis version', name: 'POSTGIS_VERSION')
         string(defaultValue: '18.0', description: 'PGAUDIT version', name: 'PGAUDIT_VERSION')
         string(defaultValue: 'ver_1.5.3', description: 'PG_REPACK version', name: 'PG_REPACK_VERSION')
-        string(defaultValue: 'v4.1.0', description: 'Patroni version', name: 'PATRONI_VERSION')
+        string(defaultValue: 'v4.1.3', description: 'Patroni version', name: 'PATRONI_VERSION')
         string(defaultValue: 'release/2.58.0', description: 'pgbackrest version', name: 'PGBACKREST_VERSION')
         string(defaultValue: 'REL4_2_0', description: 'pgaudit13_set_user version', name: 'SETUSER_VERSION')
         string(defaultValue: 'v13.2', description: 'pgbadger version', name: 'PGBADGER_VERSION')
-        string(defaultValue: 'pgbouncer_1_25_1', description: 'pgbouncer version', name: 'PGBOUNCER_VERSION')
+        string(defaultValue: 'pgbouncer_1_25_2', description: 'pgbouncer version', name: 'PGBOUNCER_VERSION')
         string(defaultValue: 'wal2json_2_6', description: 'wal2json version', name: 'WAL2JSON_VERSION')
-        string(defaultValue: 'v0.8.1', description: 'pgvector version', name: 'PGVECTOR_VERSION')
+        string(defaultValue: 'v0.8.2', description: 'pgvector version', name: 'PGVECTOR_VERSION')
     }
 
     options {

--- a/ppg/docker-component-multiOS.groovy
+++ b/ppg/docker-component-multiOS.groovy
@@ -19,12 +19,12 @@ pipeline {
     }
     parameters {
         string(
-            defaultValue: '18.3',
+            defaultValue: '18.4',
             description: 'TAG of the server docker from perconalab/percona (hub.docker.com) to use. For example, 16, 16.1, 16.1-multi.',
             name: 'DOCKER_SERVER_TAG'
         )
         string(
-            defaultValue: '18.3',
+            defaultValue: '18.4',
             description: 'Docker Server PG version being used, including both major and minor version. For example, 15.4.',
             name: 'SERVER_VERSION'
         )

--- a/ppg/docker-component-parallel.groovy
+++ b/ppg/docker-component-parallel.groovy
@@ -19,12 +19,12 @@ pipeline {
     }
     parameters {
         string(
-            defaultValue: '18.3',
+            defaultValue: '18.4',
             description: 'TAG of the server docker from perconalab/percona (hub.docker.com) to use. For example, 16, 16.1, 16.1-multi.',
             name: 'DOCKER_SERVER_TAG'
         )
         string(
-            defaultValue: '18.3',
+            defaultValue: '18.4',
             description: 'Docker Server PG version being used, including both major and minor version. For example, 15.4.',
             name: 'SERVER_VERSION'
         )

--- a/ppg/docker-cve-scan.groovy
+++ b/ppg/docker-cve-scan.groovy
@@ -288,14 +288,15 @@ docker.io/perconalab/percona-distribution-postgresql-with-postgis:18
 docker.io/perconalab/percona-distribution-postgresql-with-postgis:17
 docker.io/perconalab/percona-distribution-postgresql-with-postgis:16
 docker.io/perconalab/percona-distribution-postgresql-with-postgis:15
-docker.io/perconalab/percona-distribution-postgresql-with-postgis:14''', description: 'List of perconalab official images to scan (one per line)')
+docker.io/perconalab/percona-distribution-postgresql-with-postgis:14
+docker.io/perconalab/percona-distribution-postgresql-upgrade:18-17-16-15-14''', description: 'List of perconalab official images to scan (one per line)')
 
         booleanParam(name: 'SCAN_PERCONALAB_CUSTOM', defaultValue: true, description: 'Scan perconalab custom images (perconalab/percona-distribution-postgresql-custom)')
         text(name: 'PERCONALAB_CUSTOM_IMAGES', defaultValue: '''\
 docker.io/perconalab/percona-distribution-postgresql-custom:18
 docker.io/perconalab/percona-distribution-postgresql-custom:17
 docker.io/perconalab/percona-distribution-postgresql-custom:16
-docker.io/perconalab/percona-distribution-postgresql-upgrade-custom:18.3-17.9-16.13-2''', description: 'List of perconalab custom images to scan (one per line)')
+docker.io/perconalab/percona-distribution-postgresql-upgrade-custom:18-17-16''', description: 'List of perconalab custom images to scan (one per line)')
 
         booleanParam(name: 'SCAN_WITH_FIXES_ONLY', defaultValue: true, description: 'Scan known (HIGH/CRITICAL only) CVEs with available fixes have been addressed.')
         booleanParam(name: 'DESTROY_ENV', defaultValue: true, description: 'Destroy VM after tests')

--- a/ppg/docker-server-multiOS.groovy
+++ b/ppg/docker-server-multiOS.groovy
@@ -19,12 +19,12 @@ pipeline {
     }
     parameters {
         string(
-            defaultValue: '18.3',
+            defaultValue: '18.4',
             description: 'TAG of the docker to test. For example, 16, 16.1, 16.1-multi.',
             name: 'DOCKER_TAG'
         )
         string(
-            defaultValue: '18.3',
+            defaultValue: '18.4',
             description: 'Docker PG version to test, including both major and minor version. For example, 15.4.',
             name: 'SERVER_VERSION'
         )

--- a/ppg/docker-server-parallel-custom-upgrade.groovy
+++ b/ppg/docker-server-parallel-custom-upgrade.groovy
@@ -4,7 +4,7 @@ library changelog: false, identifier: "lib@master", retriever: modernSCM([
 ])
 
 // Helper function
-def sendSlackNotification(repo, old_server_version, new_server_version, old_version_docker_tag, new_version_docker_tag, upgrade_docker_tag, with_postgis, milestone) {
+def sendSlackNotification(repo, old_server_version, new_server_version, old_version_docker_tag, new_version_docker_tag, upgrade_docker_tag) {
     // Note: Result might be null if the build fails early, default to FAILURE
     def status = currentBuild.result ?: "FAILURE"
     def color = (status == "SUCCESS") ? "good" : "danger"
@@ -16,8 +16,6 @@ Old Version Docker Tag: ${old_version_docker_tag}
 New Version Docker Tag: ${new_version_docker_tag}
 Upgrade Docker Tag: ${upgrade_docker_tag}
 Repo: ${repo}
-With_PostGIS: ${with_postgis}
-Milestone: ${milestone}
 Status: *${status}*
 Build Report: ${env.BUILD_URL}"""
 
@@ -28,15 +26,13 @@ pipeline {
     agent { label 'min-ol-9-x64' }
 
     parameters {
-        string(name: 'OLD_SERVER_VERSION', defaultValue: '16.13', description: 'Old server version that needs to be upgraded: 16.13, 17.9, 18.3, etc.')
-        string(name: 'NEW_SERVER_VERSION', defaultValue: '17.9', description: 'New server version to upgrade to: 17.9, 18.3. etc.')
-        string(name: 'OLD_VERSION_DOCKER_TAG', defaultValue: '16.13-v2', description: 'Old version docker tag to test: 16.13-v2, 17.9-v2, 18.3-v2. etc.')
-        string(name: 'NEW_VERSION_DOCKER_TAG', defaultValue: '17.9-v2', description: 'New version docker tag to test: 16.13-v2, 17.9-v2, 18.3-v2. etc.')
-        string(name: 'UPGRADE_DOCKER_TAG', defaultValue: '18.3-17.9-16.13-1', description: 'Upgrade docker tag to use: 18.3-17.9-16.13-1, 18.3-17.9-16.13-2. etc.')
+        string(name: 'OLD_SERVER_VERSION', defaultValue: '16.14', description: 'Old server version that needs to be upgraded: 16.13, 17.9, 18.3, etc.')
+        string(name: 'NEW_SERVER_VERSION', defaultValue: '17.10', description: 'New server version to upgrade to: 17.9, 18.3. etc.')
+        string(name: 'OLD_VERSION_DOCKER_TAG', defaultValue: '16.14', description: 'Old version docker tag to test: 16.13, 17.9, 18.3. etc.')
+        string(name: 'NEW_VERSION_DOCKER_TAG', defaultValue: '17.10', description: 'New version docker tag to test: 16.13, 17.9, 18.3. etc.')
+        string(name: 'UPGRADE_DOCKER_TAG', defaultValue: '18-17-16', description: 'Upgrade docker tag to use: 18.3-17.9-16.13-1, 18.3-17.9-16.13-2. etc.')
         string(name: 'TESTING_BRANCH', defaultValue: 'main', description: 'Branch for testing repository')
         choice(name: 'REPOSITORY', choices: ['perconalab', 'percona'], description: 'Docker hub repository.')
-        choice(name: 'MILESTONE', choices: ['3', '1', '2'], description: 'Custom image Milestone.')
-        booleanParam(name: 'WITH_POSTGIS', defaultValue: true, description: "Enable PostGIS testing.")
         booleanParam(name: 'DESTROY_ENV', defaultValue: true, description: 'Destroy VM after tests')
     }
 
@@ -112,7 +108,7 @@ pipeline {
                     moleculeParallelPostDestroyPPG(distros, env.MOLECULE_DIR)
                 }
                 // FIX: Passing params explicitly
-                sendSlackNotification(params.REPOSITORY, params.OLD_SERVER_VERSION, params.NEW_SERVER_VERSION, params.OLD_VERSION_DOCKER_TAG, params.NEW_VERSION_DOCKER_TAG, params.UPGRADE_DOCKER_TAG, params.WITH_POSTGIS, params.MILESTONE)
+                sendSlackNotification(params.REPOSITORY, params.OLD_SERVER_VERSION, params.NEW_SERVER_VERSION, params.OLD_VERSION_DOCKER_TAG, params.NEW_VERSION_DOCKER_TAG, params.UPGRADE_DOCKER_TAG)
             }
         }
     }

--- a/ppg/docker-server-parallel-custom.groovy
+++ b/ppg/docker-server-parallel-custom.groovy
@@ -4,7 +4,7 @@ library changelog: false, identifier: "lib@master", retriever: modernSCM([
 ])
 
 // Helper function
-def sendSlackNotification(repo, version, tag, with_postgis, milestone) {
+def sendSlackNotification(repo, version, tag) {
     // Note: Result might be null if the build fails early, default to FAILURE
     def status = currentBuild.result ?: "FAILURE"
     def color = (status == "SUCCESS") ? "good" : "danger"
@@ -13,8 +13,6 @@ def sendSlackNotification(repo, version, tag, with_postgis, milestone) {
 Version: ${version}
 Repo: ${repo}
 Docker-tag: ${tag}
-With_PostGIS: ${with_postgis}
-Milestone: ${milestone}
 Status: *${status}*
 Build Report: ${env.BUILD_URL}"""
 
@@ -25,12 +23,10 @@ pipeline {
     agent { label 'min-ol-9-x64' }
     
     parameters {
-        string(name: 'DOCKER_TAG', defaultValue: '18.3', description: 'TAG of the docker to test.')
-        string(name: 'SERVER_VERSION', defaultValue: '18.3', description: 'Docker PG version to test.')
+        string(name: 'DOCKER_TAG', defaultValue: '18.4', description: 'TAG of the docker to test.')
+        string(name: 'SERVER_VERSION', defaultValue: '18.4', description: 'Docker PG version to test.')
         string(name: 'TESTING_BRANCH', defaultValue: 'main', description: 'Branch for testing repository')
         choice(name: 'REPOSITORY', choices: ['perconalab', 'percona'], description: 'Docker hub repository.')
-        choice(name: 'MILESTONE', choices: ['3', '1', '2'], description: 'Custom image Milestone.')
-        booleanParam(name: 'WITH_POSTGIS', defaultValue: true, description: "Enable PostGIS testing.")
         booleanParam(name: 'DESTROY_ENV', defaultValue: true, description: 'Destroy VM after tests')
     }
 
@@ -49,8 +45,7 @@ pipeline {
         stage('Set build name') {
             steps {
                 script {
-                    def suffix = params.WITH_POSTGIS ? "with-postgis" : "no-postgis"
-                    currentBuild.displayName = "#${env.BUILD_NUMBER}-docker-custom-${suffix}-${params.SERVER_VERSION}"
+                    currentBuild.displayName = "#${env.BUILD_NUMBER}-docker-custom-${params.SERVER_VERSION}"
                 }
             }
         }
@@ -108,7 +103,7 @@ pipeline {
                     moleculeParallelPostDestroyPPG(distros, env.MOLECULE_DIR)
                 }
                 // FIX: Passing params explicitly
-                sendSlackNotification(params.REPOSITORY, params.SERVER_VERSION, params.DOCKER_TAG, params.WITH_POSTGIS, params.MILESTONE)
+                sendSlackNotification(params.REPOSITORY, params.SERVER_VERSION, params.DOCKER_TAG)
             }
         }
     }

--- a/ppg/docker-server-parallel-upgrade.groovy
+++ b/ppg/docker-server-parallel-upgrade.groovy
@@ -27,11 +27,11 @@ pipeline {
     agent { label 'min-ol-9-x64' }
 
     parameters {
-        string(name: 'OLD_SERVER_VERSION', defaultValue: '16.13', description: 'Old server version that needs to be upgraded: 16.13, 17.9, 18.3, etc.')
-        string(name: 'NEW_SERVER_VERSION', defaultValue: '17.9', description: 'New server version to upgrade to: 17.9, 18.3. etc.')
-        string(name: 'OLD_VERSION_DOCKER_TAG', defaultValue: '16.13-v2', description: 'Old version docker tag to test: 16.13-v2, 17.9-v2, 18.3-v2. etc.')
-        string(name: 'NEW_VERSION_DOCKER_TAG', defaultValue: '17.9-v2', description: 'New version docker tag to test: 16.13-v2, 17.9-v2, 18.3-v2. etc.')
-        string(name: 'UPGRADE_DOCKER_TAG', defaultValue: '18.3-17.9-16.13-1', description: 'Upgrade docker tag to use: 18.3-17.9-16.13-1, 18.3-17.9-16.13-2. etc.')
+        string(name: 'OLD_SERVER_VERSION', defaultValue: '16.14', description: 'Old server version that needs to be upgraded: 16.13, 17.9, 18.3, etc.')
+        string(name: 'NEW_SERVER_VERSION', defaultValue: '17.10', description: 'New server version to upgrade to: 17.9, 18.3. etc.')
+        string(name: 'OLD_VERSION_DOCKER_TAG', defaultValue: '16.14', description: 'Old version docker tag to test: 16.13-v2, 17.9-v2, 18.3-v2. etc.')
+        string(name: 'NEW_VERSION_DOCKER_TAG', defaultValue: '17.10', description: 'New version docker tag to test: 16.13-v2, 17.9-v2, 18.3-v2. etc.')
+        string(name: 'UPGRADE_DOCKER_TAG', defaultValue: '18-17-16-15-14', description: 'Upgrade docker tag to use: 18.3-17.9-16.13-1, 18.3-17.9-16.13-2. etc.')
         string(name: 'TESTING_BRANCH', defaultValue: 'main', description: 'Branch for testing repository')
         choice(name: 'REPOSITORY', choices: ['perconalab', 'percona'], description: 'Docker hub repository.')
         booleanParam(name: 'WITH_POSTGIS', defaultValue: true, description: "Enable PostGIS testing.")

--- a/ppg/docker-server-parallel.groovy
+++ b/ppg/docker-server-parallel.groovy
@@ -19,12 +19,12 @@ pipeline {
     }
     parameters {
         string(
-            defaultValue: '18.3',
+            defaultValue: '18.4',
             description: 'TAG of the docker to test. For example, 16, 16.1, 16.1-multi.',
             name: 'DOCKER_TAG'
         )
         string(
-            defaultValue: '18.3',
+            defaultValue: '18.4',
             description: 'Docker PG version to test, including both major and minor version. For example, 15.4.',
             name: 'SERVER_VERSION'
         )

--- a/ppg/pgsm-multiOS.groovy
+++ b/ppg/pgsm-multiOS.groovy
@@ -33,12 +33,12 @@ pipeline {
             name: 'PGSM_REPO'
         )
         string(
-            defaultValue: 'release-2.3.2',
+            defaultValue: '2.3.2',
             description: 'PGSM repo version/branch/tag to use; e.g main, 2.0.5',
             name: 'PGSM_BRANCH'
         )
         string(
-            defaultValue: 'ppg-18.3',
+            defaultValue: 'ppg-18.4',
             description: 'Server PG version for test, including major and minor version, e.g ppg-16.2, ppg-15.5',
             name: 'VERSION'
         )

--- a/ppg/pgsm-parallel.groovy
+++ b/ppg/pgsm-parallel.groovy
@@ -33,12 +33,12 @@ pipeline {
             name: 'PGSM_REPO'
         )
         string(
-            defaultValue: 'release-2.3.2',
+            defaultValue: '2.3.2',
             description: 'PGSM repo version/branch/tag to use; e.g main, 2.0.5',
             name: 'PGSM_BRANCH'
         )
         string(
-            defaultValue: 'ppg-18.3',
+            defaultValue: 'ppg-18.4',
             description: 'Server PG version for test, including major and minor version, e.g ppg-16.2, ppg-15.5',
             name: 'VERSION'
         )

--- a/ppg/pgsm-pgdg-parallel.groovy
+++ b/ppg/pgsm-pgdg-parallel.groovy
@@ -29,7 +29,7 @@ pipeline {
             name: 'PGSM_BRANCH'
         )
         string(
-            defaultValue: 'pg-18.3',
+            defaultValue: 'pg-18.4',
             description: 'PGDG Server PG version for test, including major and minor version, e.g pg-16.2, pg-15.5',
             name: 'VERSION'
         )

--- a/ppg/pgsm-pgdg.groovy
+++ b/ppg/pgsm-pgdg.groovy
@@ -25,7 +25,7 @@ pipeline {
             name: 'PGSM_BRANCH'
         )
         string(
-            defaultValue: 'ppg-18.3',
+            defaultValue: 'ppg-18.4',
             description: 'PGDG Server PG version for test, including major and minor version, e.g pg-16.2, pg-15.5',
             name: 'VERSION'
         )

--- a/ppg/pgsm.groovy
+++ b/ppg/pgsm.groovy
@@ -29,12 +29,12 @@ pipeline {
             name: 'PGSM_REPO'
         )
         string(
-            defaultValue: 'release-2.3.2',
+            defaultValue: '2.3.2',
             description: 'PGSM repo version/branch/tag to use; e.g main, 2.0.5',
             name: 'PGSM_BRANCH'
         )
         string(
-            defaultValue: 'ppg-18.3',
+            defaultValue: 'ppg-18.4',
             description: 'Server PG version for test, including major and minor version, e.g ppg-16.2, ppg-15.5',
             name: 'VERSION'
         )

--- a/ppg/ppg-multiOS-parallel.groovy
+++ b/ppg/ppg-multiOS-parallel.groovy
@@ -29,7 +29,7 @@ pipeline {
             ]
         )
         string(
-            defaultValue: 'ppg-18.3',
+            defaultValue: 'ppg-18.4',
             description: 'PG version for test',
             name: 'VERSION'
         )

--- a/ppg/ppg-multiOS.groovy
+++ b/ppg/ppg-multiOS.groovy
@@ -29,7 +29,7 @@ pipeline {
             ]
         )
         string(
-            defaultValue: 'ppg-18.3',
+            defaultValue: 'ppg-18.4',
             description: 'PG version for test',
             name: 'VERSION'
         )

--- a/ppg/ppg-upgrade-multiOS.groovy
+++ b/ppg/ppg-upgrade-multiOS.groovy
@@ -37,12 +37,12 @@ pipeline {
             ]
         )
         string(
-            defaultValue: 'ppg-18.1',
+            defaultValue: 'ppg-18.3',
             description: 'From this version PPG will be updated',
             name: 'FROM_VERSION'
         )
         string(
-            defaultValue: 'ppg-18.3',
+            defaultValue: 'ppg-18.4',
             description: 'To this version PPG will be updated',
             name: 'VERSION'
         )

--- a/ppg/ppg-upgrade-parallel.groovy
+++ b/ppg/ppg-upgrade-parallel.groovy
@@ -37,12 +37,12 @@ pipeline {
             ]
         )
         string(
-            defaultValue: 'ppg-18.1',
+            defaultValue: 'ppg-18.3',
             description: 'From this version PPG will be updated',
             name: 'FROM_VERSION'
         )
         string(
-            defaultValue: 'ppg-18.3',
+            defaultValue: 'ppg-18.4',
             description: 'To this version PPG will be updated',
             name: 'VERSION'
         )

--- a/ppg/ppg-upgrade.groovy
+++ b/ppg/ppg-upgrade.groovy
@@ -36,12 +36,12 @@ pipeline {
             ]
         )
         string(
-            defaultValue: 'ppg-18.1',
+            defaultValue: 'ppg-18.3',
             description: 'From this version PPG will be updated',
             name: 'FROM_VERSION'
         )
         string(
-            defaultValue: 'ppg-18.3',
+            defaultValue: 'ppg-18.4',
             description: 'To this version PPG will be updated',
             name: 'VERSION'
         )

--- a/ppg/ppg.groovy
+++ b/ppg/ppg.groovy
@@ -24,7 +24,7 @@ pipeline {
             ]
         )
         string(
-            defaultValue: 'ppg-18.3',
+            defaultValue: 'ppg-18.4',
             description: 'PG version for test',
             name: 'VERSION'
         )

--- a/ppg/psp-installcheck-world-multiOS.groovy
+++ b/ppg/psp-installcheck-world-multiOS.groovy
@@ -19,12 +19,12 @@ pipeline {
     }
     parameters {
         string(
-            defaultValue: '18.3',
+            defaultValue: '18.4',
             description: 'Server PG version for test, including major and minor version, e.g 17.4, 17.3',
             name: 'VERSION'
         )
         string(
-            defaultValue: '18.3.1',
+            defaultValue: '18.4.1',
             description: 'Server PG version for test, including major and minor version, e.g 17.6.1',
             name: 'PERCONA_SERVER_VERSION'
         )
@@ -63,7 +63,7 @@ pipeline {
             ]
         )
         string(
-            defaultValue: 'release-2.1.2',
+            defaultValue: 'release-2.2.0',
             description: 'Branch for pg_tde repository. Would only be used with check-tde, check-all and installcheck-world testsuites.',
             name: 'TDE_BRANCH'
         )

--- a/ppg/psp-installcheck-world-parallel.groovy
+++ b/ppg/psp-installcheck-world-parallel.groovy
@@ -19,12 +19,12 @@ pipeline {
     }
     parameters {
         string(
-            defaultValue: '18.3',
+            defaultValue: '18.4',
             description: 'Server PG version for test, including major and minor version, e.g 17.4, 17.3',
             name: 'VERSION'
         )
         string(
-            defaultValue: '18.3.1',
+            defaultValue: '18.4.1',
             description: 'Server PG version for test, including major and minor version, e.g 17.6.1',
             name: 'PERCONA_SERVER_VERSION'
         )
@@ -63,7 +63,7 @@ pipeline {
             ]
         )
         string(
-            defaultValue: 'release-2.1.2',
+            defaultValue: 'release-2.2.0',
             description: 'Branch for pg_tde repository. Would only be used with check-tde, check-all and installcheck-world testsuites.',
             name: 'TDE_BRANCH'
         )

--- a/ppg/psp-installcheck-world.groovy
+++ b/ppg/psp-installcheck-world.groovy
@@ -15,12 +15,12 @@ pipeline {
             choices: ppgOperatingSystemsALL()
         )
         string(
-            defaultValue: '18.3',
+            defaultValue: '18.4',
             description: 'Server PG version for test, including major and minor version, e.g 17.4, 17.3',
             name: 'VERSION'
         )
         string(
-            defaultValue: '18.3.1',
+            defaultValue: '18.4.1',
             description: 'Server PG version for test, including major and minor version, e.g 17.6.1',
             name: 'PERCONA_SERVER_VERSION'
         )

--- a/ppg/tarball-multiOS-ssl1.groovy
+++ b/ppg/tarball-multiOS-ssl1.groovy
@@ -36,12 +36,12 @@ pipeline {
             ]
         )
         string(
-            defaultValue: 'ppg-18.3',
+            defaultValue: 'ppg-18.4',
             description: 'PG version for test',
             name: 'VERSION'
         )
         string(
-            defaultValue: 'https://downloads.percona.com/downloads/TESTING/pg_tarballs-18.3/percona-postgresql-18.3-ssl1.1-linux-x86_64.tar.gz',
+            defaultValue: 'https://downloads.percona.com/downloads/TESTING/pg_tarballs-18.4/percona-postgresql-18.4-ssl1.1-linux-x86_64.tar.gz',
             description: 'URL for tarball.',
             name: 'TARBALL_URL'
         )

--- a/ppg/tarball-multiOS-ssl3.groovy
+++ b/ppg/tarball-multiOS-ssl3.groovy
@@ -27,7 +27,7 @@ pipeline {
             ]
         )
         string(
-            defaultValue: 'ppg-18.3',
+            defaultValue: 'ppg-18.4',
             description: 'PG version for test',
             name: 'VERSION'
         )
@@ -41,7 +41,7 @@ pipeline {
             ]
         )
         string(
-            defaultValue: 'https://downloads.percona.com/downloads/TESTING/pg_tarballs-18.3/percona-postgresql-18.3-ssl3-linux-x86_64.tar.gz',
+            defaultValue: 'https://downloads.percona.com/downloads/TESTING/pg_tarballs-18.4/percona-postgresql-18.4-ssl3-linux-x86_64.tar.gz',
             description: 'URL for tarball.',
             name: 'TARBALL_URL'
         )

--- a/ppg/tarball-multiOS-ssl35.groovy
+++ b/ppg/tarball-multiOS-ssl35.groovy
@@ -27,7 +27,7 @@ pipeline {
             ]
         )
         string(
-            defaultValue: 'ppg-18.3',
+            defaultValue: 'ppg-18.4',
             description: 'PG version for test',
             name: 'VERSION'
         )
@@ -41,7 +41,7 @@ pipeline {
             ]
         )
         string(
-            defaultValue: 'https://downloads.percona.com/downloads/TESTING/pg_tarballs-18.3/percona-postgresql-18.3-ssl3-linux-x86_64.tar.gz',
+            defaultValue: 'https://downloads.percona.com/downloads/TESTING/pg_tarballs-18.4/percona-postgresql-18.4-ssl3-linux-x86_64.tar.gz',
             description: 'URL for tarball.',
             name: 'TARBALL_URL'
         )

--- a/ppg/tarball-parallel-ssl1.groovy
+++ b/ppg/tarball-parallel-ssl1.groovy
@@ -36,12 +36,12 @@ pipeline {
             ]
         )
         string(
-            defaultValue: 'ppg-18.3',
+            defaultValue: 'ppg-18.4',
             description: 'PG version for test',
             name: 'VERSION'
         )
         string(
-            defaultValue: 'https://downloads.percona.com/downloads/TESTING/pg_tarballs-18.3/percona-postgresql-18.3-ssl1.1-linux-x86_64.tar.gz',
+            defaultValue: 'https://downloads.percona.com/downloads/TESTING/pg_tarballs-18.4/percona-postgresql-18.4-ssl1.1-linux-x86_64.tar.gz',
             description: 'URL for tarball.',
             name: 'TARBALL_URL'
         )

--- a/ppg/tarball-parallel-ssl3.groovy
+++ b/ppg/tarball-parallel-ssl3.groovy
@@ -27,7 +27,7 @@ pipeline {
             ]
         )
         string(
-            defaultValue: 'ppg-18.3',
+            defaultValue: 'ppg-18.3`',
             description: 'PG version for test',
             name: 'VERSION'
         )
@@ -41,7 +41,7 @@ pipeline {
             ]
         )
         string(
-            defaultValue: 'https://downloads.percona.com/downloads/TESTING/pg_tarballs-18.3/percona-postgresql-18.3-ssl3-linux-x86_64.tar.gz',
+            defaultValue: 'https://downloads.percona.com/downloads/TESTING/pg_tarballs-18.4/percona-postgresql-18.4-ssl3-linux-x86_64.tar.gz',
             description: 'URL for tarball.',
             name: 'TARBALL_URL'
         )

--- a/ppg/tarball-parallel-ssl35.groovy
+++ b/ppg/tarball-parallel-ssl35.groovy
@@ -27,7 +27,7 @@ pipeline {
             ]
         )
         string(
-            defaultValue: 'ppg-18.3',
+            defaultValue: 'ppg-18.3',`
             description: 'PG version for test',
             name: 'VERSION'
         )
@@ -41,7 +41,7 @@ pipeline {
             ]
         )
         string(
-            defaultValue: 'https://downloads.percona.com/downloads/TESTING/pg_tarballs-18.3/percona-postgresql-18.3-ssl3-linux-x86_64.tar.gz',
+            defaultValue: 'https://downloads.percona.com/downloads/TESTING/pg_tarballs-18.4/percona-postgresql-18.4-ssl3-linux-x86_64.tar.gz',
             description: 'URL for tarball.',
             name: 'TARBALL_URL'
         )

--- a/ppg/tarball.groovy
+++ b/ppg/tarball.groovy
@@ -24,7 +24,7 @@ pipeline {
             ]
         )
         string(
-            defaultValue: 'ppg-18.3',
+            defaultValue: 'ppg-18.4',
             description: 'PG version for test',
             name: 'VERSION'
         )
@@ -38,7 +38,7 @@ pipeline {
             ]
         )
         string(
-            defaultValue: 'https://downloads.percona.com/downloads/TESTING/pg_tarballs-18.3/percona-postgresql-18.3-ssl1.1-linux-x86_64.tar.gz',
+            defaultValue: 'https://downloads.percona.com/downloads/TESTING/pg_tarballs-18.4/percona-postgresql-18.4-ssl1.1-linux-x86_64.tar.gz',
             description: 'URL for tarball.',
             name: 'TARBALL_URL'
         )

--- a/ppg/tde-auxiliary-parallel.groovy
+++ b/ppg/tde-auxiliary-parallel.groovy
@@ -20,7 +20,7 @@ pipeline {
     parameters {
         string(
             name: 'VERSION',
-            defaultValue: 'ppg-18.3',
+            defaultValue: 'ppg-18.4',
             description: 'Server PG version for test, including major and minor version, e.g 17.4, 17.3'
         )
         choice(
@@ -63,7 +63,7 @@ pipeline {
         )
         string(
             name: 'TDE_BRANCH',
-            defaultValue: 'release-2.1.2',
+            defaultValue: 'release-2.2.0',
             description: 'TDE repo version/branch/tag to use; e.g main, release-2.1. NOT applicable with INSTALL_FROM_PACKAGES enabled.'
         )
         string(

--- a/ppg/tde-auxiliary.groovy
+++ b/ppg/tde-auxiliary.groovy
@@ -16,7 +16,7 @@ pipeline {
         )
         string(
             name: 'VERSION',
-            defaultValue: 'ppg-18.3',
+            defaultValue: 'ppg-18.4',
             description: 'Server PG version for test, including major and minor version, e.g 17.4, 17.3'
         )
         choice(
@@ -59,7 +59,7 @@ pipeline {
         )
         string(
             name: 'TDE_BRANCH',
-            defaultValue: 'release-2.1.2',
+            defaultValue: 'release-2.2.0',
             description: 'TDE repo version/branch/tag to use; e.g main, release-2.1. NOT applicable with INSTALL_FROM_PACKAGES enabled.'
         )
         string(

--- a/ppg/tde-multiOS.groovy
+++ b/ppg/tde-multiOS.groovy
@@ -33,12 +33,12 @@ pipeline {
             name: 'TDE_REPO'
         )
         string(
-            defaultValue: 'release-2.1.2',
+            defaultValue: 'release-2.2.0',
             description: 'TDE repo version/branch/tag to use; e.g main, release-2.1',
             name: 'TDE_BRANCH'
         )
         string(
-            defaultValue: 'ppg-18.3',
+            defaultValue: 'ppg-18.4',
             description: 'Server PG version for test, including major and minor version, e.g ppg-17.4, ppg-17.3',
             name: 'VERSION'
         )

--- a/ppg/tde-parallel.groovy
+++ b/ppg/tde-parallel.groovy
@@ -33,12 +33,12 @@ pipeline {
             name: 'TDE_REPO'
         )
         string(
-            defaultValue: 'release-2.1.2',
+            defaultValue: 'release-2.2.0',
             description: 'TDE repo version/branch/tag to use; e.g main, release-2.1',
             name: 'TDE_BRANCH'
         )
         string(
-            defaultValue: 'ppg-18.3',
+            defaultValue: 'ppg-18.4',
             description: 'Server PG version for test, including major and minor version, e.g ppg-17.4, ppg-17.3',
             name: 'VERSION'
         )

--- a/ppg/tde.groovy
+++ b/ppg/tde.groovy
@@ -29,12 +29,12 @@ pipeline {
             name: 'TDE_REPO'
         )
         string(
-            defaultValue: 'release-2.1.2',
+            defaultValue: 'release-2.2.0',
             description: 'TDE repo version/branch/tag to use; e.g main, release-2.1',
             name: 'TDE_BRANCH'
         )
         string(
-            defaultValue: 'ppg-18.3',
+            defaultValue: 'ppg-18.4',
             description: 'Server PG version for test, including major and minor version, e.g ppg-17.4, ppg-17.3',
             name: 'VERSION'
         )


### PR DESCRIPTION
Version bumps across all PPG release test pipelines:
- PPG: 18.3 → 18.4
- pgpool: 4.7.0 → 4.7.1
- PostGIS: 3.5.5 → 3.5.6
- Patroni: v4.1.0 → v4.1.3
- pgBouncer: pgbouncer_1_25_1 → pgbouncer_1_25_2
- pgvector: v0.8.1 → v0.8.2
- Upgrade default server versions: 16.13/17.9 → 16.14/17.10

Pipeline cleanup in docker-server-parallel-custom and docker-server-parallel-custom-upgrade:
- Remove WITH_POSTGIS and MILESTONE parameters from sendSlackNotification() — no longer needed
- Simplify build display name to drop postgis suffix

CVE scan image list updates:
- Add percona-distribution-postgresql-upgrade:18-17-16-15-14 to perconalab-official scan group
- Update upgrade-custom tag to 18-17-16