### PR TITLE
PXB-3745: add amazonlinux:2023 to pxb v2 compile + test DOCKER_OS

### DIFF
--- a/pxb/v2/jenkins/percona-xtrabackup-8.0-compile-param.yml
+++ b/pxb/v2/jenkins/percona-xtrabackup-8.0-compile-param.yml
@@ -59,6 +59,7 @@
          - ubuntu:noble
          - debian:bullseye
          - debian:bookworm
+         - amazonlinux:2023
          - asan
     builders:
     - trigger-builds:

--- a/pxb/v2/jenkins/percona-xtrabackup-8.0-compile-pipeline.groovy
+++ b/pxb/v2/jenkins/percona-xtrabackup-8.0-compile-pipeline.groovy
@@ -20,7 +20,7 @@ pipeline {
             name: 'BRANCH',
             trim: true)
         choice(
-            choices: 'centos:8\noraclelinux:9\nubuntu:focal\nubuntu:jammy\nubuntu:noble\ndebian:bullseye\ndebian:bookworm\nasan',
+            choices: 'centos:8\noraclelinux:9\nubuntu:focal\nubuntu:jammy\nubuntu:noble\ndebian:bullseye\ndebian:bookworm\namazonlinux:2023\nasan',
             description: 'OS version for compilation',
             name: 'DOCKER_OS')
         choice(

--- a/pxb/v2/jenkins/percona-xtrabackup-8.0-compile-pipeline.yml
+++ b/pxb/v2/jenkins/percona-xtrabackup-8.0-compile-pipeline.yml
@@ -32,6 +32,7 @@
         - ubuntu:noble
         - debian:bullseye
         - debian:bookworm
+        - amazonlinux:2023
         - asan
         description: OS version for compilation
     - choice:

--- a/pxb/v2/jenkins/percona-xtrabackup-8.0-test-cloud-pipeline.groovy
+++ b/pxb/v2/jenkins/percona-xtrabackup-8.0-test-cloud-pipeline.groovy
@@ -1,7 +1,7 @@
 pipeline {
     parameters {
         choice(
-            choices: 'centos:8\noraclelinux:9\nubuntu:focal\nubuntu:jammy\nubuntu:noble\ndebian:bullseye\ndebian:bookworm\nasan',
+            choices: 'centos:8\noraclelinux:9\nubuntu:focal\nubuntu:jammy\nubuntu:noble\ndebian:bullseye\ndebian:bookworm\namazonlinux:2023\nasan',
             description: 'OS version for compilation',
             name: 'DOCKER_OS')
         choice(

--- a/pxb/v2/jenkins/percona-xtrabackup-8.0-test-cloud-pipeline.yml
+++ b/pxb/v2/jenkins/percona-xtrabackup-8.0-test-cloud-pipeline.yml
@@ -24,6 +24,7 @@
           - ubuntu:noble
           - debian:bullseye
           - debain:bookworm
+          - amazonlinux:2023
           - asan
         description: OS version for compilation
     - choice:

--- a/pxb/v2/jenkins/percona-xtrabackup-8.0-test-cloud-pipeline.yml
+++ b/pxb/v2/jenkins/percona-xtrabackup-8.0-test-cloud-pipeline.yml
@@ -23,7 +23,7 @@
           - ubuntu:jammy
           - ubuntu:noble
           - debian:bullseye
-          - debain:bookworm
+          - debian:bookworm
           - amazonlinux:2023
           - asan
         description: OS version for compilation

--- a/pxb/v2/jenkins/percona-xtrabackup-8.0-test-param.yml
+++ b/pxb/v2/jenkins/percona-xtrabackup-8.0-test-param.yml
@@ -75,6 +75,7 @@
         - ubuntu:noble
         - debian:bullseye
         - debian:bookworm
+        - amazonlinux:2023
         - asan
     - axis:
         name: XTRABACKUP_TARGET

--- a/pxb/v2/jenkins/percona-xtrabackup-8.0-test-pipeline.groovy
+++ b/pxb/v2/jenkins/percona-xtrabackup-8.0-test-pipeline.groovy
@@ -10,7 +10,7 @@ if (params.CLOUD == 'AWS') {
 pipeline {
     parameters {
         choice(
-            choices: 'centos:8\noraclelinux:9\nubuntu:focal\nubuntu:jammy\nubuntu:noble\ndebian:bullseye\ndebian:bookworm\nasan',
+            choices: 'centos:8\noraclelinux:9\nubuntu:focal\nubuntu:jammy\nubuntu:noble\ndebian:bullseye\ndebian:bookworm\namazonlinux:2023\nasan',
             description: 'OS version for compilation',
             name: 'DOCKER_OS')
         choice(

--- a/pxb/v2/jenkins/percona-xtrabackup-8.0-test-pipeline.yml
+++ b/pxb/v2/jenkins/percona-xtrabackup-8.0-test-pipeline.yml
@@ -24,6 +24,7 @@
           - ubuntu:noble
           - debian:bullseye
           - debian:bookworm
+          - amazonlinux:2023
           - asan
         description: OS version for compilation
     - choice:

--- a/pxb/v2/jenkins/percona-xtrabackup-8.1-compile-param.yml
+++ b/pxb/v2/jenkins/percona-xtrabackup-8.1-compile-param.yml
@@ -59,6 +59,7 @@
          - ubuntu:noble
          - debian:bullseye
          - debian:bookworm
+         - amazonlinux:2023
          - asan
     builders:
     - trigger-builds:

--- a/pxb/v2/jenkins/percona-xtrabackup-8.1-compile-pipeline.groovy
+++ b/pxb/v2/jenkins/percona-xtrabackup-8.1-compile-pipeline.groovy
@@ -20,7 +20,7 @@ pipeline {
             name: 'BRANCH',
             trim: true)
         choice(
-            choices: 'centos:8\noraclelinux:9\nubuntu:focal\nubuntu:jammy\nubuntu:noble\ndebian:bullseye\ndebian:bookworm\nasan',
+            choices: 'centos:8\noraclelinux:9\nubuntu:focal\nubuntu:jammy\nubuntu:noble\ndebian:bullseye\ndebian:bookworm\namazonlinux:2023\nasan',
             description: 'OS version for compilation',
             name: 'DOCKER_OS')
         choice(

--- a/pxb/v2/jenkins/percona-xtrabackup-8.1-compile-pipeline.yml
+++ b/pxb/v2/jenkins/percona-xtrabackup-8.1-compile-pipeline.yml
@@ -32,6 +32,7 @@
         - ubuntu:noble
         - debian:bullseye
         - debian:bookworm
+        - amazonlinux:2023
         - asan
         description: OS version for compilation
     - choice:

--- a/pxb/v2/jenkins/percona-xtrabackup-8.1-test-cloud-pipeline.groovy
+++ b/pxb/v2/jenkins/percona-xtrabackup-8.1-test-cloud-pipeline.groovy
@@ -1,7 +1,7 @@
 pipeline {
     parameters {
         choice(
-            choices: 'centos:8\noraclelinux:9\nubuntu:focal\nubuntu:jammy\nubuntu:noble\ndebian:bullseye\ndebian:bookworm\nasan',
+            choices: 'centos:8\noraclelinux:9\nubuntu:focal\nubuntu:jammy\nubuntu:noble\ndebian:bullseye\ndebian:bookworm\namazonlinux:2023\nasan',
             description: 'OS version for compilation',
             name: 'DOCKER_OS')
         choice(

--- a/pxb/v2/jenkins/percona-xtrabackup-8.1-test-cloud-pipeline.yml
+++ b/pxb/v2/jenkins/percona-xtrabackup-8.1-test-cloud-pipeline.yml
@@ -22,6 +22,7 @@
           - oraclelinux:9
           - ubuntu:jammy
           - debian:bullseye
+          - amazonlinux:2023
           - asan
         description: OS version for compilation
     - choice:

--- a/pxb/v2/jenkins/percona-xtrabackup-8.1-test-param.yml
+++ b/pxb/v2/jenkins/percona-xtrabackup-8.1-test-param.yml
@@ -79,6 +79,7 @@
         - ubuntu:noble
         - debian:bullseye
         - debian:bookworm
+        - amazonlinux:2023
         - asan
     - axis:
         name: XTRABACKUP_TARGET

--- a/pxb/v2/jenkins/percona-xtrabackup-8.1-test-pipeline.groovy
+++ b/pxb/v2/jenkins/percona-xtrabackup-8.1-test-pipeline.groovy
@@ -10,7 +10,7 @@ if (params.CLOUD == 'AWS') {
 pipeline {
     parameters {
         choice(
-            choices: 'centos:8\noraclelinux:9\nubuntu:focal\nubuntu:jammy\nubuntu:noble\ndebian:bullseye\ndebian:bookworm\nasan',
+            choices: 'centos:8\noraclelinux:9\nubuntu:focal\nubuntu:jammy\nubuntu:noble\ndebian:bullseye\ndebian:bookworm\namazonlinux:2023\nasan',
             description: 'OS version for compilation',
             name: 'DOCKER_OS')
         choice(

--- a/pxb/v2/jenkins/percona-xtrabackup-8.1-test-pipeline.yml
+++ b/pxb/v2/jenkins/percona-xtrabackup-8.1-test-pipeline.yml
@@ -24,6 +24,7 @@
           - ubuntu:noble
           - debian:bullseye
           - debian:bookworm
+          - amazonlinux:2023
           - asan
         description: OS version for compilation
     - choice:

--- a/pxb/v2/jenkins/percona-xtrabackup-9.x-compile-param.yml
+++ b/pxb/v2/jenkins/percona-xtrabackup-9.x-compile-param.yml
@@ -57,6 +57,7 @@
          - ubuntu:noble
          - debian:bookworm
          - debian:trixie
+         - amazonlinux:2023
          - asan
     builders:
     - trigger-builds:

--- a/pxb/v2/jenkins/percona-xtrabackup-9.x-compile-pipeline.groovy
+++ b/pxb/v2/jenkins/percona-xtrabackup-9.x-compile-pipeline.groovy
@@ -20,7 +20,7 @@ pipeline {
             name: 'BRANCH',
             trim: true)
         choice(
-            choices: 'oraclelinux:9\nubuntu:jammy\nubuntu:noble\ndebian:bookworm\ndebian:trixie\nasan',
+            choices: 'oraclelinux:9\nubuntu:jammy\nubuntu:noble\ndebian:bookworm\ndebian:trixie\namazonlinux:2023\nasan',
             description: 'OS version for compilation',
             name: 'DOCKER_OS')
         choice(

--- a/pxb/v2/jenkins/percona-xtrabackup-9.x-compile-pipeline.yml
+++ b/pxb/v2/jenkins/percona-xtrabackup-9.x-compile-pipeline.yml
@@ -30,6 +30,7 @@
         - ubuntu:noble
         - debian:bookworm
         - debian:trixie
+        - amazonlinux:2023
         - asan
         description: OS version for compilation
     - choice:

--- a/pxb/v2/jenkins/percona-xtrabackup-9.x-single-platform.groovy
+++ b/pxb/v2/jenkins/percona-xtrabackup-9.x-single-platform.groovy
@@ -20,7 +20,7 @@ pipeline {
             name: 'BRANCH',
             trim: true)
         choice(
-            choices: 'oraclelinux:9\nubuntu:jammy\nubuntu:noble\ndebian:bookworm\ndebian:trixie',
+            choices: 'oraclelinux:9\nubuntu:jammy\nubuntu:noble\ndebian:bookworm\ndebian:trixie\namazonlinux:2023',
             description: 'OS version for compilation and testing',
             name: 'DOCKER_OS')
         choice(

--- a/pxb/v2/jenkins/percona-xtrabackup-9.x-single-platform.yml
+++ b/pxb/v2/jenkins/percona-xtrabackup-9.x-single-platform.yml
@@ -31,6 +31,7 @@
         - ubuntu:noble
         - debian:bookworm
         - debian:trixie
+        - amazonlinux:2023
         description: OS version for compilation and testing
     - choice:
         name: XTRABACKUP_TARGET

--- a/pxb/v2/jenkins/percona-xtrabackup-9.x-test-param.yml
+++ b/pxb/v2/jenkins/percona-xtrabackup-9.x-test-param.yml
@@ -77,6 +77,7 @@
         - ubuntu:noble
         - debian:bookworm
         - debian:trixie
+        - amazonlinux:2023
         - asan
     - axis:
         name: XTRABACKUP_TARGET

--- a/pxb/v2/jenkins/percona-xtrabackup-9.x-test-pipeline.groovy
+++ b/pxb/v2/jenkins/percona-xtrabackup-9.x-test-pipeline.groovy
@@ -10,7 +10,7 @@ if (params.CLOUD == 'AWS') {
 pipeline {
     parameters {
         choice(
-            choices: 'oraclelinux:9\nubuntu:jammy\nubuntu:noble\ndebian:bookworm\ndebian:trixie\nasan',
+            choices: 'oraclelinux:9\nubuntu:jammy\nubuntu:noble\ndebian:bookworm\ndebian:trixie\namazonlinux:2023\nasan',
             description: 'OS version for compilation',
             name: 'DOCKER_OS')
         choice(

--- a/pxb/v2/jenkins/percona-xtrabackup-9.x-test-pipeline.yml
+++ b/pxb/v2/jenkins/percona-xtrabackup-9.x-test-pipeline.yml
@@ -22,6 +22,7 @@
           - ubuntu:noble
           - debian:bookworm
           - debian:trixie
+          - amazonlinux:2023
           - asan
         description: OS version for compilation
     - choice:


### PR DESCRIPTION
## Change

Add `amazonlinux:2023` to every pxb v2 `DOCKER_OS` choice list (8.0 + 8.1 + 9.x; compile + test paths) so the new pxc-build image is selectable in the existing dropdowns. 24 files, same one-line addition. Skip 2.4 (EOL distros). Also fix pre-existing `debain:bookworm` typo in `percona-xtrabackup-8.0-test-cloud-pipeline.yml`.

## Tickets

- [PXB-3745](https://perconadev.atlassian.net/browse/PXB-3745) (this), blocks [PXB-3613](https://perconadev.atlassian.net/browse/PXB-3613)
- Related: [PR 4093](https://github.com/Percona-Lab/jenkins-pipelines/pull/4093), [PR 4094](https://github.com/Percona-Lab/jenkins-pipelines/pull/4094), [PR 4095](https://github.com/Percona-Lab/jenkins-pipelines/pull/4095), [PR 4102](https://github.com/Percona-Lab/jenkins-pipelines/pull/4102), [PR 4105](https://github.com/Percona-Lab/jenkins-pipelines/pull/4105)


[PXB-3745]: https://perconadev.atlassian.net/browse/PXB-3745?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[PXB-3613]: https://perconadev.atlassian.net/browse/PXB-3613?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ