### PR TITLE
feat(ps3): allow :8080 from percona-ci-platform EKS NAT (PS-10945)

### DIFF
--- a/IaC/ps3.cd/JenkinsStack.yml
+++ b/IaC/ps3.cd/JenkinsStack.yml
@@ -235,10 +235,13 @@ Resources:
       - Key: iit-billing-tag
         Value: !Ref JShortName
 
-  HTTPSecurityGroup: # allow http and https access to jenkins master
+  HTTPSecurityGroup: # allow http/https public access + :8080 from EKS NAT
     Type: AWS::EC2::SecurityGroup
     Properties:
       GroupName: HTTP
+      # GroupDescription is immutable on AWS::EC2::SecurityGroup; do not
+      # edit or CF will Replacement-recreate the SG. PS-10945 :8080 rule
+      # below is added via SecurityGroupIngress (no replacement).
       GroupDescription: HTTP and HTTPS traffic in
       VpcId: !Ref JVPC
       SecurityGroupIngress:
@@ -250,6 +253,15 @@ Resources:
         FromPort: 443
         ToPort: 443
         CidrIp: 0.0.0.0/0
+      # PS-10945: jenkins-ingress nginx proxy in percona-ci-platform EKS
+      # (us-east-1, NAT GW nat-07fa1058bd856dd8a) proxy_passes to Jenkins on
+      # :8080. Removed in cleanup PR once openresty is stripped and Route53
+      # cut over; at that point :443 + :80 close to the public and only the
+      # NAT EIP keeps ingress to :8080.
+      - IpProtocol: tcp
+        FromPort: 8080
+        ToPort: 8080
+        CidrIp: 54.156.234.228/32
       Tags:
       - Key: iit-billing-tag
         Value: !Ref JShortName


### PR DESCRIPTION
## Fix
- Add `tcp/8080 from 54.156.234.228/32` to `HTTPSecurityGroup` in `IaC/ps3.cd/JenkinsStack.yml`.
- That `/32` is the EIP of `nat-07fa1058bd856dd8a` (the single NAT GW in `vpc-0fbe9a3c623b184fa`, `percona-ci-platform` EKS cluster, `us-east-1`), i.e. the source IP of pod egress from the cluster.
- Additive only: leaves `0.0.0.0/0 :80` and `:443` untouched. `GroupDescription` deliberately unchanged (immutable, would force SG replacement).

## Tickets
- Parent: [PS-10945](https://perconadev.atlassian.net/browse/PS-10945).
- Companions: #4085 (strip openresty); #4086 (remove CF JDNSRecord); nogueiraanderson/percona-ci-platform PRs merged for the jenkins-ingress addon + dedicated `jenkins-masters` ALB.

## Sequence
1. Land + `update-stack` this PR (low risk, additive). Live SG gains the :8080 rule.
2. Flip `jenkins-ingress` values.yaml in percona-ci-platform to `upstreamScheme: http`, `upstreamPort: 8080`. ArgoCD syncs in ~1 min. Verify proxy still works.
3. Land + `update-stack` #4085 (strip openresty). SpotFleet cycles, master comes up with Jenkins on :8080 only.
4. Land + `update-stack` #4086 (remove CF JDNSRecord). external-dns publishes `ps3.cd.percona.com` -> `k8s-jenkinsmasters-...` ALB.
5. Follow-up SG cleanup PR: remove `0.0.0.0/0 :443/:80`, keep only NAT /32 :8080 + SSH /32s.

## Drift note
`describe-stack-drift-detection-status` reports 4 drifted resources on `jenkins-ps3`: `JMasterInstance`, `JMasterRole`, `JWorkerRole`, `SSHSecurityGroup` (likely from PR #4037 alloy-gateway bearer rollout + recent operator changes). `HTTPSecurityGroup` is NOT drifted; this PR's update-stack will only touch HTTPSecurityGroup and will not affect the drifted resources.

## Rollback
Revert the commit + `update-stack`. AWS removes the :8080 ingress rule. Or `aws ec2 revoke-security-group-ingress --group-id sg-0c743652807eb62c4 --protocol tcp --port 8080 --cidr 54.156.234.228/32` for sub-minute revert.

[PS-10945]: https://perconadev.atlassian.net/browse/PS-10945?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ