### PR TITLE
PMM-7: fix RC testing Groovy syntax

### DIFF
--- a/pmm/v3/pmm3-rc-testing.groovy
+++ b/pmm/v3/pmm3-rc-testing.groovy
@@ -576,7 +576,7 @@ pipeline {
                                         string(name: 'PMM_QA_GIT_BRANCH',              value: 'main'),
                                         booleanParam(name: 'GENERATE_DASHBOARD_SCREENSHOTS', value: true),
                                         string(name: 'SCREENSHOTS_SLACK_TARGET',       value: env.SLACK_RC_SCREENSHOTS_TARGET),
-                                    ])
+                                    ]
                                 }
                             }
                         }


### PR DESCRIPTION
## Summary
- Fix the `pmm3-rc-testing.groovy` screenshots stage so the `build` step closes the `parameters` list correctly.
- Restores Jenkins Groovy parsing for the RC orchestrator pipeline after the screenshots stage addition.