### PR TITLE
fix(ps): AWS hotfix — installCli("rpm") on RPM-based docker build nodes

### DIFF
--- a/ps/jenkins/percona-server-for-mysql-8.0.groovy
+++ b/ps/jenkins/percona-server-for-mysql-8.0.groovy
@@ -421,7 +421,7 @@ parameters {
             steps {
                 slackNotify("${SLACKNOTIFY}", "#00FF00", "[${JOB_NAME}]: starting build for ${BRANCH} - [${BUILD_URL}]")
                 cleanUpWS()
-                installCli("deb")
+                installCli("rpm")
                 script {
                             if (env.FIPSMODE == 'YES') {
                                 buildStage("ubuntu:focal", "--get_sources=1 --enable_fipsmode=1")

--- a/ps/jenkins/percona-server-for-mysql-9.0.groovy
+++ b/ps/jenkins/percona-server-for-mysql-9.0.groovy
@@ -232,7 +232,7 @@ parameters {
             steps {
                 slackNotify("${SLACKNOTIFY}", "#00FF00", "[${JOB_NAME}]: starting build for ${BRANCH} - [${BUILD_URL}]")
                 cleanUpWS()
-                installCli("deb")
+                installCli("rpm")
                 buildStage("ubuntu:jammy", "--get_sources=1")
                 sh '''
                    REPO_UPLOAD_PATH=$(grep "UPLOAD" test/percona-server-9.0.properties | cut -d = -f 2 | sed "s:$:${BUILD_NUMBER}:")
@@ -280,7 +280,7 @@ parameters {
                     }
                     steps {
                         cleanUpWS()
-                        installCli("deb")
+                        installCli("rpm")
                         unstash 'properties'
                         popArtifactFolder(params.CLOUD, "source_tarball/", AWS_STASH_PATH)
                         script {
@@ -471,7 +471,7 @@ parameters {
                                 echo "The step is skipped"
                             } else {
                                 cleanUpWS()
-                                installCli("deb")
+                                installCli("rpm")
                                 unstash 'properties'
                                 popArtifactFolder(params.CLOUD, "source_deb/", AWS_STASH_PATH)
                                 buildStage("ubuntu:focal", "--build_deb=1 --with_zenfs=1")
@@ -489,7 +489,7 @@ parameters {
                     }
                     steps {
                         cleanUpWS()
-                        installCli("deb")
+                        installCli("rpm")
                         unstash 'properties'
                         popArtifactFolder(params.CLOUD, "source_deb/", AWS_STASH_PATH)
                         script {
@@ -510,7 +510,7 @@ parameters {
                     }
                     steps {
                         cleanUpWS()
-                        installCli("deb")
+                        installCli("rpm")
                         unstash 'properties'
                         popArtifactFolder(params.CLOUD, "source_deb/", AWS_STASH_PATH)
                         script {
@@ -534,7 +534,7 @@ parameters {
                                 echo "The step is skipped"
                             } else {
                                 cleanUpWS()
-                                installCli("deb")
+                                installCli("rpm")
                                 unstash 'properties'
                                 popArtifactFolder(params.CLOUD, "source_deb/", AWS_STASH_PATH)
                                 buildStage("debian:bullseye", "--build_deb=1 --with_zenfs=1")
@@ -552,7 +552,7 @@ parameters {
                     }
                     steps {
                         cleanUpWS()
-                        installCli("deb")
+                        installCli("rpm")
                         unstash 'properties'
                         popArtifactFolder(params.CLOUD, "source_deb/", AWS_STASH_PATH)
                         script {
@@ -573,7 +573,7 @@ parameters {
                     }
                     steps {
                         cleanUpWS()
-                        installCli("deb")
+                        installCli("rpm")
                         unstash 'properties'
                         popArtifactFolder(params.CLOUD, "source_deb/", AWS_STASH_PATH)
                         script {
@@ -835,7 +835,7 @@ parameters {
                                 echo "The step is skipped"
                             } else {
                                 cleanUpWS()
-                                installCli("deb")
+                                installCli("rpm")
                                 unstash 'properties'
                                 popArtifactFolder(params.CLOUD, "source_tarball/", AWS_STASH_PATH)
                                 buildStage("ubuntu:focal", "--build_tarball=1")
@@ -856,7 +856,7 @@ parameters {
                                 echo "The step is skipped"
                             } else {
                                 cleanUpWS()
-                                installCli("deb")
+                                installCli("rpm")
                                 unstash 'properties'
                                 popArtifactFolder(params.CLOUD, "source_tarball/", AWS_STASH_PATH)
                                 buildStage("ubuntu:focal", "--debug=1 --build_tarball=1")
@@ -874,7 +874,7 @@ parameters {
                     }
                     steps {
                         cleanUpWS()
-                        installCli("deb")
+                        installCli("rpm")
                         unstash 'properties'
                         popArtifactFolder(params.CLOUD, "source_tarball/", AWS_STASH_PATH)
                         script {
@@ -895,7 +895,7 @@ parameters {
                     }
                     steps {
                         cleanUpWS()
-                        installCli("deb")
+                        installCli("rpm")
                         unstash 'properties'
                         popArtifactFolder(params.CLOUD, "source_tarball/", AWS_STASH_PATH)
                         script {
@@ -916,7 +916,7 @@ parameters {
                     }
                     steps {
                         cleanUpWS()
-                        installCli("deb")
+                        installCli("rpm")
                         unstash 'properties'
                         popArtifactFolder(params.CLOUD, "source_tarball/", AWS_STASH_PATH)
                         script {
@@ -939,7 +939,7 @@ parameters {
             }
             steps {
                 cleanUpWS()
-                installCli("deb")
+                installCli("rpm")
                 unstash 'properties'
 
                 uploadRPMfromAWS(params.CLOUD, "rpm/", AWS_STASH_PATH)

--- a/vars/psBuildMatrix.groovy
+++ b/vars/psBuildMatrix.groovy
@@ -345,7 +345,7 @@ def call(Map args = [:]) {
 
                 node(agentLabel) {
                     cleanUpWS()
-                    installCli("deb")
+                    installCli("rpm")
                     unstash 'properties'
                     popArtifactFolder(cloud, sourceFolder, awsStashPath)
 


### PR DESCRIPTION
## Hotfix — follow-up to #4097 (already merged)

#4097 was squash-merged into `hetzner` carrying **only its first commit** (move source tarball into Docker). The follow-up `installCli` fixes pushed to that branch were **not** included in the squash, so `hetzner` is currently **broken on `CLOUD=AWS`**.

### Why it's broken now

#4097 moved the `Create PS source tarball` stage onto the `docker-x64`/`docker-32gb` node but kept `installCli("deb")`. `installCli()` bootstraps the build **host** (wget/curl/unzip + AWS CLI) and only runs when `CLOUD=AWS`. Those hosts are **RPM/yum-based**, so on AWS the stage fails immediately:

```
+ '[' deb = deb ']'
+ sudo apt-get update
sudo: apt-get: command not found
```

This is **systemic**, not limited to the source-tarball stage — every `installCli("deb")` in ps9.0 and the shared `psBuildMatrix` helper runs on these same RPM nodes, so the entire `CLOUD=AWS` path is dead. (`CLOUD=Hetzner` is unaffected: `installCli()` is a no-op when `CLOUD!=AWS`.)

### Fix

`installCli("deb")` → `installCli("rpm")` on all RPM-based build nodes:

- **ps9.0** — all 14 occurrences (source tarball, generic source deb, every x64 DEB build/tarball stage, S3 upload)
- **ps8.0** — source-tarball stage (its other 3 `installCli` calls were already `"rpm"`)
- **`vars/psBuildMatrix.groovy`** — unconditional per-stage `installCli("deb")`; consumed **only by ps8.0**, zero blast radius

Build OS is unchanged everywhere (still container-pinned via `buildStage(image, …)`); only the host CLI bootstrap is corrected.
