### PR TITLE
PS-10945: ps3 SSL cutover - VPC renumber + strip openresty + peering SG + drop CF DNS

### DIFF
--- a/IaC/ps3.cd/JenkinsStack.yml
+++ b/IaC/ps3.cd/JenkinsStack.yml
@@ -235,10 +235,13 @@ Resources:
       - Key: iit-billing-tag
         Value: !Ref JShortName
 
-  HTTPSecurityGroup: # allow http and https access to jenkins master
+  HTTPSecurityGroup: # allow http/https public access + :8080 from EKS NAT
     Type: AWS::EC2::SecurityGroup
     Properties:
       GroupName: HTTP
+      # GroupDescription is immutable on AWS::EC2::SecurityGroup; do not
+      # edit or CF will Replacement-recreate the SG. PS-10945 :8080 rule
+      # below is added via SecurityGroupIngress (no replacement).
       GroupDescription: HTTP and HTTPS traffic in
       VpcId: !Ref JVPC
       SecurityGroupIngress:
@@ -250,6 +253,15 @@ Resources:
         FromPort: 443
         ToPort: 443
         CidrIp: 0.0.0.0/0
+      # PS-10945: jenkins-ingress nginx proxy in percona-ci-platform EKS
+      # (us-east-1, NAT GW nat-07fa1058bd856dd8a) proxy_passes to Jenkins on
+      # :8080. Removed in cleanup PR once openresty is stripped and Route53
+      # cut over; at that point :443 + :80 close to the public and only the
+      # NAT EIP keeps ingress to :8080.
+      - IpProtocol: tcp
+        FromPort: 8080
+        ToPort: 8080
+        CidrIp: 54.156.234.228/32
       Tags:
       - Key: iit-billing-tag
         Value: !Ref JShortName

--- a/IaC/ps3.cd/JenkinsStack.yml
+++ b/IaC/ps3.cd/JenkinsStack.yml
@@ -65,7 +65,7 @@ Resources:
       - Key: iit-billing-tag
         Value: !Ref JShortName
 
-  JInternetGateway: # Internet Gateway for jenkins VPC
+  JInternetGatewayV2: # Internet Gateway for jenkins VPC
     Type: AWS::EC2::InternetGateway
     Properties:
       Tags:
@@ -78,7 +78,7 @@ Resources:
     Type: AWS::EC2::VPCGatewayAttachment
     Properties:
       VpcId: !Ref JVPC
-      InternetGatewayId: !Ref JInternetGateway
+      InternetGatewayId: !Ref JInternetGatewayV2
 
   JSubnetB: # create subnet in AZ
     Type: AWS::EC2::Subnet
@@ -120,9 +120,16 @@ Resources:
 
   JInternetRoute: # add default route
     Type: AWS::EC2::Route
+    # Explicit DependsOn: CF infers GatewayId/RouteTableId dependencies on
+    # the IGW and RT existing, but not on the GatewayAttachment. Without
+    # this, an UPDATE that replaces the VPC races RT/Route creation against
+    # the IGW->VPC attachment and AWS rejects with "route table and network
+    # gateway belong to different networks". Stack CREATE happens to work
+    # by accident; UPDATE-replace surfaces the gap.
+    DependsOn: JVPCGatewayAttachment
     Properties:
       DestinationCidrBlock: 0.0.0.0/0
-      GatewayId: !Ref JInternetGateway
+      GatewayId: !Ref JInternetGatewayV2
       RouteTableId: !Ref JRouteTable
 
   SubnetBRouteTable: # add subnet route
@@ -430,15 +437,12 @@ Resources:
     Properties:
       Domain: vpc
 
-  JDNSRecord: # create DNS record for jenkins master
-    Type: AWS::Route53::RecordSet
-    Properties:
-      HostedZoneId: !Ref ZoneId
-      Name: !Ref JHostName
-      Type: A
-      TTL: 300
-      ResourceRecords:
-      - !Ref MasterIP
+  # JDNSRecord removed for PS-10945 cutover: ps3.cd.percona.com is now
+  # owned by external-dns in the percona-ci-platform EKS cluster, publishing
+  # an A-alias to the dedicated jenkins-masters ALB. CF must NOT own the
+  # public record so external-dns can adopt it via its TXT registry.
+  # JHostName parameter stays in the template (still drives JENKINS_HOST
+  # in user-data so the master knows its own public name).
 
   JDataVolume: # create volume for jenkins data directory
     Type: AWS::EC2::Volume

--- a/IaC/ps3.cd/JenkinsStack.yml
+++ b/IaC/ps3.cd/JenkinsStack.yml
@@ -52,7 +52,10 @@ Resources:
   JVPC: # separate virtual network for jenkins instances
     Type: AWS::EC2::VPC
     Properties:
-      CidrBlock: 10.177.0.0/22
+      # PS-10945: renumbered from 10.177.0.0/22 (collided with pxc/ps57/cloud)
+      # to 10.181.0.0/22 so this VPC can peer with the percona-ci-platform
+      # EKS VPC (10.220.0.0/16) without route-table conflict.
+      CidrBlock: 10.181.0.0/22
       EnableDnsSupport: true
       EnableDnsHostnames: true
       InstanceTenancy: default
@@ -81,7 +84,7 @@ Resources:
     Type: AWS::EC2::Subnet
     Properties:
       VpcId: !Ref JVPC
-      CidrBlock: 10.177.1.0/24
+      CidrBlock: 10.181.1.0/24
       MapPublicIpOnLaunch: true
       AvailabilityZone:
         Fn::Select: [ 1, !GetAZs '' ]
@@ -95,7 +98,7 @@ Resources:
     Type: AWS::EC2::Subnet
     Properties:
       VpcId: !Ref JVPC
-      CidrBlock: 10.177.2.0/24
+      CidrBlock: 10.181.2.0/24
       MapPublicIpOnLaunch: true
       AvailabilityZone:
         Fn::Select: [ 2, !GetAZs '' ]
@@ -254,14 +257,14 @@ Resources:
         ToPort: 443
         CidrIp: 0.0.0.0/0
       # PS-10945: jenkins-ingress nginx proxy in percona-ci-platform EKS
-      # (us-east-1, NAT GW nat-07fa1058bd856dd8a) proxy_passes to Jenkins on
-      # :8080. Removed in cleanup PR once openresty is stripped and Route53
-      # cut over; at that point :443 + :80 close to the public and only the
-      # NAT EIP keeps ingress to :8080.
+      # (us-east-1 VPC 10.220.0.0/16) reaches Jenkins :8080 via cross-region
+      # VPC peering (percona-ci-platform/terraform/peering-ps3.tf), not via
+      # the cluster's NAT EIP. Source is the EKS VPC CIDR. :443 + :80 close
+      # in a follow-up once Route53 has cut over to the ALB.
       - IpProtocol: tcp
         FromPort: 8080
         ToPort: 8080
-        CidrIp: 54.156.234.228/32
+        CidrIp: 10.220.0.0/16
       Tags:
       - Key: iit-billing-tag
         Value: !Ref JShortName

--- a/IaC/ps3.cd/JenkinsStack.yml
+++ b/IaC/ps3.cd/JenkinsStack.yml
@@ -568,8 +568,6 @@ Resources:
                   done
 
                   yum -y install yum-utils wget cronie rsync bc
-                  yum-config-manager --add-repo "https://openresty.org/package/amazon/2023/x86_64/"
-                  rpm --import https://openresty.org/package/pubkey.gpg
                   # ps3 runs the current LTS line (2.541.x) to match the live
                   # plugin set on the EBS data volume; the rest of the fleet
                   # remains on jenkins-2.528.3 from redhat-stable-legacy.
@@ -579,7 +577,7 @@ Resources:
                   rpm --import https://pkg.jenkins.io/redhat-stable/jenkins.io-2026.key
                   yum -y install java-17-amazon-corretto
                   yum -y update --security
-                  yum -y install jenkins-2.541.3 certbot git dnf-automatic aws-cli xfsprogs openresty
+                  yum -y install jenkins-2.541.3 git dnf-automatic aws-cli xfsprogs
 
                   sed -i 's/upgrade_type = default/upgrade_type = security/' /etc/dnf/automatic.conf
                   sed -i 's/apply_updates = no/apply_updates = yes/'         /etc/dnf/automatic.conf
@@ -675,198 +673,6 @@ Resources:
                   printf "* * * * * root bash -c 'curl -s http://169.254.169.254/latest/meta-data/spot/instance-action | grep action && sh -c \"systemctl stop jenkins; cp /var/log/jenkins/jenkins.log /mnt/jenkins-latest.log; umount /mnt\" || :'\n* * * * * root sleep 30; bash -c 'curl -s http://169.254.169.254/latest/meta-data/spot/instance-action | grep action && sh -c \"systemctl stop jenkins; cp /var/log/jenkins/jenkins.log /mnt/jenkins-latest.log; umount /mnt\" || :'\n" > /etc/cron.d/terminate-check
               }
 
-              create_fake_ssl_cert() {
-                  mkdir -p /etc/nginx/ssl
-                  mkdir -p /mnt/$JENKINS_HOST/ssl
-                  if [ ! -f /mnt/$JENKINS_HOST/ssl/certificate.key -o ! -f /mnt/$JENKINS_HOST/ssl/certificate.crt ]; then
-                      echo "
-                          [ req ]
-                          distinguished_name = req_distinguished_name
-                          prompt             = no
-                          [ req_distinguished_name ]
-                          O                  = Main Org.
-                      " | tee /mnt/$JENKINS_HOST/ssl/certificate.conf
-                      openssl req -x509 -nodes -days 365 -newkey rsa:2048 \
-                                    -keyout /mnt/$JENKINS_HOST/ssl/certificate.key \
-                                    -out    /mnt/$JENKINS_HOST/ssl/certificate.crt \
-                                    -config /mnt/$JENKINS_HOST/ssl/certificate.conf
-                  fi
-                  cp /mnt/$JENKINS_HOST/ssl/certificate.key /etc/nginx/ssl/certificate.key
-                  cp /mnt/$JENKINS_HOST/ssl/certificate.crt /etc/nginx/ssl/certificate.crt
-                  if [ ! -f /mnt/$JENKINS_HOST/ssl/dhparam-4096.pem ]; then
-                      openssl dhparam -out /mnt/$JENKINS_HOST/ssl/dhparam-4096.pem 4096
-                  fi
-                  cp /mnt/$JENKINS_HOST/ssl/dhparam-4096.pem /etc/nginx/ssl/dhparam.pem
-                  curl https://letsencrypt.org/certs/isrgrootx1.pem                          > /etc/nginx/ssl/ca-certs.pem
-                  curl https://letsencrypt.org/certs/lets-encrypt-x1-cross-signed.pem       >> /etc/nginx/ssl/ca-certs.pem
-                  curl https://letsencrypt.org/certs/letsencryptauthorityx1.pem             >> /etc/nginx/ssl/ca-certs.pem
-                  curl https://www.identrust.com/certificates/trustid/root-download-x3.html >> /etc/nginx/ssl/ca-certs.pem
-              }
-
-              setup_nginx() {
-                  if [ ! -f /mnt/$JENKINS_HOST/ssl/nginx.conf ]; then
-                      cat <<-EOF | tee /mnt/$JENKINS_HOST/ssl/nginx.conf
-              			upstream jenkins {
-              			  server 127.0.0.1:8080 fail_timeout=0;
-              			}
-
-              			server {
-              			  listen 80;
-              			  server_name $JENKINS_HOST;
-
-              			  # letsencrypt certificates validation
-              			  location /.well-known {
-              			    alias /usr/share/nginx/html/.well-known;
-              			  }
-
-              			  # or redirect to https
-              			  if (\$uri !~* ^/.well-known) {
-              			    return 301 https://\$host\$request_uri;
-              			  }
-              			}
-
-              			server {
-              			  listen 443 ssl;
-              			  server_name $JENKINS_HOST;
-
-              			  ssl_certificate             /etc/nginx/ssl/certificate.crt;
-              			  ssl_certificate_key         /etc/nginx/ssl/certificate.key;
-              			  ssl_trusted_certificate     /etc/nginx/ssl/ca-certs.pem;
-              			  ssl_dhparam                 /etc/nginx/ssl/dhparam.pem;
-
-              			  ssl_protocols TLSv1.2;
-              			  ssl_ciphers ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:DHE-RSA-AES128-GCM-SHA256:DHE-RSA-AES256-GCM-SHA384;
-              			  ssl_prefer_server_ciphers off;
-
-              			  resolver                    8.8.8.8 ipv6=off;
-              			  lua_ssl_trusted_certificate /etc/pki/tls/certs/ca-bundle.crt;
-              			  lua_ssl_verify_depth        3;
-              			  include                     /mnt/$JENKINS_HOST/ssl/*-list.conf;
-              			  satisfy                     any;
-
-              			  location / {
-              			    proxy_set_header        Host \$host:\$server_port;
-              			    proxy_set_header        X-Real-IP \$remote_addr;
-              			    proxy_set_header        X-Forwarded-For \$proxy_add_x_forwarded_for;
-              			    proxy_set_header        X-Forwarded-Proto \$scheme;
-              			    proxy_redirect http:// https://;
-              			    proxy_pass              http://jenkins;
-              			    # Required for new HTTP-based CLI
-              			    proxy_http_version 1.1;
-              			    proxy_request_buffering off;
-              			    proxy_buffering off; # Required for HTTP-based CLI to work over SSL
-              			    # workaround for https://issues.jenkins-ci.org/browse/JENKINS-45651
-              			    add_header 'X-SSH-Endpoint' '$JENKINS_HOST:50022' always;
-              			  }
-              			}
-              		EOF
-                  fi
-
-                  ln -f -s /mnt/$JENKINS_HOST/ssl/nginx.conf /usr/local/openresty/nginx/conf/jenkins.conf
-                  sed -i'' -e 's/listen/#listen/; s/mime.types/jenkins.conf/' /usr/local/openresty/nginx/conf/nginx.conf
-
-                  systemctl enable --now openresty
-              }
-
-              setup_letsencrypt() {
-                  install -d /usr/share/nginx/html
-                  # Wait for web server to serve port 80 (needed for ACME HTTP-01 challenge)
-                  for i in $(seq 1 30); do
-                    curl -sf -o /dev/null http://127.0.0.1:80/ && break
-                    echo "Waiting for port 80... ($i/30)"
-                    sleep 2
-                  done
-                  curl -sf -o /dev/null http://127.0.0.1:80/ || echo "WARNING: port 80 not responding after 60s"
-                  if [[ -d /mnt/ssl_backup ]]; then
-                    rsync -aHSv --delete /mnt/ssl_backup/ /etc/letsencrypt/
-                    if ! certbot renew -q; then
-                      echo "WARNING: certbot renew failed (backup cert still in use)"
-                    fi
-                  else
-                    certbot --debug --non-interactive certonly --agree-tos --register-unsafely-without-email --webroot -w /usr/share/nginx/html --keep -d $JENKINS_HOST
-                  fi
-                  ln -f -s /etc/letsencrypt/live/$JENKINS_HOST/fullchain.pem /etc/nginx/ssl/certificate.crt
-                  ln -f -s /etc/letsencrypt/live/$JENKINS_HOST/privkey.pem   /etc/nginx/ssl/certificate.key
-
-                  # Back up certs to EBS after successful setup
-                  rsync -aHSv --delete /etc/letsencrypt/ /mnt/ssl_backup/
-
-                  # Create deploy hook directory
-                  mkdir -p /etc/letsencrypt/renewal-hooks/deploy
-
-                  # Create the hook script that runs after successful renewal
-                  cat << 'EOF' > /etc/letsencrypt/renewal-hooks/deploy/restart-openresty.sh
-              #!/bin/bash
-              # This script runs automatically after certbot renews certificates
-              # Create certs backup
-              BACKUP_DATE=$(date +%Y%m%d_%H%M%S)
-              rsync -aHSv /etc/letsencrypt/ /mnt/ssl_backup_$BACKUP_DATE/
-              # also to regular backup directory
-              rsync -aHSv --delete /etc/letsencrypt/ /mnt/ssl_backup/
-              # Prune timestamped backups older than 1 year
-              find /mnt -maxdepth 1 -name 'ssl_backup_*' -mtime +365 -exec rm -rf {} +
-              systemctl stop openresty
-              sleep 2
-              systemctl start openresty
-              EOF
-
-                  chmod +x /etc/letsencrypt/renewal-hooks/deploy/restart-openresty.sh
-
-                  systemctl stop openresty
-                  sleep 2
-                  systemctl start openresty
-                  systemctl enable certbot-renew.timer
-                  systemctl restart certbot-renew.timer
-              }
-
-              restore_real_cert_from_backup() {
-                  # Must run before setup_nginx: OpenResty would otherwise start
-                  # with the stale self-signed cert from create_fake_ssl_cert and
-                  # serve TLS warnings until setup_letsencrypt swaps the symlinks.
-                  [[ -d /mnt/ssl_backup ]] || return 0
-                  local src_cert=/mnt/ssl_backup/live/$JENKINS_HOST/fullchain.pem
-                  local src_key=/mnt/ssl_backup/live/$JENKINS_HOST/privkey.pem
-                  [[ -f $src_cert && -f $src_key ]] || return 0
-                  # Validate before rsync so an expired backup does not pollute
-                  # /etc/letsencrypt/; setup_letsencrypt will provision fresh.
-                  openssl x509 -in $src_cert -checkend 0 -noout || return 0
-                  rsync -aHSv --delete /mnt/ssl_backup/ /etc/letsencrypt/
-                  mkdir -p /etc/nginx/ssl
-                  ln -f -s /etc/letsencrypt/live/$JENKINS_HOST/fullchain.pem /etc/nginx/ssl/certificate.crt
-                  ln -f -s /etc/letsencrypt/live/$JENKINS_HOST/privkey.pem  /etc/nginx/ssl/certificate.key
-              }
-
-              setup_dhparam() {
-                  if [ ! -f /mnt/$JENKINS_HOST/ssl/dhparam-4096.pem ]; then
-                      openssl dhparam -out /mnt/$JENKINS_HOST/ssl/dhparam-4096.pem 4096
-                  fi
-                  cp /mnt/$JENKINS_HOST/ssl/dhparam-4096.pem /etc/nginx/ssl/dhparam.pem
-                  systemctl restart openresty
-              }
-
-              setup_nginx_allow_list() {
-                  if [ ! -f /home/ec2-user/copy-nginx-allow-list.sh ]; then
-                    cat <<-EOF | tee /home/ec2-user/copy-nginx-allow-list.sh
-                      #!/bin/bash
-
-                      PATH_TO_BUILDS="/mnt/$JENKINS_HOST/jobs/manage-nginx-allow-list/builds"
-                      if [ -d "\$PATH_TO_BUILDS" ]; then
-                          lastSuccessfulBuildID=\$(grep 'lastSuccessfulBuild' \$PATH_TO_BUILDS/permalinks | awk '{print \$2}')
-
-                          PATH_TO_ALLOW_LIST="\$PATH_TO_BUILDS/\$lastSuccessfulBuildID/archive"
-                          if [ -f "\$PATH_TO_ALLOW_LIST/nginx-white-list.conf" ]; then
-                              isChanged=\$(rsync -aHv \$PATH_TO_ALLOW_LIST/nginx-white-list.conf /mnt/$JENKINS_HOST/ssl/ | grep nginx-white-list.conf)
-                              if [ -n "\$isChanged" ]; then
-                                  openresty -s reload
-                              fi
-                          fi
-                      fi
-              		EOF
-              		chmod 755 /home/ec2-user/copy-nginx-allow-list.sh
-              		echo '* * * * * root sleep 30; /home/ec2-user/copy-nginx-allow-list.sh' > /etc/cron.d/sync-nginx-allow-list
-                  fi
-              }
-
               setup_ssh_keys() {
                 KEYS_LIST="evgeniy.patlan alex.miroshnychenko eduardo.casarero santiago.ruiz andrew.siemen vadim.yalovets surabhi.bhat talha.rizwan anderson.nogueira"
 
@@ -895,12 +701,6 @@ Resources:
                   mount_data_partition
                   install_software
                   start_jenkins
-                  create_fake_ssl_cert
-                  restore_real_cert_from_backup
-                  setup_nginx
-                  setup_dhparam
-                  setup_letsencrypt
-                  setup_nginx_allow_list
                   curl -fsSL --retry 5 https://raw.githubusercontent.com/Percona-Lab/jenkins-pipelines/08df5f4e101e52d0e03a7e0062696ace909a86bc/scripts/install-master-observability.sh | JENKINS_HOST="$JENKINS_HOST" bash
               }
 


### PR DESCRIPTION
## Bug

`ps3.cd.percona.com` ran openresty + certbot on every master instance, serving TLS to the public. Certbot HTTP-01 renewals failed on spot rotations; openresty drift across 10 masters meant per-master diffs every time the pattern changed; ps3's VPC `10.177.0.0/22` collided with `pxc`/`ps57`/`cloud` (blocks VPC peering).

## Fix

Single PR for the ps3 cutover. Already direct-applied to the `jenkins-ps3` CF stack to validate; PR brings the source of truth back in line with the live template.

- **Renumber VPC** `10.177.0.0/22` -> `10.181.0.0/22` (no overlap with EKS `10.220/16` or remaining ps3-cohort `10.177/22`). EIP `52.210.70.55` survives; EBS data restored via snapshot. New IGW (`JInternetGatewayV2`) forces clean replacement; explicit `DependsOn: JVPCGatewayAttachment` on `JInternetRoute` avoids the route/IGW race on UPDATE.
- **Strip openresty + certbot**: drop the 6 SSL functions (`create_fake_ssl_cert`, `setup_nginx`, `setup_letsencrypt`, `setup_dhparam`, `setup_nginx_allow_list`, `restore_real_cert_from_backup`), drop their main() calls, drop `openresty` repo + `certbot`/`openresty` packages from yum install.
- **SG :8080 from EKS VPC** (`10.220.0.0/16`), reached via cross-region VPC peering from us-east-1. Master listens on :8080 only; :443/:80 stay open to `0.0.0.0/0` only until step 7 of the cutover runbook closes them.
- **Drop `JDNSRecord`**: external-dns in percona-ci-platform EKS now owns `ps3.cd.percona.com` and publishes the alias to the dedicated `jenkins-masters` ALB.

Counterpart in [`nogueiraanderson/percona-ci-platform` PR #79](https://github.com/nogueiraanderson/percona-ci-platform/pull/79): peering Terraform + ADR 0019 amendment + cutover runbook updates.

## Verified

- HTTP/2 200 on `https://ps3.cd.percona.com/login` via public DNS.
- `X-Jenkins: 2.541.3` / `X-Hudson: 1.395` (proxy reaches actual Jenkins, not the friendly 503 page).
- Master listens on `:8080`/`:22` only; no openresty/certbot packages, units, or root-vol cert paths remain (SSM `RunCommand`).
- EBS `/mnt/ps3.cd.percona.com/ssl/` and `/mnt/ssl_backup/` cleaned; rest of JENKINS_HOME intact.

## Tickets

- PS-10945