### PR TITLE
PMM-7: Use pmm-qa repo for AMI upgrades

### DIFF
--- a/pmm/v3/pmm3-rc-testing.groovy
+++ b/pmm/v3/pmm3-rc-testing.groovy
@@ -507,7 +507,6 @@ pipeline {
                                     triggerJenkinsRc('pmm3-upgrade-ami-test', 'pmm3-upgrade-ami-test', [
                                         string(name: 'PMM_UI_GIT_BRANCH',         value: 'main'),
                                         string(name: 'PMM_QA_GIT_BRANCH',         value: 'main'),
-                                        string(name: 'QA_INTEGRATION_GIT_BRANCH', value: 'main'),
                                         booleanParam(name: 'IS_RC_TESTING',       value: true),
                                     ])
                                 }

--- a/pmm/v3/pmm3-upgrade-ami-test-runner.groovy
+++ b/pmm/v3/pmm3-upgrade-ami-test-runner.groovy
@@ -141,10 +141,6 @@ pipeline {
             description: 'Tag/Branch for pmm qa repository',
             name: 'PMM_QA_GIT_BRANCH')
         string(
-            defaultValue: 'main',
-            description: 'Tag/Branch for qa-integration repository',
-            name: 'QA_INTEGRATION_GIT_BRANCH')
-        string(
             defaultValue: '',
             description: 'public ssh key for "admin" user, please set if you need ssh access',
             name: 'SSH_KEY')
@@ -169,11 +165,6 @@ pipeline {
                     sudo mkdir -p /srv/pmm-qa || :
                     cd  /srv/pmm-qa
                         sudo git clone --single-branch --branch ${PMM_QA_GIT_BRANCH} https://github.com/percona/pmm-qa.git .
-                    sudo mkdir -p /srv/qa-integration || true
-                    cd  /srv/qa-integration
-                        sudo git clone --single-branch --branch \${QA_INTEGRATION_GIT_BRANCH} https://github.com/Percona-Lab/qa-integration.git .
-                    sudo chmod -R 755 /srv/qa-integration
-                    sudo chown $(id -u):$(id -u) -R /srv/qa-integration
                     sudo ln -s /usr/bin/chromium-browser /usr/bin/chromium
                 '''
             }
@@ -205,7 +196,7 @@ pipeline {
                     set -o errexit
                     set -o xtrace
 
-                    pushd /srv/qa-integration/pmm_qa
+                    pushd /srv/pmm-qa/qa-integration/pmm_qa
                     echo "Setting docker based PMM clients"
                     mkdir -m 777 -p /tmp/backup_data
                     python3 -m venv virtenv

--- a/pmm/v3/pmm3-upgrade-ami-tests.groovy
+++ b/pmm/v3/pmm3-upgrade-ami-tests.groovy
@@ -8,7 +8,7 @@ def amiVersions = versionsList.values().toList()[-5..-1]
 def pmmVersions = versionsList.keySet().toList()[-5..-1]
 def latestVersion = pmmVersions[pmmVersions.size() - 1]
 
-void runUpgradeJob(String PMM_UI_PRE_UPGRADE_GIT_BRANCH, PMM_UI_GIT_BRANCH, AMI_TAG, DOCKER_TAG_UPGRADE, CLIENT_VERSION, CLIENT_REPOSITORY, PMM_SERVER_LATEST, PMM_QA_GIT_BRANCH, QA_INTEGRATION_GIT_BRANCH) {
+void runUpgradeJob(String PMM_UI_PRE_UPGRADE_GIT_BRANCH, PMM_UI_GIT_BRANCH, AMI_TAG, DOCKER_TAG_UPGRADE, CLIENT_VERSION, CLIENT_REPOSITORY, PMM_SERVER_LATEST, PMM_QA_GIT_BRANCH) {
     upgradeJob = build job: 'pmm3-upgrade-ami-test-runner', parameters: [
         string(name: 'PMM_UI_PRE_UPGRADE_GIT_BRANCH', value: PMM_UI_PRE_UPGRADE_GIT_BRANCH),
         string(name: 'PMM_UI_GIT_BRANCH', value: PMM_UI_GIT_BRANCH),
@@ -18,11 +18,10 @@ void runUpgradeJob(String PMM_UI_PRE_UPGRADE_GIT_BRANCH, PMM_UI_GIT_BRANCH, AMI_
         string(name: 'CLIENT_REPOSITORY', value: CLIENT_REPOSITORY),
         string(name: 'PMM_SERVER_LATEST', value: PMM_SERVER_LATEST),
         string(name: 'PMM_QA_GIT_BRANCH', value: PMM_QA_GIT_BRANCH),
-        string(name: 'QA_INTEGRATION_GIT_BRANCH', value: QA_INTEGRATION_GIT_BRANCH),
     ]
 }
 
-def generateVariants(PMM_UI_GIT_BRANCH, PMM_QA_GIT_BRANCH, QA_INTEGRATION_GIT_BRANCH, versionsList, latestVersion, IS_RC_TESTING) {
+def generateVariants(PMM_UI_GIT_BRANCH, PMM_QA_GIT_BRANCH, versionsList, latestVersion, IS_RC_TESTING) {
     def results = new HashMap<>();
 
     versionsList.each { pmmVersion, amiTag ->
@@ -39,8 +38,7 @@ def generateVariants(PMM_UI_GIT_BRANCH, PMM_QA_GIT_BRANCH, QA_INTEGRATION_GIT_BR
                     pmmClientVersion,
                     'experimental',
                     latestVersion,
-                    PMM_QA_GIT_BRANCH,
-                    QA_INTEGRATION_GIT_BRANCH
+                    PMM_QA_GIT_BRANCH
                 )
             )
         } else {
@@ -54,8 +52,7 @@ def generateVariants(PMM_UI_GIT_BRANCH, PMM_QA_GIT_BRANCH, QA_INTEGRATION_GIT_BR
                     pmmVersion,
                     'testing',
                     latestVersion,
-                    PMM_QA_GIT_BRANCH,
-                    QA_INTEGRATION_GIT_BRANCH
+                    PMM_QA_GIT_BRANCH
                 )
             )
         }
@@ -64,11 +61,11 @@ def generateVariants(PMM_UI_GIT_BRANCH, PMM_QA_GIT_BRANCH, QA_INTEGRATION_GIT_BR
     return results;
 }
 
-def generateStage(String PMM_PRE_UPGRADE_UI_GIT_BRANCH, PMM_UI_GIT_BRANCH, amiVersion, DOCKER_TAG_UPGRADE, CLIENT_VERSION, CLIENT_REPOSITORY, PMM_SERVER_LATEST, PMM_QA_GIT_BRANCH, QA_INTEGRATION_GIT_BRANCH) {
+def generateStage(String PMM_PRE_UPGRADE_UI_GIT_BRANCH, PMM_UI_GIT_BRANCH, amiVersion, DOCKER_TAG_UPGRADE, CLIENT_VERSION, CLIENT_REPOSITORY, PMM_SERVER_LATEST, PMM_QA_GIT_BRANCH) {
     return {
         stage("Upgrade AMI PMM from ${CLIENT_VERSION} (AMI tag: ${amiVersion}) to: '${DOCKER_TAG_UPGRADE}'") {
             retry(2) {
-                runUpgradeJob(PMM_PRE_UPGRADE_UI_GIT_BRANCH, PMM_UI_GIT_BRANCH, amiVersion, DOCKER_TAG_UPGRADE, CLIENT_VERSION, CLIENT_REPOSITORY, PMM_SERVER_LATEST, PMM_QA_GIT_BRANCH, QA_INTEGRATION_GIT_BRANCH);
+                runUpgradeJob(PMM_PRE_UPGRADE_UI_GIT_BRANCH, PMM_UI_GIT_BRANCH, amiVersion, DOCKER_TAG_UPGRADE, CLIENT_VERSION, CLIENT_REPOSITORY, PMM_SERVER_LATEST, PMM_QA_GIT_BRANCH);
             }
         }
     }
@@ -88,10 +85,6 @@ pipeline {
             defaultValue: 'main',
             description: 'Tag/Branch for pmm-qa repository',
             name: 'PMM_QA_GIT_BRANCH')
-        string(
-            defaultValue: 'main',
-            description: 'Tag/Branch for qa-integration repository',
-            name: 'QA_INTEGRATION_GIT_BRANCH')
         booleanParam(
             defaultValue: true,
             description: 'Teting for RC version if true, if false - testing for latest dev version',
@@ -104,7 +97,7 @@ pipeline {
         stage('UI tests Upgrade Matrix') {
             steps {
                 script {
-                    parallel generateVariants(PMM_UI_GIT_BRANCH, PMM_QA_GIT_BRANCH, QA_INTEGRATION_GIT_BRANCH, versionsList, latestVersion, IS_RC_TESTING)
+                    parallel generateVariants(PMM_UI_GIT_BRANCH, PMM_QA_GIT_BRANCH, versionsList, latestVersion, IS_RC_TESTING)
                 }
             }
         }


### PR DESCRIPTION
## Summary
- Stops AMI upgrade tests from cloning Percona-Lab/qa-integration.
- Runs AMI database and client setup from pmm-qa/qa-integration, matching the other PMM3 jobs.

## Validation
- Ran git diff --check.
- Verified no PMM v3 references to QA_INTEGRATION or /srv/qa-integration remain.
