### PR TITLE
PMM-7: clean up screenshot deploy runs

### DIFF
--- a/pmm/v3/pmm3-deploy-services.groovy
+++ b/pmm/v3/pmm3-deploy-services.groovy
@@ -431,7 +431,13 @@ pipeline {
   // do build job:, echo, slackSend - no sh - so no node{} wrapping needed.
   post {
     success {
-      echo "Job finished normally."
+      script {
+        echo "Job finished normally."
+        if (params.GENERATE_DASHBOARD_SCREENSHOTS.toBoolean()) {
+          echo "Screenshot run completed: cleaning up resources..."
+          cleanupResources('completed/cleaned up')
+        }
+      }
     }
     failure {
       script {
@@ -455,7 +461,7 @@ pipeline {
 // CUSTOM HELPERS (Cleanup & Retry Logic)
 // ===================================================================================
 
-void cleanupResources() {
+void cleanupResources(String slackStatus = 'aborted/failed/cleaned up') {
     // 1. Clean Server based on Type
     if (env.SERVER_TYPE == "ovf" && env.OVF_INSTANCE_NAME) {
          build job: 'pmm-ovf-staging-stop', parameters: [ string(name: 'VM', value: env.OVF_INSTANCE_NAME) ]
@@ -488,7 +494,7 @@ void cleanupResources() {
     }
 
     if (env.SLACK_DM) {
-      slackSend botUser: true, channel: env.SLACK_DM, color: '#808080', message: "[${env.JOB_NAME}]: aborted/failed/cleaned up, owner: @${env.OWNER}\nURL: ${env.BUILD_URL}"
+      slackSend botUser: true, channel: env.SLACK_DM, color: '#808080', message: "[${env.JOB_NAME}]: ${slackStatus}, owner: @${env.OWNER}\nURL: ${env.BUILD_URL}"
     }
 }
 


### PR DESCRIPTION
## Summary
- Clean up `pmm3-deploy-services` resources after successful screenshot runs.
- Keep regular successful deploy-service runs unchanged, while preserving failure/abort cleanup behavior.
- Use a success-specific cleanup Slack status so screenshot completions are not reported as abort/failure.