### PR TITLE
PMM-7: screenshots zip and Slack upload after partial Playwright failures

### DIFF
--- a/pmm/v3/pmm3-deploy-services.groovy
+++ b/pmm/v3/pmm3-deploy-services.groovy
@@ -394,10 +394,7 @@ pipeline {
                 '''
                 def playwrightExit = readFile('.playwright-exit').trim() as int
                 if (playwrightExit != 0) {
-                  unstable('Playwright screenshot tests had failures; partial screenshots were zipped and will be uploaded if the zip exists.')
-                }
-                if (!fileExists(zipName)) {
-                  error('Screenshot zip was not created (playwright may have failed before producing screenshots).')
+                  unstable('Playwright screenshot tests had failures; partial screenshots were zipped and will be uploaded.')
                 }
               }
               def snapTarget = params.SCREENSHOTS_SLACK_TARGET?.trim() ?: ''

--- a/pmm/v3/pmm3-deploy-services.groovy
+++ b/pmm/v3/pmm3-deploy-services.groovy
@@ -385,27 +385,18 @@ pipeline {
                   npm ci
                   npx playwright install
                   sudo npx playwright install-deps
+                  set +e
+                  PMM_UI_URL="${GR_PMM_UI_URL}" ADMIN_PASSWORD="${GR_ADMIN_PASSWORD}" npx playwright test --config=screenshots.config.ts
+                  echo $? > "${GR_WORKSPACE}/.playwright-exit"
+                  set -e
+                  cd "${GR_WORKSPACE}"
+                  zip -rq "${GR_ZIP_NAME}" pmm-qa/e2e_tests/screenshots
                 '''
-                def playwrightExit = sh(
-                  returnStatus: true,
-                  script: '''
-                    set -eu
-                    cd "${GR_WORKSPACE}/pmm-qa/e2e_tests"
-                    PMM_UI_URL="${GR_PMM_UI_URL}" ADMIN_PASSWORD="${GR_ADMIN_PASSWORD}" npx playwright test --config=screenshots.config.ts
-                  '''
-                )
-                def zipExit = sh(
-                  returnStatus: true,
-                  script: '''
-                    set -eu
-                    cd "${GR_WORKSPACE}"
-                    zip -rq "${GR_ZIP_NAME}" pmm-qa/e2e_tests/screenshots
-                  '''
-                )
+                def playwrightExit = readFile('.playwright-exit').trim() as int
                 if (playwrightExit != 0) {
                   unstable('Playwright screenshot tests had failures; partial screenshots were zipped and will be uploaded if the zip exists.')
                 }
-                if (zipExit != 0 || !fileExists(zipName)) {
+                if (!fileExists(zipName)) {
                   error('Screenshot zip was not created (playwright may have failed before producing screenshots).')
                 }
               }

--- a/pmm/v3/pmm3-deploy-services.groovy
+++ b/pmm/v3/pmm3-deploy-services.groovy
@@ -148,7 +148,7 @@ pipeline {
                  description: '<b>Valkey:</b><br>Deploys 1 VM containing a Valkey instance.')
     booleanParam(name: 'GENERATE_DASHBOARD_SCREENSHOTS', defaultValue: false,
                  description: 'If enabled, generate dashboard screenshots at the end of provisioning and skip the 24h hold stage.')
-    string(name: 'SCREENSHOTS_SLACK_TARGET', defaultValue: '@catalina.adam', description: 'Slack target for screenshots (@user, #channel, or thread id).')
+    string(name: 'SCREENSHOTS_SLACK_TARGET', defaultValue: '@catalina.adam', description: '@user or #channel or #channel:thread_ts.')
 
     // --- DB VERSIONS ---
     choice(name: 'PXC_VERSION', choices: ['8.0', '8.4', '5.7'], description: 'Version for PXC nodes')
@@ -385,14 +385,38 @@ pipeline {
                   npm ci
                   npx playwright install
                   sudo npx playwright install-deps
-                  PMM_UI_URL="${GR_PMM_UI_URL}" ADMIN_PASSWORD="${GR_ADMIN_PASSWORD}" npx playwright test --config=screenshots.config.ts
-                  cd "${GR_WORKSPACE}"
-                  zip -rq "${GR_ZIP_NAME}" pmm-qa/e2e_tests/screenshots
                 '''
+                def playwrightExit = sh(
+                  returnStatus: true,
+                  script: '''
+                    set -eu
+                    cd "${GR_WORKSPACE}/pmm-qa/e2e_tests"
+                    PMM_UI_URL="${GR_PMM_UI_URL}" ADMIN_PASSWORD="${GR_ADMIN_PASSWORD}" npx playwright test --config=screenshots.config.ts
+                  '''
+                )
+                def zipExit = sh(
+                  returnStatus: true,
+                  script: '''
+                    set -eu
+                    cd "${GR_WORKSPACE}"
+                    zip -rq "${GR_ZIP_NAME}" pmm-qa/e2e_tests/screenshots
+                  '''
+                )
+                if (playwrightExit != 0) {
+                  unstable('Playwright screenshot tests had failures; partial screenshots were zipped and will be uploaded if the zip exists.')
+                }
+                if (zipExit != 0 || !fileExists(zipName)) {
+                  error('Screenshot zip was not created (playwright may have failed before producing screenshots).')
+                }
               }
-              slackUploadFile botUser: true, channel: params.SCREENSHOTS_SLACK_TARGET?.trim(), failOnError: true,
-                filePath: zipName,
-                initialComment: "PMM dashboard screenshots for (${dockerVersion})"
+              def snapTarget = params.SCREENSHOTS_SLACK_TARGET?.trim() ?: ''
+              if (snapTarget.startsWith('#') && snapTarget.contains(':')) {
+                slackUploadFile channel: snapTarget, failOnError: true, filePath: zipName
+              } else {
+                def slackResponse = slackSend(botUser: true, channel: snapTarget, message: "PMM dashboard screenshots for (${dockerVersion})", sendAsText: true)
+                def uploadCh = snapTarget.startsWith('#') ? "${slackResponse.channelId}:${slackResponse.ts}" : slackResponse.channelId
+                slackUploadFile channel: uploadCh, failOnError: true, filePath: zipName
+              }
             }
           }
         }

--- a/pmm/v3/pmm3-rc-testing.groovy
+++ b/pmm/v3/pmm3-rc-testing.groovy
@@ -107,6 +107,7 @@ pipeline {
 |Each triggered job will appear below with a link.""".stripMargin()
                     def slackResponse = slackSend botUser: true, channel: RC_SLACK_CHANNEL, message: intro
                     env.SLACK_RC_THREAD = slackResponse.threadId
+                    env.SLACK_RC_SCREENSHOTS_TARGET = "${RC_SLACK_CHANNEL}:${slackResponse.ts}"
                 }
             }
         }
@@ -574,7 +575,7 @@ pipeline {
                                         string(name: 'MODB_VERSION',                   value: '8.0'),
                                         string(name: 'PMM_QA_GIT_BRANCH',              value: 'main'),
                                         booleanParam(name: 'GENERATE_DASHBOARD_SCREENSHOTS', value: true),
-                                        string(name: 'SCREENSHOTS_SLACK_TARGET',       value: env.SLACK_RC_THREAD),
+                                        string(name: 'SCREENSHOTS_SLACK_TARGET',       value: env.SLACK_RC_SCREENSHOTS_TARGET),
                                     ])
                                 }
                             }


### PR DESCRIPTION
## Summary
- `pmm3-deploy-services`: run Playwright with `returnStatus: true`, always zip afterward, `unstable` when tests fail. Slack upload rules fixed to use IDs (`#ch:ts` upload-only, else ping + upload).
- `pmm3-rc-testing`: pass `SCREENSHOTS_SLACK_TARGET` as `#qa-automation:` plus the thread `ts` from Slack.