### PR TITLE
refactor(ps3): remove CF JDNSRecord; external-dns owns ps3.cd.percona.com (PS-10945)

### DIFF
--- a/IaC/ps3.cd/JenkinsStack.yml
+++ b/IaC/ps3.cd/JenkinsStack.yml
@@ -415,15 +415,11 @@ Resources:
     Properties:
       Domain: vpc
 
-  JDNSRecord: # create DNS record for jenkins master
-    Type: AWS::Route53::RecordSet
-    Properties:
-      HostedZoneId: !Ref ZoneId
-      Name: !Ref JHostName
-      Type: A
-      TTL: 300
-      ResourceRecords:
-      - !Ref MasterIP
+  # JDNSRecord removed in PS-10945: ps3.cd.percona.com is now published by
+  # external-dns in the percona-ci-platform EKS cluster, pointing at the
+  # shared jenkins-cd ALB (alb.ingress.kubernetes.io/group.name=jenkins-cd).
+  # The master remains reachable directly via its EIP (52.210.70.55) and via
+  # the origin-ps3.cd.percona.com record used by the in-cluster nginx upstream.
 
   JDataVolume: # create volume for jenkins data directory
     Type: AWS::EC2::Volume


### PR DESCRIPTION
## Bug
- PS-10945 moves SSL termination to the shared `jenkins-cd` ALB on the percona-ci-platform EKS cluster.
- `ps3.cd.percona.com` cannot point at both the master EIP and the ALB; CF-owned `JDNSRecord` blocks external-dns takeover (external-dns runs `--policy=sync --registry=txt --txt-owner-id=percona-ci-platform`).

## Fix
- Delete `AWS::Route53::RecordSet JDNSRecord` from `IaC/ps3.cd/JenkinsStack.yml`.
- CF stack-update removes the live A record; external-dns publishes new A-alias to the ALB.
- `JHostName` parameter stays (still used to set `JENKINS_HOST` in user-data).

## Tickets
- Parent: [PS-10945](https://perconadev.atlassian.net/browse/PS-10945).
- Companions: nogueiraanderson/percona-ci-platform#77 (proxy addon), Percona-Lab/jenkins-pipelines#4085 (strip openresty).

## Deploy gating
Do NOT `update-stack` until both prerequisites are live:
1. PR #77 in percona-ci-platform merged + ArgoCD synced + ALB target group healthy for ps3 host.
2. `origin-ps3.cd.percona.com -> 52.210.70.55` exists in Route53 (operator populates `terraform/local.auto.tfvars` or `aws route53 change-resource-record-sets`).

After update-stack, external-dns publishes the new A-alias within ~1 min; cutover complete.

[PS-10945]: https://perconadev.atlassian.net/browse/PS-10945?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ