### PR TITLE
refactor(ps3): strip openresty/certbot/SSL from master user-data (PS-10945)

### DIFF
--- a/IaC/ps3.cd/JenkinsStack.yml
+++ b/IaC/ps3.cd/JenkinsStack.yml
@@ -556,8 +556,6 @@ Resources:
                   done
 
                   yum -y install yum-utils wget cronie rsync bc
-                  yum-config-manager --add-repo "https://openresty.org/package/amazon/2023/x86_64/"
-                  rpm --import https://openresty.org/package/pubkey.gpg
                   # ps3 runs the current LTS line (2.541.x) to match the live
                   # plugin set on the EBS data volume; the rest of the fleet
                   # remains on jenkins-2.528.3 from redhat-stable-legacy.
@@ -567,7 +565,7 @@ Resources:
                   rpm --import https://pkg.jenkins.io/redhat-stable/jenkins.io-2026.key
                   yum -y install java-17-amazon-corretto
                   yum -y update --security
-                  yum -y install jenkins-2.541.3 certbot git dnf-automatic aws-cli xfsprogs openresty
+                  yum -y install jenkins-2.541.3 git dnf-automatic aws-cli xfsprogs
 
                   sed -i 's/upgrade_type = default/upgrade_type = security/' /etc/dnf/automatic.conf
                   sed -i 's/apply_updates = no/apply_updates = yes/'         /etc/dnf/automatic.conf
@@ -663,198 +661,6 @@ Resources:
                   printf "* * * * * root bash -c 'curl -s http://169.254.169.254/latest/meta-data/spot/instance-action | grep action && sh -c \"systemctl stop jenkins; cp /var/log/jenkins/jenkins.log /mnt/jenkins-latest.log; umount /mnt\" || :'\n* * * * * root sleep 30; bash -c 'curl -s http://169.254.169.254/latest/meta-data/spot/instance-action | grep action && sh -c \"systemctl stop jenkins; cp /var/log/jenkins/jenkins.log /mnt/jenkins-latest.log; umount /mnt\" || :'\n" > /etc/cron.d/terminate-check
               }
 
-              create_fake_ssl_cert() {
-                  mkdir -p /etc/nginx/ssl
-                  mkdir -p /mnt/$JENKINS_HOST/ssl
-                  if [ ! -f /mnt/$JENKINS_HOST/ssl/certificate.key -o ! -f /mnt/$JENKINS_HOST/ssl/certificate.crt ]; then
-                      echo "
-                          [ req ]
-                          distinguished_name = req_distinguished_name
-                          prompt             = no
-                          [ req_distinguished_name ]
-                          O                  = Main Org.
-                      " | tee /mnt/$JENKINS_HOST/ssl/certificate.conf
-                      openssl req -x509 -nodes -days 365 -newkey rsa:2048 \
-                                    -keyout /mnt/$JENKINS_HOST/ssl/certificate.key \
-                                    -out    /mnt/$JENKINS_HOST/ssl/certificate.crt \
-                                    -config /mnt/$JENKINS_HOST/ssl/certificate.conf
-                  fi
-                  cp /mnt/$JENKINS_HOST/ssl/certificate.key /etc/nginx/ssl/certificate.key
-                  cp /mnt/$JENKINS_HOST/ssl/certificate.crt /etc/nginx/ssl/certificate.crt
-                  if [ ! -f /mnt/$JENKINS_HOST/ssl/dhparam-4096.pem ]; then
-                      openssl dhparam -out /mnt/$JENKINS_HOST/ssl/dhparam-4096.pem 4096
-                  fi
-                  cp /mnt/$JENKINS_HOST/ssl/dhparam-4096.pem /etc/nginx/ssl/dhparam.pem
-                  curl https://letsencrypt.org/certs/isrgrootx1.pem                          > /etc/nginx/ssl/ca-certs.pem
-                  curl https://letsencrypt.org/certs/lets-encrypt-x1-cross-signed.pem       >> /etc/nginx/ssl/ca-certs.pem
-                  curl https://letsencrypt.org/certs/letsencryptauthorityx1.pem             >> /etc/nginx/ssl/ca-certs.pem
-                  curl https://www.identrust.com/certificates/trustid/root-download-x3.html >> /etc/nginx/ssl/ca-certs.pem
-              }
-
-              setup_nginx() {
-                  if [ ! -f /mnt/$JENKINS_HOST/ssl/nginx.conf ]; then
-                      cat <<-EOF | tee /mnt/$JENKINS_HOST/ssl/nginx.conf
-              			upstream jenkins {
-              			  server 127.0.0.1:8080 fail_timeout=0;
-              			}
-
-              			server {
-              			  listen 80;
-              			  server_name $JENKINS_HOST;
-
-              			  # letsencrypt certificates validation
-              			  location /.well-known {
-              			    alias /usr/share/nginx/html/.well-known;
-              			  }
-
-              			  # or redirect to https
-              			  if (\$uri !~* ^/.well-known) {
-              			    return 301 https://\$host\$request_uri;
-              			  }
-              			}
-
-              			server {
-              			  listen 443 ssl;
-              			  server_name $JENKINS_HOST;
-
-              			  ssl_certificate             /etc/nginx/ssl/certificate.crt;
-              			  ssl_certificate_key         /etc/nginx/ssl/certificate.key;
-              			  ssl_trusted_certificate     /etc/nginx/ssl/ca-certs.pem;
-              			  ssl_dhparam                 /etc/nginx/ssl/dhparam.pem;
-
-              			  ssl_protocols TLSv1.2;
-              			  ssl_ciphers ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:DHE-RSA-AES128-GCM-SHA256:DHE-RSA-AES256-GCM-SHA384;
-              			  ssl_prefer_server_ciphers off;
-
-              			  resolver                    8.8.8.8 ipv6=off;
-              			  lua_ssl_trusted_certificate /etc/pki/tls/certs/ca-bundle.crt;
-              			  lua_ssl_verify_depth        3;
-              			  include                     /mnt/$JENKINS_HOST/ssl/*-list.conf;
-              			  satisfy                     any;
-
-              			  location / {
-              			    proxy_set_header        Host \$host:\$server_port;
-              			    proxy_set_header        X-Real-IP \$remote_addr;
-              			    proxy_set_header        X-Forwarded-For \$proxy_add_x_forwarded_for;
-              			    proxy_set_header        X-Forwarded-Proto \$scheme;
-              			    proxy_redirect http:// https://;
-              			    proxy_pass              http://jenkins;
-              			    # Required for new HTTP-based CLI
-              			    proxy_http_version 1.1;
-              			    proxy_request_buffering off;
-              			    proxy_buffering off; # Required for HTTP-based CLI to work over SSL
-              			    # workaround for https://issues.jenkins-ci.org/browse/JENKINS-45651
-              			    add_header 'X-SSH-Endpoint' '$JENKINS_HOST:50022' always;
-              			  }
-              			}
-              		EOF
-                  fi
-
-                  ln -f -s /mnt/$JENKINS_HOST/ssl/nginx.conf /usr/local/openresty/nginx/conf/jenkins.conf
-                  sed -i'' -e 's/listen/#listen/; s/mime.types/jenkins.conf/' /usr/local/openresty/nginx/conf/nginx.conf
-
-                  systemctl enable --now openresty
-              }
-
-              setup_letsencrypt() {
-                  install -d /usr/share/nginx/html
-                  # Wait for web server to serve port 80 (needed for ACME HTTP-01 challenge)
-                  for i in $(seq 1 30); do
-                    curl -sf -o /dev/null http://127.0.0.1:80/ && break
-                    echo "Waiting for port 80... ($i/30)"
-                    sleep 2
-                  done
-                  curl -sf -o /dev/null http://127.0.0.1:80/ || echo "WARNING: port 80 not responding after 60s"
-                  if [[ -d /mnt/ssl_backup ]]; then
-                    rsync -aHSv --delete /mnt/ssl_backup/ /etc/letsencrypt/
-                    if ! certbot renew -q; then
-                      echo "WARNING: certbot renew failed (backup cert still in use)"
-                    fi
-                  else
-                    certbot --debug --non-interactive certonly --agree-tos --register-unsafely-without-email --webroot -w /usr/share/nginx/html --keep -d $JENKINS_HOST
-                  fi
-                  ln -f -s /etc/letsencrypt/live/$JENKINS_HOST/fullchain.pem /etc/nginx/ssl/certificate.crt
-                  ln -f -s /etc/letsencrypt/live/$JENKINS_HOST/privkey.pem   /etc/nginx/ssl/certificate.key
-
-                  # Back up certs to EBS after successful setup
-                  rsync -aHSv --delete /etc/letsencrypt/ /mnt/ssl_backup/
-
-                  # Create deploy hook directory
-                  mkdir -p /etc/letsencrypt/renewal-hooks/deploy
-
-                  # Create the hook script that runs after successful renewal
-                  cat << 'EOF' > /etc/letsencrypt/renewal-hooks/deploy/restart-openresty.sh
-              #!/bin/bash
-              # This script runs automatically after certbot renews certificates
-              # Create certs backup
-              BACKUP_DATE=$(date +%Y%m%d_%H%M%S)
-              rsync -aHSv /etc/letsencrypt/ /mnt/ssl_backup_$BACKUP_DATE/
-              # also to regular backup directory
-              rsync -aHSv --delete /etc/letsencrypt/ /mnt/ssl_backup/
-              # Prune timestamped backups older than 1 year
-              find /mnt -maxdepth 1 -name 'ssl_backup_*' -mtime +365 -exec rm -rf {} +
-              systemctl stop openresty
-              sleep 2
-              systemctl start openresty
-              EOF
-
-                  chmod +x /etc/letsencrypt/renewal-hooks/deploy/restart-openresty.sh
-
-                  systemctl stop openresty
-                  sleep 2
-                  systemctl start openresty
-                  systemctl enable certbot-renew.timer
-                  systemctl restart certbot-renew.timer
-              }
-
-              restore_real_cert_from_backup() {
-                  # Must run before setup_nginx: OpenResty would otherwise start
-                  # with the stale self-signed cert from create_fake_ssl_cert and
-                  # serve TLS warnings until setup_letsencrypt swaps the symlinks.
-                  [[ -d /mnt/ssl_backup ]] || return 0
-                  local src_cert=/mnt/ssl_backup/live/$JENKINS_HOST/fullchain.pem
-                  local src_key=/mnt/ssl_backup/live/$JENKINS_HOST/privkey.pem
-                  [[ -f $src_cert && -f $src_key ]] || return 0
-                  # Validate before rsync so an expired backup does not pollute
-                  # /etc/letsencrypt/; setup_letsencrypt will provision fresh.
-                  openssl x509 -in $src_cert -checkend 0 -noout || return 0
-                  rsync -aHSv --delete /mnt/ssl_backup/ /etc/letsencrypt/
-                  mkdir -p /etc/nginx/ssl
-                  ln -f -s /etc/letsencrypt/live/$JENKINS_HOST/fullchain.pem /etc/nginx/ssl/certificate.crt
-                  ln -f -s /etc/letsencrypt/live/$JENKINS_HOST/privkey.pem  /etc/nginx/ssl/certificate.key
-              }
-
-              setup_dhparam() {
-                  if [ ! -f /mnt/$JENKINS_HOST/ssl/dhparam-4096.pem ]; then
-                      openssl dhparam -out /mnt/$JENKINS_HOST/ssl/dhparam-4096.pem 4096
-                  fi
-                  cp /mnt/$JENKINS_HOST/ssl/dhparam-4096.pem /etc/nginx/ssl/dhparam.pem
-                  systemctl restart openresty
-              }
-
-              setup_nginx_allow_list() {
-                  if [ ! -f /home/ec2-user/copy-nginx-allow-list.sh ]; then
-                    cat <<-EOF | tee /home/ec2-user/copy-nginx-allow-list.sh
-                      #!/bin/bash
-
-                      PATH_TO_BUILDS="/mnt/$JENKINS_HOST/jobs/manage-nginx-allow-list/builds"
-                      if [ -d "\$PATH_TO_BUILDS" ]; then
-                          lastSuccessfulBuildID=\$(grep 'lastSuccessfulBuild' \$PATH_TO_BUILDS/permalinks | awk '{print \$2}')
-
-                          PATH_TO_ALLOW_LIST="\$PATH_TO_BUILDS/\$lastSuccessfulBuildID/archive"
-                          if [ -f "\$PATH_TO_ALLOW_LIST/nginx-white-list.conf" ]; then
-                              isChanged=\$(rsync -aHv \$PATH_TO_ALLOW_LIST/nginx-white-list.conf /mnt/$JENKINS_HOST/ssl/ | grep nginx-white-list.conf)
-                              if [ -n "\$isChanged" ]; then
-                                  openresty -s reload
-                              fi
-                          fi
-                      fi
-              		EOF
-              		chmod 755 /home/ec2-user/copy-nginx-allow-list.sh
-              		echo '* * * * * root sleep 30; /home/ec2-user/copy-nginx-allow-list.sh' > /etc/cron.d/sync-nginx-allow-list
-                  fi
-              }
-
               setup_ssh_keys() {
                 KEYS_LIST="evgeniy.patlan alex.miroshnychenko eduardo.casarero santiago.ruiz andrew.siemen vadim.yalovets surabhi.bhat talha.rizwan anderson.nogueira"
 
@@ -883,12 +689,6 @@ Resources:
                   mount_data_partition
                   install_software
                   start_jenkins
-                  create_fake_ssl_cert
-                  restore_real_cert_from_backup
-                  setup_nginx
-                  setup_dhparam
-                  setup_letsencrypt
-                  setup_nginx_allow_list
                   curl -fsSL --retry 5 https://raw.githubusercontent.com/Percona-Lab/jenkins-pipelines/08df5f4e101e52d0e03a7e0062696ace909a86bc/scripts/install-master-observability.sh | JENKINS_HOST="$JENKINS_HOST" bash
               }
 


### PR DESCRIPTION
## Bug
- Each Jenkins master runs its own openresty + certbot stack on EC2; expiry pain documented in PR #3866 (made certbot non-fatal).
- PS-10945 moves SSL termination to the shared `jenkins-cd` ALB on the `percona-ci-platform` EKS cluster.

## Fix
- `install_software`: remove openresty yum repo + GPG import; drop `certbot` and `openresty` from the install list.
- Delete six SSL functions in `IaC/ps3.cd/JenkinsStack.yml`: `create_fake_ssl_cert`, `setup_nginx`, `setup_letsencrypt`, `restore_real_cert_from_backup`, `setup_dhparam`, `setup_nginx_allow_list` (192 lines).
- Remove the matching six SSL calls from `main()`.
- Net diff: 1 insertion, 201 deletions.

## Tickets
- Parent: [PS-10945](https://perconadev.atlassian.net/browse/PS-10945), centralised SSL termination for Jenkins masters.
- Companion: nogueiraanderson/percona-ci-platform#77 (nginx reverse proxy + Ingress on shared ALB).

## Validation
- `cfn-lint`: only pre-existing warnings remain (deletemessagebatch action name, UpdateReplacePolicy pairing), no new errors.
- `grep -E 'openresty|certbot|setup_nginx|setup_letsencrypt|setup_dhparam|create_fake_ssl_cert|restore_real_cert|nginx_allow_list|letsencrypt|/etc/nginx/ssl|ssl_backup|/etc/letsencrypt'` returns zero matches in the modified file.
- File line count: 906 -> 704.

## Deploy gating
**Do NOT `update-stack` until both prerequisites are live:**
1. percona-ci-platform PR #77 deployed; `jenkins-ingress` chart `values.yaml` switched from spike upstream (`https://ps3.cd.percona.com:443`) to production upstream (`http://ps3.cd.percona.com:8080`).
2. `HTTPSecurityGroup` on this stack opens tcp/8080 to the percona-ci-platform NAT egress EIPs. (Separate follow-up PR; current SG keeps :80/:443 open which is harmless after the strip, just unused.)

After deploy, the master binds Jenkins on :8080 only (RPM default). Stale `/mnt/$JENKINS_HOST/ssl/`, `/mnt/ssl_backup/`, `/etc/letsencrypt/` directories remain harmlessly on the EBS data volume. The `manage-nginx-allow-list` Jenkins job becomes a no-op and can be deleted in a follow-up.

[PS-10945]: https://perconadev.atlassian.net/browse/PS-10945?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ