### PR TITLE
PMM-7 Fix GO_VERSION variable usage in rpm-build

### DIFF
--- a/pmm/infrastructure/rpm-build.groovy
+++ b/pmm/infrastructure/rpm-build.groovy
@@ -67,13 +67,13 @@ pipeline {
                     GO_VERSION=$(grep '^go ' ./go.mod | awk '{print $2}')
                     cd build/docker/rpmbuild/
                     docker buildx build --pull --platform linux/amd64,linux/arm64 \
-                      --build-arg GO_VERSION=$(GO_VERSION) \
+                      --build-arg GO_VERSION=${GO_VERSION} \
                       --tag ${ECR_REGISTRY}/${IMAGE_NAME} \
                       --tag ${DOCKERHUB_REGISTRY}/perconalab/${IMAGE_NAME} \
                       -f Dockerfile.el9 --push .
 
                     docker buildx build --pull --platform linux/amd64,linux/arm64 \
-                      --build-arg GO_VERSION=$(GO_VERSION) \
+                      --build-arg GO_VERSION=${GO_VERSION} \
                       --tag ${ECR_REGISTRY}/${IMAGE_OL8_NAME} \
                       --tag ${DOCKERHUB_REGISTRY}/perconalab/${IMAGE_OL8_NAME} \
                       -f Dockerfile.el8 --push .


### PR DESCRIPTION
This pull request includes a syntax fix for referencing the `GO_VERSION` environment variable when passing it as a build argument to Docker.

