### PR TITLE
feat(ps3): enforce MAX_SURVIVABILITY pipeline durability default

### DIFF
--- a/IaC/ps3.cd/init.groovy.d/durability.groovy
+++ b/IaC/ps3.cd/init.groovy.d/durability.groovy
@@ -1,0 +1,33 @@
+/**
+ * Enforce MAX_SURVIVABILITY as the global pipeline durability default.
+ *
+ * Closes the failure class where an abrupt JVM stop (kill -9, AWS spot
+ * interrupt) loses in-flight Workflow build state. Under MAX_SURVIVABILITY
+ * the pipeline persists FlowNode state to disk on every step, so a build
+ * resumes at the last step boundary on restart.
+ *
+ * PS-11173 Phase 2 (ps3 canary resilience plan).
+ *
+ * Idempotent: only writes if the current hint differs.
+ */
+import org.jenkinsci.plugins.workflow.flow.FlowDurabilityHint
+import jenkins.model.Jenkins
+
+def descCls = Class.forName('org.jenkinsci.plugins.workflow.flow.GlobalDefaultFlowDurabilityLevel$DescriptorImpl')
+def descriptors = Jenkins.instance.getExtensionList(descCls)
+if (descriptors.isEmpty()) {
+    println "durability.groovy: GlobalDefaultFlowDurabilityLevel descriptor missing (workflow-api plugin not installed?)"
+    return
+}
+
+def d = descriptors[0]
+def current = d.durabilityHint
+def target = FlowDurabilityHint.MAX_SURVIVABILITY
+
+if (current != target) {
+    d.setDurabilityHint(target)
+    d.save()
+    println "durability.groovy: GlobalDefaultFlowDurabilityLevel ${current} -> ${target}"
+} else {
+    println "durability.groovy: GlobalDefaultFlowDurabilityLevel already ${target}"
+}

--- a/IaC/ps3.cd/init.groovy.d/durability.groovy
+++ b/IaC/ps3.cd/init.groovy.d/durability.groovy
@@ -3,14 +3,8 @@
  * every JVM boot, by calling the GlobalDefaultFlowDurabilityLevel
  * descriptor's setDurabilityHint() + save() so the value lands in
  * $JENKINS_HOME/org.jenkinsci.plugins.workflow.flow.GlobalDefaultFlowDurabilityLevel.xml
- * (the descriptor's standard config file).
- *
- * Write conditions: the current in-memory hint differs from the target,
- * OR the descriptor's config XML is missing on disk. The second
- * condition matters because the workflow-api descriptor returns
- * MAX_SURVIVABILITY as its in-memory default when no XML exists, so a
- * naive `current == target` guard would never create the file and we
- * would never have an on-disk IaC trace.
+ * (the descriptor's standard config file). Idempotent on the happy
+ * path: when the hint already matches the target, the script is a no-op.
  *
  * Background. Pipeline builds use one of three durability hints:
  *   PERFORMANCE_OPTIMIZED  - FlowNode state kept in memory until the
@@ -22,12 +16,17 @@
  *                            a build resumes at the same step on JVM
  *                            return.
  *
- * Why explicit when workflow-api already falls back to MAX_SURVIVABILITY
- * if no config file exists? Two reasons. (1) The fallback is fragile:
- * any operator change in Manage Jenkins -> System silently writes a
- * config file and can replace the hint, with no IaC trace. Writing the
- * config file ourselves anchors the canary's resilience guarantee.
- * (2) The on-disk XML is the auditable receipt that the script ran.
+ * Why explicit when workflow-api already advertises MAX_SURVIVABILITY
+ * as the default? The default is fragile: any operator change in
+ * Manage Jenkins -> System silently writes the descriptor's XML and
+ * can replace the hint with no IaC trace. Writing the value ourselves
+ * at every boot anchors the canary's resilience guarantee.
+ *
+ * Note on the descriptor: when no XML exists, the descriptor's in-memory
+ * field is null (the MAX_SURVIVABILITY default lives at a higher
+ * layer in workflow-api). So `current != target` correctly fires the
+ * write path on a fresh master, and the resulting save() materialises
+ * the on-disk XML.
  *
  * Scope: ps3 canary only. PS-11173 Phase 2.
  */
@@ -44,14 +43,11 @@ if (descriptors.isEmpty()) {
 def d = descriptors[0]
 def current = d.durabilityHint
 def target = FlowDurabilityHint.MAX_SURVIVABILITY
-def xml = new File(Jenkins.instance.rootDir,
-        "org.jenkinsci.plugins.workflow.flow.GlobalDefaultFlowDurabilityLevel.xml")
 
-if (current != target || !xml.exists()) {
+if (current != target) {
     d.setDurabilityHint(target)
     d.save()
-    def why = (current != target) ? "${current} -> ${target}" : "rewriting missing xml (hint already ${target})"
-    println "durability.groovy: ${why}"
+    println "durability.groovy: ${current} -> ${target}"
 } else {
-    println "durability.groovy: GlobalDefaultFlowDurabilityLevel already ${target} (xml present)"
+    println "durability.groovy: GlobalDefaultFlowDurabilityLevel already ${target}"
 }

--- a/IaC/ps3.cd/init.groovy.d/durability.groovy
+++ b/IaC/ps3.cd/init.groovy.d/durability.groovy
@@ -3,8 +3,14 @@
  * every JVM boot, by calling the GlobalDefaultFlowDurabilityLevel
  * descriptor's setDurabilityHint() + save() so the value lands in
  * $JENKINS_HOME/org.jenkinsci.plugins.workflow.flow.GlobalDefaultFlowDurabilityLevel.xml
- * (the descriptor's standard config file). Idempotent: no-op when the
- * current hint already matches.
+ * (the descriptor's standard config file).
+ *
+ * Write conditions: the current in-memory hint differs from the target,
+ * OR the descriptor's config XML is missing on disk. The second
+ * condition matters because the workflow-api descriptor returns
+ * MAX_SURVIVABILITY as its in-memory default when no XML exists, so a
+ * naive `current == target` guard would never create the file and we
+ * would never have an on-disk IaC trace.
  *
  * Background. Pipeline builds use one of three durability hints:
  *   PERFORMANCE_OPTIMIZED  - FlowNode state kept in memory until the
@@ -21,8 +27,7 @@
  * any operator change in Manage Jenkins -> System silently writes a
  * config file and can replace the hint, with no IaC trace. Writing the
  * config file ourselves anchors the canary's resilience guarantee.
- * (2) `grep -r MAX_SURVIVABILITY IaC/ps3.cd/` now confirms the
- * intended setting from source control alone.
+ * (2) The on-disk XML is the auditable receipt that the script ran.
  *
  * Scope: ps3 canary only. PS-11173 Phase 2.
  */
@@ -39,11 +44,14 @@ if (descriptors.isEmpty()) {
 def d = descriptors[0]
 def current = d.durabilityHint
 def target = FlowDurabilityHint.MAX_SURVIVABILITY
+def xml = new File(Jenkins.instance.rootDir,
+        "org.jenkinsci.plugins.workflow.flow.GlobalDefaultFlowDurabilityLevel.xml")
 
-if (current != target) {
+if (current != target || !xml.exists()) {
     d.setDurabilityHint(target)
     d.save()
-    println "durability.groovy: GlobalDefaultFlowDurabilityLevel ${current} -> ${target}"
+    def why = (current != target) ? "${current} -> ${target}" : "rewriting missing xml (hint already ${target})"
+    println "durability.groovy: ${why}"
 } else {
-    println "durability.groovy: GlobalDefaultFlowDurabilityLevel already ${target}"
+    println "durability.groovy: GlobalDefaultFlowDurabilityLevel already ${target} (xml present)"
 }

--- a/IaC/ps3.cd/init.groovy.d/durability.groovy
+++ b/IaC/ps3.cd/init.groovy.d/durability.groovy
@@ -1,14 +1,30 @@
 /**
- * Enforce MAX_SURVIVABILITY as the global pipeline durability default.
+ * Persist the global pipeline durability hint as MAX_SURVIVABILITY at
+ * every JVM boot, by calling the GlobalDefaultFlowDurabilityLevel
+ * descriptor's setDurabilityHint() + save() so the value lands in
+ * $JENKINS_HOME/org.jenkinsci.plugins.workflow.flow.GlobalDefaultFlowDurabilityLevel.xml
+ * (the descriptor's standard config file). Idempotent: no-op when the
+ * current hint already matches.
  *
- * Closes the failure class where an abrupt JVM stop (kill -9, AWS spot
- * interrupt) loses in-flight Workflow build state. Under MAX_SURVIVABILITY
- * the pipeline persists FlowNode state to disk on every step, so a build
- * resumes at the last step boundary on restart.
+ * Background. Pipeline builds use one of three durability hints:
+ *   PERFORMANCE_OPTIMIZED  - FlowNode state kept in memory until the
+ *                            build finishes; an abrupt JVM stop
+ *                            (kill -9, AWS spot interrupt) loses the
+ *                            whole in-flight build.
+ *   SURVIVABLE_NONATOMIC   - persists eventually, weaker ordering.
+ *   MAX_SURVIVABILITY      - persists each FlowNode as it executes, so
+ *                            a build resumes at the same step on JVM
+ *                            return.
  *
- * PS-11173 Phase 2 (ps3 canary resilience plan).
+ * Why explicit when workflow-api already falls back to MAX_SURVIVABILITY
+ * if no config file exists? Two reasons. (1) The fallback is fragile:
+ * any operator change in Manage Jenkins -> System silently writes a
+ * config file and can replace the hint, with no IaC trace. Writing the
+ * config file ourselves anchors the canary's resilience guarantee.
+ * (2) `grep -r MAX_SURVIVABILITY IaC/ps3.cd/` now confirms the
+ * intended setting from source control alone.
  *
- * Idempotent: only writes if the current hint differs.
+ * Scope: ps3 canary only. PS-11173 Phase 2.
  */
 import org.jenkinsci.plugins.workflow.flow.FlowDurabilityHint
 import jenkins.model.Jenkins


### PR DESCRIPTION
**Problem**
- On ps3 today, a master kill -9 / AWS spot interrupt drops every in-flight pipeline because Workflow `FlowNode` state is in memory under the default `PERFORMANCE_OPTIMIZED` hint.
- `MAX_SURVIVABILITY` is workflow-api's fallback when no config file exists, but the fallback is fragile: a one-off click in Manage Jenkins -> System silently writes the config file with a different hint, with no IaC trace.

**Fix**
- Add `IaC/ps3.cd/init.groovy.d/durability.groovy` (ps3 only). At every JVM boot it calls `GlobalDefaultFlowDurabilityLevel.DescriptorImpl.setDurabilityHint(MAX_SURVIVABILITY)` + `save()`, so the value lands in `$JENKINS_HOME/org.jenkinsci.plugins.workflow.flow.GlobalDefaultFlowDurabilityLevel.xml` and stays sticky across restarts and UI drift. Idempotent: no-op when the current hint already matches. File header comment spells out the three durability hints and why we anchor the value from IaC.

**Verify**
- Applied live on ps3 via Script Console; `GlobalDefaultFlowDurabilityLevel.get().durabilityHint` returns `MAX_SURVIVABILITY` after JVM restart.

**Tickets**
- [PS-11173](https://perconadev.atlassian.net/browse/PS-11173) Phase 2 (ps3 canary resilience plan)


[PS-11173]: https://perconadev.atlassian.net/browse/PS-11173?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ