### PR TITLE
chore(scripts): move install-master-observability.sh to percona-cd-platform

### DIFF
--- a/scripts/install-master-observability.sh
+++ b/scripts/install-master-observability.sh
@@ -1,128 +1,24 @@
 #!/bin/bash
 # install-master-observability.sh
 #
-# PS-10997 / ADR 0013: master-side push pipeline.
-# Installs amazon-ssm-agent (fleet ops fan-out) and Grafana Alloy
-# (scrapes /hetzner-prometheus + tails Jenkins log; pushes to the
-# in-cluster alloy-gateway ALB). Bearer token is fetched from AWS
-# Secrets Manager at every Alloy restart via systemd ExecStartPre.
+# Back-compat shim. The canonical script now lives in
+# Percona/percona-cd-platform/scripts/install-master-observability.sh
+# alongside the rest of the alloy-gateway + AlloyGatewayBearerRead
+# IAM contract that this script depends on (one PR per platform
+# change instead of two).
 #
-# Caller must export JENKINS_HOST (FQDN, e.g. ps3.cd.percona.com).
-# Loaded at master boot from the CFN userData install_observability()
-# bootstrap on all 10 Percona Jenkins masters.
+# Existing CFN stacks pin to a specific SHA of this file and fetch
+# it from GitHub raw; those URLs serve immutable content by SHA and
+# continue working unchanged. Anyone fetching at master HEAD gets
+# this shim, which curls the canonical version from the platform
+# repo and pipes it to bash. JENKINS_HOST and any other caller env
+# vars pass through.
 #
-# Idempotent: dnf install, file writes, systemctl enable --now all
-# re-run safely.
+# When the last CFN-managed Jenkins master is migrated to Terraform
+# (Percona/percona-cd-platform), this file can be deleted.
 
 set -euo pipefail
 
-if [[ -z "${JENKINS_HOST:-}" ]]; then
-    echo "FATAL: JENKINS_HOST not set" >&2
-    exit 1
-fi
+CANONICAL_URL="${CANONICAL_URL:-https://raw.githubusercontent.com/percona/percona-cd-platform/6f5346eadc4bfa44e6d86d73ceb62ce7efbb7b79/scripts/install-master-observability.sh}"
 
-MASTER_LABEL="${JENKINS_HOST%.percona.com}"
-
-# 1. SSM agent (used for fleet-wide Run Command fan-out, not for the push itself).
-dnf -y install amazon-ssm-agent || yum -y install amazon-ssm-agent
-systemctl enable --now amazon-ssm-agent
-
-# 2. Grafana RPM repo + Alloy.
-cat > /etc/yum.repos.d/grafana.repo <<'REPO'
-[grafana]
-name=grafana
-baseurl=https://rpm.grafana.com
-repo_gpgcheck=1
-enabled=1
-gpgcheck=1
-gpgkey=https://rpm.grafana.com/gpg.key
-sslverify=1
-sslcacert=/etc/pki/tls/certs/ca-bundle.crt
-REPO
-dnf -y install alloy
-
-# 3. Boot-time bearer fetch from Secrets Manager (us-east-1, account-local).
-# The secret value is JSON (`{"bearer_token":"..."}`); extract the field with
-# python3 (always present on AL2023). Atomic write: stage to .tmp then mv,
-# so a failed Secrets Manager call does NOT leave an empty token file that
-# would 401 every push.
-cat > /usr/local/bin/alloy-fetch-token <<'SCRIPT'
-#!/bin/bash
-set -euo pipefail
-umask 077
-raw=$(aws secretsmanager get-secret-value \
-    --region us-east-1 \
-    --secret-id percona-ci-platform/alloy-gateway/bearer \
-    --query SecretString --output text)
-tok=$(printf '%s' "$raw" | python3 -c '
-import json, sys
-d = json.loads(sys.stdin.read())
-for k in ("bearer_token", "bearer", "token"):
-    if isinstance(d, dict) and k in d:
-        print(d[k], end=""); break
-else:
-    print(d, end="")
-')
-[[ -n "$tok" ]] || { echo "alloy-fetch-token: empty bearer" >&2; exit 1; }
-tmp=/etc/alloy/gateway-token.tmp
-printf '%s' "$tok" > "$tmp"
-chown root:alloy "$tmp"
-chmod 0440 "$tmp"
-mv -f "$tmp" /etc/alloy/gateway-token
-SCRIPT
-chmod 0755 /usr/local/bin/alloy-fetch-token
-
-install -d -m 0755 /etc/systemd/system/alloy.service.d
-# `+` prefix on ExecStartPre runs the fetcher as root regardless of `User=alloy`
-# on the unit, so it can write /etc/alloy/gateway-token (0440 root:alloy).
-cat > /etc/systemd/system/alloy.service.d/fetch-token.conf <<'DROPIN'
-[Service]
-ExecStartPre=+/usr/local/bin/alloy-fetch-token
-Restart=on-failure
-RestartSec=30s
-DROPIN
-
-# 4. Alloy config. master external_label is DNS-shaped (gotcha 5 in
-# percona-observability skill); the receiver path is
-# /api/v1/metrics/write (gotcha 4), not /api/v1/push.
-install -d -o root -g alloy -m 0750 /etc/alloy
-cat > /etc/alloy/config.alloy <<CONFIG
-prometheus.scrape "hetzner_local" {
-  targets         = [{__address__ = "localhost:8080", __metrics_path__ = "/hetzner-prometheus/"}]
-  forward_to      = [prometheus.remote_write.mimir.receiver]
-  scrape_interval = "60s"
-  scrape_timeout  = "15s"
-}
-
-prometheus.remote_write "mimir" {
-  endpoint {
-    url               = "https://mimir-push.cd.percona.com/api/v1/metrics/write"
-    bearer_token_file = "/etc/alloy/gateway-token"
-    headers           = { "X-Scope-OrgID" = "percona-ci" }
-  }
-  external_labels = {
-    master = "$MASTER_LABEL",
-    fleet  = "percona-jenkins",
-    role   = "master",
-  }
-}
-
-loki.source.file "jenkins" {
-  targets       = [{__path__ = "/var/log/jenkins/jenkins.log", master = "$MASTER_LABEL", fleet = "percona-jenkins", role = "master", component = "jenkins"}]
-  forward_to    = [loki.write.gateway.receiver]
-  tail_from_end = false
-}
-
-loki.write "gateway" {
-  endpoint {
-    url               = "https://loki-push.cd.percona.com/loki/api/v1/push"
-    bearer_token_file = "/etc/alloy/gateway-token"
-  }
-}
-CONFIG
-chown root:alloy /etc/alloy/config.alloy
-chmod 0640 /etc/alloy/config.alloy
-
-# 5. Enable + start (ExecStartPre fetches the bearer at every restart).
-systemctl daemon-reload
-systemctl enable --now alloy
+exec bash -c "$(curl -fsSL --retry 5 "$CANONICAL_URL")"


### PR DESCRIPTION
## Summary

Move the canonical \`install-master-observability.sh\` to the platform repo where the gateway, IAM grant (\`AlloyGatewayBearerRead\`), and Secrets Manager bearer it depends on already live: [percona/percona-cd-platform@6f5346e](https://github.com/percona/percona-cd-platform/blob/6f5346eadc4bfa44e6d86d73ceb62ce7efbb7b79/scripts/install-master-observability.sh). Both repos are AGPL-3.0; no licence boundary.

This PR turns the file in jenkins-pipelines into a thin shim:

\`\`\`bash
exec bash -c "$(curl -fsSL --retry 5 \"$CANONICAL_URL\")"
\`\`\`

The shim is SHA-pinned to the same commit the platform's Terraform user-data points at, so masters fetching either URL run identical content.

## Compatibility

- Existing CFN-managed Jenkins masters pin to a specific SHA of this file and fetch it from GitHub raw. Those URLs serve immutable content by SHA; current launches and re-launches are unaffected and continue running the original 128-line script.
- Anyone fetching at master HEAD now gets the shim, which curls the canonical version and pipes to bash. \`JENKINS_HOST\` and any other caller env vars pass through.
- The platform's TF user-data (ps3 and pxb today) already points at the new URL.

## When this file can be deleted

When the last CFN-managed master migrates to Terraform in percona-cd-platform.