### PR TITLE
fix(ps): build PS 8.0/9.0 source tarball in Docker instead of native Focal node

### DIFF
--- a/ps/jenkins/percona-server-for-mysql-8.0.groovy
+++ b/ps/jenkins/percona-server-for-mysql-8.0.groovy
@@ -416,7 +416,7 @@ parameters {
     stages {
         stage('Create PS source tarball') {
             agent {
-               label params.CLOUD == 'Hetzner' ? 'deb12-x64' : 'min-focal-x64'
+                label params.CLOUD == 'Hetzner' ? 'docker-x64' : 'docker-32gb'
             }
             steps {
                 slackNotify("${SLACKNOTIFY}", "#00FF00", "[${JOB_NAME}]: starting build for ${BRANCH} - [${BUILD_URL}]")
@@ -424,9 +424,9 @@ parameters {
                 installCli("deb")
                 script {
                             if (env.FIPSMODE == 'YES') {
-                                buildStage("none", "--get_sources=1 --enable_fipsmode=1")
+                                buildStage("ubuntu:focal", "--get_sources=1 --enable_fipsmode=1")
                             } else {
-                                buildStage("none", "--get_sources=1")
+                                buildStage("ubuntu:focal", "--get_sources=1")
                             }
                        }
                 sh '''

--- a/ps/jenkins/percona-server-for-mysql-9.0.groovy
+++ b/ps/jenkins/percona-server-for-mysql-9.0.groovy
@@ -227,13 +227,13 @@ parameters {
 
         stage('Create PS source tarball') {
             agent {
-               label params.CLOUD == 'Hetzner' ? 'deb12-x64' : 'min-focal-x64'
+                label params.CLOUD == 'Hetzner' ? 'docker-x64' : 'docker-32gb'
             }
             steps {
                 slackNotify("${SLACKNOTIFY}", "#00FF00", "[${JOB_NAME}]: starting build for ${BRANCH} - [${BUILD_URL}]")
                 cleanUpWS()
                 installCli("deb")
-                buildStage("none", "--get_sources=1")
+                buildStage("ubuntu:jammy", "--get_sources=1")
                 sh '''
                    REPO_UPLOAD_PATH=$(grep "UPLOAD" test/percona-server-9.0.properties | cut -d = -f 2 | sed "s:$:${BUILD_NUMBER}:")
                    AWS_STASH_PATH=$(echo ${REPO_UPLOAD_PATH} | sed  "s:UPLOAD/experimental/::")


### PR DESCRIPTION
## Problem

The `Create PS source tarball` stage in both `hetzner-ps8.0-autobuild-RELEASE` and `hetzner-ps9.0-RELEASE` ran `buildStage("none", ...)` — i.e. **natively on the agent host OS** (Hetzner: `deb12-x64` / AWS: `min-focal-x64`).

With `CLOUD=AWS` this builds sources natively on the AWS spot host (Ubuntu Focal 20.04), so the build environment depends on the host rather than a pinned image. For PS 9.x the Focal toolchain/deps do not reliably satisfy the build, so `CLOUD=AWS` runs fail at the very first stage while Hetzner (Debian 12) succeeds. PS 8.0 carries the same host-OS coupling.

## Fix

Move both stages onto a generic Docker build node (`docker-x64` / `docker-32gb`) and run `get_sources` inside a pinned container, mirroring each pipeline's own `Build PS generic source deb` stage:

- **ps9.0:** `buildStage("ubuntu:jammy", "--get_sources=1")`
- **ps8.0:** `buildStage("ubuntu:focal", ...)` — FIPS and non-FIPS branches

The source-build OS is now identical on AWS and Hetzner; `CLOUD` only selects the node pool, not the build environment. All other steps (`slackNotify`, `cleanUpWS`, `installCli("deb")`, stash, `pushArtifactFolder`, `uploadTarballfromAWS`) are unchanged. `buildStage` mounts the workspace into the container so the generated `test/percona-server-*.properties` still reaches the host for the subsequent stash/upload steps.
