### PR TITLE
CLOUD-938 handle failure during image certification

### DIFF
--- a/cloud/jenkins/pgo_image_certification.groovy
+++ b/cloud/jenkins/pgo_image_certification.groovy
@@ -22,7 +22,7 @@ def buildTargetImage(key, image, params) {
 
     switch (key) {
         case 'IMAGE_OPERATOR':
-            return target(image, operatorProjectId, ${params.RELEASE}, operatorCredentials)
+            return target(image, operatorProjectId, params.RELEASE, operatorCredentials)
 
         case 'IMAGE_PMM3_CLIENT':
             return target(image, containersProjectId, "${params.RELEASE}-pmm3", containersCredentials)

--- a/cloud/scripts/certify_images.py
+++ b/cloud/scripts/certify_images.py
@@ -319,6 +319,10 @@ def run_preflight(dest, platform, docker_config, token, component):
 
     rename_result_json_files(results_dir, dest)
 
+    if "Preflight result: FAILED" in output:
+        log("preflight failed (output contains FAILED)")
+        sys.exit(1)
+
     if result.returncode != 0:
         log(f"preflight failed ({result.returncode})")
         sys.exit(result.returncode)


### PR DESCRIPTION
Exit code works only for special cases like incorrect auth, image and etc. When certification itself fails, the exit code is 0.

Adding a log tracker to exit a failure.