### PR TITLE
PMM-7: Make screenshots stage compatible with Jenkins sh

### DIFF
--- a/pmm/v3/pmm3-deploy-services.groovy
+++ b/pmm/v3/pmm3-deploy-services.groovy
@@ -365,19 +365,31 @@ pipeline {
               }
               def dockerTag = dockerVersion.substring(dockerVersion.lastIndexOf(':') + 1)
               def zipName = "screenshots-${dockerTag}.zip"
-              sh """
-                set -euo pipefail
-                git clone --depth 1 --branch "${params.PMM_QA_GIT_BRANCH}" https://github.com/percona/pmm-qa.git
-                cd pmm-qa/e2e_tests
-                curl -sL https://deb.nodesource.com/setup_22.x | sudo -E bash -
-                sudo apt-get install -y nodejs gettext zip
-                npm ci
-                npx playwright install
-                sudo npx playwright install-deps
-                PMM_UI_URL="${env.PMM_UI_URL}" ADMIN_PASSWORD="${params.ADMIN_PASSWORD}" npx playwright test --config=screenshots.config.ts
-                cd "${env.WORKSPACE}"
-                zip -rq "${zipName}" pmm-qa/e2e_tests/screenshots
-              """
+
+              // Pass Groovy values via withEnv so the shell sees plain
+              // POSIX variables — no Groovy interpolation inside sh.
+              withEnv([
+                  "GR_QA_BRANCH=${params.PMM_QA_GIT_BRANCH}",
+                  "GR_PMM_UI_URL=${env.PMM_UI_URL}",
+                  "GR_ADMIN_PASSWORD=${params.ADMIN_PASSWORD}",
+                  "GR_WORKSPACE=${env.WORKSPACE}",
+                  "GR_ZIP_NAME=${zipName}"
+              ]) {
+                sh '''
+                  set -eu
+                  git clone --depth 1 --branch "${GR_QA_BRANCH}" https://github.com/percona/pmm-qa.git
+                  cd pmm-qa/e2e_tests
+                  curl -fsSL https://deb.nodesource.com/setup_22.x -o /tmp/nodesource-setup-22.sh
+                  sudo -E bash /tmp/nodesource-setup-22.sh
+                  sudo apt-get install -y nodejs gettext zip
+                  npm ci
+                  npx playwright install
+                  sudo npx playwright install-deps
+                  PMM_UI_URL="${GR_PMM_UI_URL}" ADMIN_PASSWORD="${GR_ADMIN_PASSWORD}" npx playwright test --config=screenshots.config.ts
+                  cd "${GR_WORKSPACE}"
+                  zip -rq "${GR_ZIP_NAME}" pmm-qa/e2e_tests/screenshots
+                '''
+              }
               slackUploadFile botUser: true, channel: params.SCREENSHOTS_SLACK_TARGET?.trim(), failOnError: true,
                 filePath: zipName,
                 initialComment: "PMM dashboard screenshots for (${dockerVersion})"


### PR DESCRIPTION
## Summary
Fix the screenshots generation shell block in `pmm3-deploy-services` so it works when Jenkins executes `sh` with dash.

## Problem
The stage used `set -euo pipefail` and Groovy double-quoted `sh ""...""` with `${env.PMM_UI_URL}` / `${params.*}`.

On agents where Jenkins `sh` runs under **dash**, `pipefail` is not supported and the stage fails immediately:

`
set: Illegal option -o pipefail
script returned exit code 2
`

Additionally, `curl ... | sudo -E bash -` relies on `pipefail` to detect a download failure — without it a broken download would be silently piped into bash.

## Fix
- Wrap the block in `withEnv([...])` and switch to single-quoted `sh '''...'''`, so shell variables are plain POSIX names (no Groovy interpolation, no dots).
- Drop `pipefail` entirely; use `set -eu` (supported by all POSIX shells).
- Replace the `curl | bash` pipeline with download-then-execute (`curl -fsSL ... -o /tmp/...` + `sudo -E bash /tmp/...`), so `curl -f` catches HTTP errors without needing `pipefail`.

## Local validation

| Shell          | Old (`set -euo pipefail`)                 | New (`withEnv` + `set -eu`)  |
|----------------|---------------------------------------------|----------------------------------|
| **bash**       | runs (pipefail supported)                   | runs, exit 0                     |
| **sh (dash)**  | `Illegal option -o pipefail`, exit 2      | runs, exit 0                     |