### PR TITLE
fix(ps80): grant Overall Administer to nogueiraanderson

### DIFF
--- a/IaC/ps80.cd/init.groovy.d/matrix.groovy
+++ b/IaC/ps80.cd/init.groovy.d/matrix.groovy
@@ -151,6 +151,7 @@ authz_strategy_config = [
         'percona*doc': ['Overall Read','Agent Build','Agent Connect','Agent Provision','Job Discover','Job Read','Job Build','Job Cancel','Job Workspace','View Read'],
         'JNKPercona': ['Overall Read','Agent Build','Agent Connect','Agent Provision','Job Discover','Job Read','Job Build','Job Cancel','Job Workspace','View Read'],
         'percona*external-contractors-ps': ['Overall Read','Agent Build','Agent Connect','Agent Provision','Job Discover','Job Read','Job Build','Job Cancel','Job Workspace','View Read'],
+        'nogueiraanderson' : ['Overall Administer'],
     ]
 ]
 


### PR DESCRIPTION
## Summary

Adds direct user grant `'nogueiraanderson' : ['Overall Administer']` to `ps80.cd`'s `matrix.groovy`. 

The existing `'percona*build-engineers': ['Overall Administer']` team grant works for users who OAuth-login via the web UI (the GithubSecurityRealm caches GitHub team membership in the session) but does not get hydrated for API-token-only requests. The Script Console (`/scriptText`) returns HTTP 403 to my user as a result, blocking fleet ops via the jenkins CLI.

Today I had to deploy `hetzner-cloud-plugin v103.percona.14` to ps80 via SSH instead of the standard Script Console upload path. This PR makes the workaround permanent and AMI-rebuild safe.

Already applied live on the ps80 master (init.groovy.d ran on a Jenkins restart and produced the matching `<permission>hudson.model.Hudson.Administer:nogueiraanderson</permission>` entry in `config.xml`).

## Note on drift

The live `matrix.groovy` on ps80 also contains `peterSirotnak` and `puneet0191` individual grants that are NOT in this canonical IaC file. Out of scope for this PR but worth tracking separately.