### PR TITLE
PXB-3745: add amazonlinux:2023 to prepare-pxc-build-docker matrix

### DIFF
--- a/pxc/jenkins/prepare-pxc-build-docker.groovy
+++ b/pxc/jenkins/prepare-pxc-build-docker.groovy
@@ -47,6 +47,7 @@ pipeline {
                         "debian:bullseye":  { build('debian:bullseye') },
                         "debian:bookworm":  { build('debian:bookworm') },
                         "debian:trixie":    { build('debian:trixie') },
+                        "amazonlinux:2023": { build('amazonlinux:2023') },
                     ]
                     if (params.ARCH != 'aarch64') {
                         builders["centos:7"] = { build('centos:7') }


### PR DESCRIPTION
## Change

Add `amazonlinux:2023` to the `prepare-pxc-build-docker-ecr` parallel matrix. One-line addition to the `.groovy` introduced by [PR 4093](https://github.com/Percona-Lab/jenkins-pipelines/pull/4093). Reuses the existing `build()` helper; aarch64 inherits the `ARCH_SUFFIX` from `pxc/docker/prepare-docker`.

## Tickets

- [PXB-3745](https://perconadev.atlassian.net/browse/PXB-3745) (this), blocks [PXB-3613](https://perconadev.atlassian.net/browse/PXB-3613)
- Related: [PR 4093](https://github.com/Percona-Lab/jenkins-pipelines/pull/4093), [PR 4094](https://github.com/Percona-Lab/jenkins-pipelines/pull/4094), [PR 4096](https://github.com/Percona-Lab/jenkins-pipelines/pull/4096), [PR 4102](https://github.com/Percona-Lab/jenkins-pipelines/pull/4102), [PR 4105](https://github.com/Percona-Lab/jenkins-pipelines/pull/4105)


[PXB-3745]: https://perconadev.atlassian.net/browse/PXB-3745?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[PXB-3613]: https://perconadev.atlassian.net/browse/PXB-3613?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ