### PR TITLE
PS-10640: add PS pillar image certification smoke pipeline

### DIFF
--- a/cloud/jenkins/ps_image_certification.groovy
+++ b/cloud/jenkins/ps_image_certification.groovy
@@ -1,0 +1,140 @@
+// =============================================================================
+// PS Pillar Image Certification (SMOKE TEST - PS-10640)
+// =============================================================================
+// This pipeline is a stripped-down variant of pso_image_certification.groovy
+// for certifying the standalone Percona Server 8.0 pillar image (no operator,
+// no release_versions plumbing, no operator git checkout).
+//
+// STATUS: SMOKE TEST ONLY. NOT FOR PRODUCTION USE.
+//
+// Before any non-DRY_RUN execution against a real Red Hat ISV project:
+//   - Replace PYXIS_PROJECT_ID default with the actual PS pillar PID
+//   - Replace REGISTRY_CREDS_ID default with the matching Jenkins credential
+//     (the per-PID quay.io robot account from Red Hat Connect)
+//
+// Tracking: https://perconadev.atlassian.net/browse/PS-10640
+// =============================================================================
+
+def certificationTests = []
+def certification
+
+pipeline {
+    agent {
+        label 'docker-x64-min'
+    }
+
+    parameters {
+        string(
+            name: 'IMAGE',
+            defaultValue: 'percona/percona-server:8.0.45-36',
+            description: 'Source image to certify (Docker Hub coordinates)'
+        )
+        string(
+            name: 'IMAGE_TAG',
+            defaultValue: '8.0.45-36',
+            description: 'Tag to publish under in the Red Hat ISV registry'
+        )
+
+        choice(
+            name: 'PLATFORM',
+            choices: ['multiplatform', 'amd64', 'arm64'],
+            description: 'Target platform'
+        )
+
+        string(
+            name: 'PYXIS_PROJECT_ID',
+            defaultValue: 'REPLACE_WITH_NEW_PS_PILLAR_PID',
+            description: 'Pyxis project ID for the PS pillar image (placeholder until provisioned)'
+        )
+        string(
+            name: 'REGISTRY_CREDS_ID',
+            defaultValue: 'PS_CONTAINERS_REGISTRY',
+            description: 'Jenkins credential ID for the per-PID quay.io robot account (placeholder)'
+        )
+
+        booleanParam(
+            name: 'DRY_RUN',
+            defaultValue: true,
+            description: 'Skip --submit so this run does not dirty the Pyxis project (smoke-test safe)'
+        )
+    }
+
+    stages {
+        stage('Certify Image') {
+            steps {
+                script {
+                    certification = load "cloud/common/imageCertification.groovy"
+
+                    currentBuild.displayName = "${params.IMAGE_TAG} (${params.PLATFORM})"
+
+                    echo "Image: ${params.IMAGE}"
+                    echo "Tag: ${params.IMAGE_TAG}"
+                    echo "Platform: ${params.PLATFORM}"
+                    echo "Pyxis project ID: ${params.PYXIS_PROJECT_ID}"
+                    echo "DRY_RUN: ${params.DRY_RUN}"
+
+                    if (params.PYXIS_PROJECT_ID == 'REPLACE_WITH_NEW_PS_PILLAR_PID' && !params.DRY_RUN) {
+                        error("PYXIS_PROJECT_ID is still the placeholder. Set a real PID or run with DRY_RUN=true.")
+                    }
+
+                    def target = [
+                        src: params.IMAGE,
+                        dest: "quay.io/redhat-isv-containers/${params.PYXIS_PROJECT_ID}:${params.IMAGE_TAG}",
+                        credentials: params.REGISTRY_CREDS_ID
+                    ]
+
+                    def startedAt = System.currentTimeMillis()
+                    def status
+
+                    withCredentials([
+                        string(credentialsId: 'PYXIS_TOKEN', variable: 'PYXIS_TOKEN'),
+                        usernamePassword(
+                            credentialsId: target.credentials,
+                            usernameVariable: 'REGISTRY_USER',
+                            passwordVariable: 'REGISTRY_KEY'
+                        )
+                    ]) {
+                        def component = env.REGISTRY_USER.replaceAll(/^.*\+/, '').replaceAll(/-robot$/, '')
+                        def noSubmitFlag = params.DRY_RUN ? '--no-submit' : ''
+
+                        status = sh(
+                            returnStatus: true,
+                            script: """
+                            set -e
+                            python3 cloud/scripts/certify_images.py \
+                              --image ${target.src} \
+                              --dest_image ${target.dest} \
+                              --component ${component} \
+                              --platform ${params.PLATFORM} \
+                              ${noSubmitFlag}
+                        """
+                        )
+                    }
+
+                    certificationTests.add([
+                        name: 'IMAGE_PS',
+                        cluster: params.PLATFORM,
+                        result: status == 0 ? 'passed' : 'failure',
+                        time: (System.currentTimeMillis() - startedAt) / 1000,
+                    ])
+
+                    if (status != 0) {
+                        currentBuild.result = 'UNSTABLE'
+                        echo "Certification failed for PS pillar image: ${params.IMAGE}"
+                    }
+                }
+            }
+        }
+    }
+
+    post {
+        always {
+            script {
+                certification = certification ?: load("cloud/common/imageCertification.groovy")
+
+                certification.publishResults()
+                certification.sendSlack(certificationTests, '-', params.PLATFORM, params.IMAGE_TAG)
+            }
+        }
+    }
+}

--- a/cloud/jenkins/ps_image_certification.groovy
+++ b/cloud/jenkins/ps_image_certification.groovy
@@ -2,21 +2,28 @@
 // PS Pillar Image Certification (SMOKE TEST - PS-10640)
 // =============================================================================
 // This pipeline is a stripped-down variant of pso_image_certification.groovy
-// for certifying the standalone Percona Server 8.0 pillar image (no operator,
+// for certifying the standalone Percona Server pillar image (no operator,
 // no release_versions plumbing, no operator git checkout).
 //
 // STATUS: SMOKE TEST ONLY. NOT FOR PRODUCTION USE.
 //
-// Before any non-DRY_RUN execution against a real Red Hat ISV project:
-//   - Replace PYXIS_PROJECT_ID default with the actual PS pillar PID
-//   - Replace REGISTRY_CREDS_ID default with the matching Jenkins credential
-//     (the per-PID quay.io robot account from Red Hat Connect)
+// DRY_RUN=true (default): runs preflight against the SOURCE image only.
+//   No registry login, no image push to quay.io, no Pyxis API contact,
+//   no credentials required. Safe to run without any RHPC setup.
+//
+// DRY_RUN=false: full cert path. Requires:
+//   - PYXIS_PROJECT_ID set to a real Pyxis certification project id
+//   - REGISTRY_CREDS_ID set to a Jenkins credential containing the per-PID
+//     quay.io robot account from Red Hat Connect
+//   - PYXIS_TOKEN credential present on the Jenkins instance
 //
 // Tracking: https://perconadev.atlassian.net/browse/PS-10640
 // =============================================================================
 
 def certificationTests = []
 def certification
+def PLACEHOLDER_PID = 'REPLACE_WITH_NEW_PS_PILLAR_PID'
+def PLACEHOLDER_CREDS = 'REPLACE_WITH_REAL_REGISTRY_CREDS_ID'
 
 pipeline {
     agent {
@@ -32,7 +39,7 @@ pipeline {
         string(
             name: 'IMAGE_TAG',
             defaultValue: '8.0.45-36',
-            description: 'Tag to publish under in the Red Hat ISV registry'
+            description: 'Tag to publish under in the Red Hat ISV registry (used only when DRY_RUN=false)'
         )
 
         choice(
@@ -44,18 +51,18 @@ pipeline {
         string(
             name: 'PYXIS_PROJECT_ID',
             defaultValue: 'REPLACE_WITH_NEW_PS_PILLAR_PID',
-            description: 'Pyxis project ID for the PS pillar image (placeholder until provisioned)'
+            description: 'Pyxis project ID for the PS pillar image. Required when DRY_RUN=false.'
         )
         string(
             name: 'REGISTRY_CREDS_ID',
-            defaultValue: 'PS_CONTAINERS_REGISTRY',
-            description: 'Jenkins credential ID for the per-PID quay.io robot account (placeholder)'
+            defaultValue: 'REPLACE_WITH_REAL_REGISTRY_CREDS_ID',
+            description: 'Jenkins credential ID for the per-PID quay.io robot account. Required when DRY_RUN=false.'
         )
 
         booleanParam(
             name: 'DRY_RUN',
             defaultValue: true,
-            description: 'Skip --submit so this run does not dirty the Pyxis project (smoke-test safe)'
+            description: 'When true: run preflight against the source image only, no registry push, no Pyxis submit, no credentials required. When false: full cert path.'
         )
     }
 
@@ -65,50 +72,65 @@ pipeline {
                 script {
                     certification = load "cloud/common/imageCertification.groovy"
 
-                    currentBuild.displayName = "${params.IMAGE_TAG} (${params.PLATFORM})"
+                    currentBuild.displayName = "${params.IMAGE_TAG} (${params.PLATFORM})${params.DRY_RUN ? ' DRY' : ''}"
+
+                    def pid = (params.PYXIS_PROJECT_ID ?: '').trim()
+                    def credsId = (params.REGISTRY_CREDS_ID ?: '').trim()
 
                     echo "Image: ${params.IMAGE}"
-                    echo "Tag: ${params.IMAGE_TAG}"
                     echo "Platform: ${params.PLATFORM}"
-                    echo "Pyxis project ID: ${params.PYXIS_PROJECT_ID}"
                     echo "DRY_RUN: ${params.DRY_RUN}"
 
-                    if (params.PYXIS_PROJECT_ID == 'REPLACE_WITH_NEW_PS_PILLAR_PID' && !params.DRY_RUN) {
-                        error("PYXIS_PROJECT_ID is still the placeholder. Set a real PID or run with DRY_RUN=true.")
+                    if (!params.DRY_RUN) {
+                        if (!pid || pid == 'REPLACE_WITH_NEW_PS_PILLAR_PID') {
+                            error("PYXIS_PROJECT_ID must be set to a real PID when DRY_RUN=false (currently: '${pid}').")
+                        }
+                        if (!credsId || credsId == 'REPLACE_WITH_REAL_REGISTRY_CREDS_ID') {
+                            error("REGISTRY_CREDS_ID must be set to a real Jenkins credential id when DRY_RUN=false (currently: '${credsId}').")
+                        }
+                        echo "Pyxis project ID: ${pid}"
+                        echo "Registry creds id: ${credsId}"
                     }
-
-                    def target = [
-                        src: params.IMAGE,
-                        dest: "quay.io/redhat-isv-containers/${params.PYXIS_PROJECT_ID}:${params.IMAGE_TAG}",
-                        credentials: params.REGISTRY_CREDS_ID
-                    ]
 
                     def startedAt = System.currentTimeMillis()
                     def status
 
-                    withCredentials([
-                        string(credentialsId: 'PYXIS_TOKEN', variable: 'PYXIS_TOKEN'),
-                        usernamePassword(
-                            credentialsId: target.credentials,
-                            usernameVariable: 'REGISTRY_USER',
-                            passwordVariable: 'REGISTRY_KEY'
-                        )
-                    ]) {
-                        def component = env.REGISTRY_USER.replaceAll(/^.*\+/, '').replaceAll(/-robot$/, '')
-                        def noSubmitFlag = params.DRY_RUN ? '--no-submit' : ''
-
+                    if (params.DRY_RUN) {
                         status = sh(
                             returnStatus: true,
                             script: """
                             set -e
-                            python3 cloud/scripts/certify_images.py \
-                              --image ${target.src} \
-                              --dest_image ${target.dest} \
-                              --component ${component} \
-                              --platform ${params.PLATFORM} \
-                              ${noSubmitFlag}
+                            python3 cloud/scripts/certify_images.py \\
+                              --image ${params.IMAGE} \\
+                              --platform ${params.PLATFORM} \\
+                              --no-submit
                         """
                         )
+                    } else {
+                        def destImage = "quay.io/redhat-isv-containers/${pid}:${params.IMAGE_TAG}"
+
+                        withCredentials([
+                            string(credentialsId: 'PYXIS_TOKEN', variable: 'PYXIS_TOKEN'),
+                            usernamePassword(
+                                credentialsId: credsId,
+                                usernameVariable: 'REGISTRY_USER',
+                                passwordVariable: 'REGISTRY_KEY'
+                            )
+                        ]) {
+                            def component = env.REGISTRY_USER.replaceAll(/^.*\+/, '').replaceAll(/-robot$/, '')
+
+                            status = sh(
+                                returnStatus: true,
+                                script: """
+                                set -e
+                                python3 cloud/scripts/certify_images.py \\
+                                  --image ${params.IMAGE} \\
+                                  --dest_image ${destImage} \\
+                                  --component ${component} \\
+                                  --platform ${params.PLATFORM}
+                            """
+                            )
+                        }
                     }
 
                     certificationTests.add([

--- a/cloud/scripts/certify_images.py
+++ b/cloud/scripts/certify_images.py
@@ -298,8 +298,8 @@ def run_preflight(dest, platform, docker_config, token, component, no_submit=Fal
         "" if platform == "multiplatform" else f"--platform={platform}",
         f"--artifacts={os.path.abspath(results_dir)}",
         f"--docker-config={docker_config}",
-        f"--pyxis-api-token={token}",
-        f"--certification-component-id={component}",
+        "" if no_submit else f"--pyxis-api-token={token}",
+        "" if no_submit else f"--certification-component-id={component}",
         "--loglevel",
         "debug",
         "" if no_submit else "--submit",
@@ -341,8 +341,14 @@ def main():
     parser = argparse.ArgumentParser()
 
     parser.add_argument("--image", required=True)
-    parser.add_argument("--dest_image", required=True)
-    parser.add_argument("--component", required=True)
+    parser.add_argument(
+        "--dest_image",
+        help="Destination image in quay.io ISV registry (required unless --no-submit)",
+    )
+    parser.add_argument(
+        "--component",
+        help="Pyxis certification component id (required unless --no-submit)",
+    )
     parser.add_argument(
         "--platform", choices=["amd64", "arm64", "multiplatform"], required=True
     )
@@ -365,6 +371,43 @@ def main():
     )
 
     args = parser.parse_args()
+
+    if args.no_submit:
+        log(f"Dry-run preflight on source image: {args.image}")
+        log("start (no registry login, no image push, no Pyxis submit)")
+        target_image = args.image
+        try:
+            run_preflight(
+                target_image,
+                args.platform,
+                args.docker_config,
+                token=None,
+                component=None,
+                no_submit=True,
+            )
+        except SystemExit as e:
+            status = e.code if isinstance(e.code, int) else 1
+            write_junit_result(
+                args.image,
+                target_image,
+                args.platform,
+                args.component or "dry-run",
+                status,
+            )
+            raise
+
+        write_junit_result(
+            args.image,
+            target_image,
+            args.platform,
+            args.component or "dry-run",
+            0,
+        )
+        log("done")
+        return
+
+    if not args.dest_image or not args.component:
+        parser.error("--dest_image and --component are required unless --no-submit is set")
 
     token = get_secret(args.token, "PYXIS_TOKEN")
     registry_user = get_secret(args.registry_user, "REGISTRY_USER")

--- a/cloud/scripts/certify_images.py
+++ b/cloud/scripts/certify_images.py
@@ -282,7 +282,7 @@ def write_junit_result(image, dest, platform, _component, status):
     log(f"junit result saved: {path}")
 
 
-def run_preflight(dest, platform, docker_config, token, component):
+def run_preflight(dest, platform, docker_config, token, component, no_submit=False):
     preflight = install_preflight()
 
     log("running preflight")
@@ -302,7 +302,7 @@ def run_preflight(dest, platform, docker_config, token, component):
         f"--certification-component-id={component}",
         "--loglevel",
         "debug",
-        "--submit",
+        "" if no_submit else "--submit",
     ]
     cmd = [arg for arg in cmd if arg]
 
@@ -358,6 +358,12 @@ def main():
         default=os.path.expanduser("~/.docker/config.json"),
     )
 
+    parser.add_argument(
+        "--no-submit",
+        action="store_true",
+        help="Skip the preflight --submit upload (smoke-test / dry-run safe)",
+    )
+
     args = parser.parse_args()
 
     token = get_secret(args.token, "PYXIS_TOKEN")
@@ -382,6 +388,7 @@ def main():
             args.docker_config,
             token,
             args.component,
+            no_submit=args.no_submit,
         )
     except SystemExit as e:
         status = e.code if isinstance(e.code, int) else 1


### PR DESCRIPTION
Phase-1 scaffolding for [PS-10640]. This proves the cert path; release wiring and all-pillar rollout are follow-up, not in this PR.

The new pipeline `cloud/jenkins/ps_image_certification.groovy` runs in safe DRY_RUN mode by default: no credentials, no registry push, no Pyxis contact. It runs `openshift-preflight` directly against the source image. When DRY_RUN is false it fails fast while PID and credential IDs are still placeholders.

The supporting Python change adds `--no-submit` to `cloud/scripts/certify_images.py`. With the flag set, the script skips docker login, skips the registry push, drops the Pyxis token and component args, and points preflight at the source image. The four existing operator pipelines never pass `--no-submit`, so their behavior is unchanged.

Locally verified on `percona/percona-server:8.0.45-36`: preflight pulls the multi-arch image, runs all 10 checks per arch, exits 0, makes zero Pyxis or registry contact.

Production follow-up tracked on the ticket: pin the preflight version, extend the common `imageCertification.groovy` helper rather than duplicating its pattern, wire cert as a downstream stage of `ps_containers_docker_build.groovy` and analogues for PXC/PSMDB/PXB/PBM/PG/PT, implement publish-stage automation, and register per-PID Jenkins credentials once strategy is confirmed.

[PS-10640]: https://perconadev.atlassian.net/browse/PS-10640
