### PR TITLE
PMM-7 Wrap pmm-agent installs in retry

### DIFF
--- a/pmm/v3/vars/setupPMM3Client.groovy
+++ b/pmm/v3/vars/setupPMM3Client.groovy
@@ -30,6 +30,26 @@ def call(String SERVER_IP, String CLIENT_VERSION, String PMM_VERSION, String ENA
                 export IP=192.168.0.1
             fi
 
+            # Percona's CDN occasionally serves an RPM whose Content-Length
+            # disagrees with the repodata-advertised size, which makes dnf abort
+            # with "Inconsistent server data ... please report to repository maintainer".
+            # The mismatch usually clears within a minute, so retry a few times.
+            retry_dnf_install() {
+                local n=3
+                local i
+                for i in $(seq 1 $n); do
+                    if sudo dnf -y install "$@"; then
+                        return 0
+                    fi
+                    if [ "$i" -lt "$n" ]; then
+                        echo "dnf install failed (attempt $i/$n); retrying in 30s..."
+                        sleep 30
+                    fi
+                done
+                echo "dnf install failed after $n attempts"
+                return 1
+            }
+
             sudo dnf clean expire-cache
             if ! command -v percona-release > /dev/null; then
                 curl -O https://repo.percona.com/yum/percona-release-latest.noarch.rpm
@@ -43,13 +63,13 @@ def call(String SERVER_IP, String CLIENT_VERSION, String PMM_VERSION, String ENA
 
             if [ "${CLIENT_VERSION}" = 3-dev-latest ]; then
                 sudo percona-release enable-only pmm3-client experimental
-                sudo dnf -y install pmm-client
+                retry_dnf_install pmm-client
             elif [ "${CLIENT_VERSION}" = pmm3-rc ]; then
                 sudo percona-release enable-only pmm3-client testing
-                sudo dnf -y install pmm-client
+                retry_dnf_install pmm-client
             elif [ "${CLIENT_VERSION}" = pmm3-latest ]; then
                 sudo percona-release enable-only pmm3-client experimental
-                sudo dnf -y install pmm-client
+                retry_dnf_install pmm-client
             elif [[ "${CLIENT_VERSION}" = 3* ]]; then
                 if [ "${ENABLE_TESTING_REPO}" = yes ]; then
                     sudo percona-release enable-only pmm3-client testing
@@ -60,7 +80,7 @@ def call(String SERVER_IP, String CLIENT_VERSION, String PMM_VERSION, String ENA
                 fi
 
                 export FULL_CLIENT_VERSION=$(dnf list pmm-client --showduplicates | grep -w "${CLIENT_VERSION}" | awk '{print $2}')
-                sudo dnf -y install "pmm-client-${FULL_CLIENT_VERSION}"
+                retry_dnf_install "pmm-client-${FULL_CLIENT_VERSION}"
                 sleep 10
             else
                 if [[ "${CLIENT_VERSION}" = http* ]]; then


### PR DESCRIPTION
This pull request improves the reliability of installing the `pmm-client` package using `dnf` in the `setupPMM3Client.groovy` script. The main enhancement is the introduction of a retry mechanism to handle intermittent CDN issues that can cause installation failures.

**Reliability improvements for package installation:**

* Added a `retry_dnf_install` shell function that attempts to install packages up to three times, with a 30-second delay between attempts, to mitigate transient CDN issues where `dnf` may fail due to inconsistent server data.
* Replaced all direct calls to `sudo dnf -y install` for `pmm-client` with the new `retry_dnf_install` function to ensure more robust and resilient installations across different `CLIENT_VERSION` branches.