### PR TITLE
PCSM-282: Bump PCSM_VERSION default to 0.9.0

### DIFF
--- a/pcsm/pcsm_generate_sbom.groovy
+++ b/pcsm/pcsm_generate_sbom.groovy
@@ -63,7 +63,7 @@ pipeline {
             description: 'URL for pcsm_sbom repository',
             name: 'GIT_REPO')
         string(
-            defaultValue: '0.5.0',
+            defaultValue: '0.9.0',
             description: 'Version of Percona ClusterSync for MongoDB',
             name: 'PCSM_VERSION')
         string(


### PR DESCRIPTION
[PCSM-282](https://perconadev.atlassian.net/browse/PCSM-282)

### Problem

`pcsm/pcsm_generate_sbom.groovy` declares `PCSM_VERSION` as a build parameter with a default of `'0.5.0'`. That value carried over from the PLM SBOM template. PCSM 0.5.0 was never released, and the current target for SBOM publication is 0.9.0.

### Solution

Bumped the default to `'0.9.0'`. One line.

The companion PR on the bash side hardens the script to fail loudly if `--pcsm_version` is missing entirely: https://github.com/percona/percona-clustersync-mongodb/pull/233.

[PCSM-282]: https://perconadev.atlassian.net/browse/PCSM-282?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ