### PR TITLE
PMM-15064: fix silently-failing password update in pmm3-deploy-services

### DIFF
--- a/pmm/v3/pmm3-deploy-services.groovy
+++ b/pmm/v3/pmm3-deploy-services.groovy
@@ -324,14 +324,23 @@ pipeline {
                  currentPass = env.AMI_ADMIN_PASS
               }
 
-              try {
-                  sh '''
-                    curl -k -X PUT -H "Content-Type: application/json" \
-                    -d '{"password":"${params.ADMIN_PASSWORD}"}' \
-                    https://admin:${currentPass}@${env.PMM_SERVER_IP}/graph/api/admin/users/1/password
-                  '''
-              } catch(e) {
-                  echo "Warning: Password update failed. Proceeding."
+              // Pass values via withEnv so the password is not Groovy-interpolated
+              // into the shell command and does not appear in the build log.
+              withEnv([
+                  "GR_NEW_PASS=${params.ADMIN_PASSWORD}",
+                  "GR_CURR_PASS=${currentPass}",
+                  "GR_HOST=${env.PMM_SERVER_IP}"
+              ]) {
+                  try {
+                      sh '''
+                        set +x
+                        curl -fsk -X PUT -H "Content-Type: application/json" \
+                          -d "{\\"password\\":\\"${GR_NEW_PASS}\\"}" \
+                          "https://admin:${GR_CURR_PASS}@${GR_HOST}/graph/api/admin/users/1/password"
+                      '''
+                  } catch(e) {
+                      echo "Warning: Password update failed: ${e.message}. Proceeding."
+                  }
               }
 
               if (env.SLACK_DM) {


### PR DESCRIPTION
## Bug

`Set Final Password` in `pmm3-deploy-services.groovy` never updated the password; the next stage still posted the requested value to Slack as if it had been applied.

The `sh '''...'''` block used Groovy `${...}` inside a single-quoted triple string, so Groovy did not interpolate. The literals reached the shell, `${env.PMM_SERVER_IP}` hit a bad-substitution (`.` invalid in POSIX var names), the URL collapsed to `https://admin:@/graph/api/admin/users/1/password`, and the failing `curl` was swallowed by a `catch` without `-f` or `e.message`.

Pre-existing since [PMM-14805](https://perconadev.atlassian.net/browse/PMM-14805) (PR #3791); caught by Codex during the [PMM-15062](https://perconadev.atlassian.net/browse/PMM-15062) review.

## Tickets

- [PMM-15064](https://perconadev.atlassian.net/browse/PMM-15064)
- [PMM-15062](https://perconadev.atlassian.net/browse/PMM-15062): review that surfaced it
- [PMM-14805](https://perconadev.atlassian.net/browse/PMM-14805) / PR #3791: source of the bug

[PMM-14805]: https://perconadev.atlassian.net/browse/PMM-14805?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[PMM-15062]: https://perconadev.atlassian.net/browse/PMM-15062?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[PMM-15064]: https://perconadev.atlassian.net/browse/PMM-15064?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ