### PR TITLE
PMM-7 Bump aws-staging-start instance type to t3.xlarge

### DIFF
--- a/pmm/v3/pmm3-aws-staging-start.groovy
+++ b/pmm/v3/pmm3-aws-staging-start.groovy
@@ -174,7 +174,7 @@ pipeline {
         stage('Run VM') {
             steps {
                 // This sets envvars: SPOT_PRICE, REQUEST_ID, IP, AMI_ID
-                runSpotInstance('t3.large')
+                runSpotInstance('t3.xlarge')
 
                 withCredentials([sshUserPrivateKey(credentialsId: 'aws-jenkins', keyFileVariable: 'KEY_PATH', passphraseVariable: '', usernameVariable: 'USER')]) {
                     sh '''


### PR DESCRIPTION
*  Doubles vCPU (2 → 4) and memory (8 GiB → 16 GiB) to give staging  more headroom for workloads.