### PR TITLE
PXB-3745: add ARCH arg to pxb v2 run-build + run-test

### DIFF
--- a/pxb/v2/docker/run-build
+++ b/pxb/v2/docker/run-build
@@ -6,6 +6,13 @@ set -o xtrace
 ROOT_DIR=$(cd $(dirname $0)/../sources; pwd -P)
 SCRIPTS_DIR=$(cd $(dirname $0)/../local; pwd -P)
 SOURCE_IMAGE=${1:-oraclelinux:9}
+ARCH=${2:-${ARCH:-x86_64}}
+
+case "${ARCH}" in
+    x86_64)  ARCH_SUFFIX="" ;;
+    aarch64) ARCH_SUFFIX="-aarch64" ;;
+    *) echo "Unsupported ARCH=${ARCH}" >&2; exit 1 ;;
+esac
 
 if [[ ${SOURCE_IMAGE} == 'asan' ]]; then
     SOURCE_IMAGE='oraclelinux:9'
@@ -16,7 +23,7 @@ docker run --rm \
     --cap-add SYS_PTRACE \
     --mount type=bind,source=${ROOT_DIR},destination=/tmp/pxb \
     --mount type=bind,source=${SCRIPTS_DIR},destination=/tmp/scripts \
-    public.ecr.aws/e7j3v3n0/pxc-build:${SOURCE_IMAGE//[:\/]/-} \
+    public.ecr.aws/e7j3v3n0/pxc-build:${SOURCE_IMAGE//[:\/]/-}${ARCH_SUFFIX} \
     sh -c "
     set -o errexit
     set -o xtrace

--- a/pxb/v2/docker/run-test
+++ b/pxb/v2/docker/run-test
@@ -10,6 +10,13 @@ function cleanup (){
 ROOT_DIR=$(cd $(dirname $0)/../sources; pwd -P)
 SCRIPTS_DIR=$(cd $(dirname $0)/../local; pwd -P)
 SOURCE_IMAGE=${1:-oraclelinux:9}
+ARCH=${2:-${ARCH:-x86_64}}
+
+case "${ARCH}" in
+    x86_64)  ARCH_SUFFIX="" ;;
+    aarch64) ARCH_SUFFIX="-aarch64" ;;
+    *) echo "Unsupported ARCH=${ARCH}" >&2; exit 1 ;;
+esac
 
 if [[ ${SOURCE_IMAGE} == 'asan' ]]; then
     SOURCE_IMAGE='oraclelinux:9'
@@ -73,7 +80,7 @@ docker run --rm \
     --mount type=bind,source=${ROOT_DIR},destination=/tmp/pxb \
     --mount type=bind,source=${SCRIPTS_DIR},destination=/tmp/scripts \
     ${DOCKER_NETWORK_FLAG} \
-    public.ecr.aws/e7j3v3n0/pxc-build:${SOURCE_IMAGE//[:\/]/-} \
+    public.ecr.aws/e7j3v3n0/pxc-build:${SOURCE_IMAGE//[:\/]/-}${ARCH_SUFFIX} \
     sh -c "
     set -o errexit
     set -o xtrace


### PR DESCRIPTION
## Bug

`pxb/v2/docker/run-build` and `run-test` hard-code the `pxc-build` image tag with no arch suffix, so ARM compile + test pipelines cannot pull the aarch64 images that [PR 4093](https://github.com/Percona-Lab/jenkins-pipelines/pull/4093) publishes.

## Fix

Accept an optional second positional `ARCH` arg (or `ARCH` env var); append `-aarch64` to the pulled tag when `ARCH=aarch64`. Backward-compatible: existing one-arg callers (8.0 / 8.1 / 9.x / 2.4 compile + test + cloud variants) stay on `x86_64` unchanged.

## Tickets

- [PXB-3745](https://perconadev.atlassian.net/browse/PXB-3745) (origin: pxc-build aarch64 tags)
- [PXB-3613](https://perconadev.atlassian.net/browse/PXB-3613) (consumer: ARM compile + test wiring)
- Related: [PR 4093](https://github.com/Percona-Lab/jenkins-pipelines/pull/4093), [PR 4094](https://github.com/Percona-Lab/jenkins-pipelines/pull/4094), [PR 4095](https://github.com/Percona-Lab/jenkins-pipelines/pull/4095), [PR 4096](https://github.com/Percona-Lab/jenkins-pipelines/pull/4096), [PR 4105](https://github.com/Percona-Lab/jenkins-pipelines/pull/4105)


[PXB-3745]: https://perconadev.atlassian.net/browse/PXB-3745?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[PXB-3613]: https://perconadev.atlassian.net/browse/PXB-3613?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ