### PR TITLE
PKG-1333: widen pg.cd min-ol-9-x64 EC2 template to 4 SKUs

### DIFF
--- a/IaC/pg.cd/init.groovy.d/cloud.groovy
+++ b/IaC/pg.cd/init.groovy.d/cloud.groovy
@@ -52,6 +52,10 @@ priceMap = [:]
 priceMap['c5.large']     = '0.08' // type=c5.large, vCPU=2, memory=4GiB, saving=49%, interruption='<5%', price=0.053400
 priceMap['c6g.large']    = '0.07' // type=c6g.large, vCPU=2, memory=4GiB (ARM)
 priceMap['d3.2xlarge']   = '0.47' // type=d3.2xlarge, vCPU=8, memory=64GiB, saving=70%, interruption='<5%', price=0.324000
+// PKG-1333: alt SKUs for min-ol-9-x64 to diversify the worker pool. Bids verified to fulfill at $0.47 across 1a/1b/1c on 2026-05-20.
+priceMap['m5d.2xlarge']  = '0.47' // type=m5d.2xlarge,  vCPU=8, memory=32GiB, recent spot peak ~$0.27 (OD ~$0.45)
+priceMap['m5dn.2xlarge'] = '0.47' // type=m5dn.2xlarge, vCPU=8, memory=32GiB, OD ~$0.54
+priceMap['i3en.2xlarge'] = '0.47' // type=i3en.2xlarge, vCPU=8, memory=64GiB, recent spot peak ~$0.44 (OD ~$0.82)
 
 userMap = [:]
 userMap['micro-amazon']       = 'ec2-user'
@@ -116,6 +120,10 @@ capMap = [:]
 capMap['c5.large']     = '20'
 capMap['c6g.large']    = '20'
 capMap['d3.2xlarge']   = '40'
+// PKG-1333: per-SKU caps for diversified min-ol-9-x64 templates.
+capMap['m5d.2xlarge']  = '40'
+capMap['m5dn.2xlarge'] = '40'
+capMap['i3en.2xlarge'] = '40'
 
 typeMap = [:]
 typeMap['micro-amazon']       = 'c5.large'
@@ -150,18 +158,23 @@ labelMap['min-al2023-x64']     = 'min-al2023-x64'
 labelMap['min-al2023-aarch64'] = 'min-al2023-aarch64'
 
 // https://github.com/jenkinsci/ec2-plugin/blob/ec2-1.41/src/main/java/hudson/plugins/ec2/SlaveTemplate.java
-SlaveTemplate getTemplate(String OSType, String AZ) {
+// PKG-1333: optional overrideType lets one OSType (label) be backed by multiple instance types.
+// When overrideType is set, the template uses that SKU instead of typeMap[OSType] while keeping the same label.
+SlaveTemplate getTemplate(String OSType, String AZ, String overrideType = null) {
+    String actualType = overrideType ?: typeMap[OSType]
+    String tagSuffix  = overrideType ? '-' + overrideType.split(/\./)[0] : ''
+    String descSuffix = overrideType ? ' (' + overrideType + ')' : ''
     return new SlaveTemplate(
         imageMap[AZ + '.' + OSType],                // String ami
         '',                                         // String zone
-        new SpotConfiguration(true, priceMap[typeMap[OSType]], false, '0'), // SpotConfiguration spotConfig
+        new SpotConfiguration(true, priceMap[actualType], false, '0'), // SpotConfiguration spotConfig
         'default',                                  // String securityGroups
         '/mnt/jenkins',                             // String remoteFS
-        InstanceType.fromValue(typeMap[OSType]),    // InstanceType type
-        ( typeMap[OSType].startsWith("c4") || typeMap[OSType].startsWith("m4") || typeMap[OSType].startsWith("c5") || typeMap[OSType].startsWith("m5") ), // boolean ebsOptimized
-        OSType + ' ' + labelMap[OSType],            // String labelString
+        InstanceType.fromValue(actualType),         // InstanceType type
+        ( actualType.startsWith("c4") || actualType.startsWith("m4") || actualType.startsWith("c5") || actualType.startsWith("m5") ), // boolean ebsOptimized
+        OSType + ' ' + labelMap[OSType],            // String labelString (shared across SKUs so jobs find any of them)
         Node.Mode.NORMAL,                           // Node.Mode mode
-        OSType,                                     // String description
+        OSType + descSuffix,                        // String description
         initMap[OSType],                            // String initScript
         '',                                         // String tmpDir
         '',                                         // String userData
@@ -172,13 +185,13 @@ SlaveTemplate getTemplate(String OSType, String AZ) {
         false,                                      // boolean stopOnTerminate
         netMap[AZ],                                 // String subnetId
         [
-            new EC2Tag('Name', 'jenkins-pg-' + OSType),
+            new EC2Tag('Name', 'jenkins-pg-' + OSType + tagSuffix),
             new EC2Tag('iit-billing-tag', 'jenkins-pg-worker')
         ],                                          // List<EC2Tag> tags
         '15',                                       // String idleTerminationMinutes
         0,                                          // Init minimumNumberOfInstances
         0,                                          // minimumNumberOfSpareInstances
-        capMap[typeMap[OSType]],                    // String instanceCapStr
+        capMap[actualType],                         // String instanceCapStr
         'arn:aws:iam::119175775298:instance-profile/jenkins-pg-worker', // String iamInstanceProfile
         true,                                       // boolean deleteRootOnTermination
         false,                                      // boolean useEphemeralDevices
@@ -221,6 +234,10 @@ String region = 'eu-central-1'
             getTemplate('min-centos-7-x64',    "${region}${it}"),
             getTemplate('min-ol-8-x64',        "${region}${it}"),
             getTemplate('min-ol-9-x64',        "${region}${it}"),
+            // PKG-1333: alt SKUs sharing the min-ol-9-x64 label so Jenkins fulfills from whichever spot pool has capacity.
+            getTemplate('min-ol-9-x64',        "${region}${it}", 'm5d.2xlarge'),
+            getTemplate('min-ol-9-x64',        "${region}${it}", 'm5dn.2xlarge'),
+            getTemplate('min-ol-9-x64',        "${region}${it}", 'i3en.2xlarge'),
             getTemplate('min-al2023-x64',      "${region}${it}"),
             getTemplate('min-al2023-aarch64',  "${region}${it}"),
         ],                                       // List<? extends SlaveTemplate> templates


### PR DESCRIPTION
## Change

PG-release jobs on `pg.cd` depend on the `min-ol-9-x64` label, but that label currently maps only to `d3.2xlarge` in `eu-central-1b/c`. When that spot market is constrained or AWS reclaims a worker, Jenkins has no alternate SKU for that label and builds can abort with `Timeout waiting for agent to come back`; on 2026-05-20 this hit [pg/docker-server-parallel build 755](https://pg.cd.percona.com/job/docker-server-parallel/755/) and [pg/ppg-upgrade-parallel build 1291](https://pg.cd.percona.com/job/ppg-upgrade-parallel/1291/).

This adds `m5d.2xlarge`, `m5dn.2xlarge`, and `i3en.2xlarge` as alternate `min-ol-9-x64` templates, so Jenkins can provision from more spot pools. The existing `d3.2xlarge` template stays in place, and the alternates reuse the same AMI, init script, subnet, and label. All alternates use the existing `$0.47` spot ceiling; validation confirmed all three SKUs fulfilled at that bid in `eu-central-1a/b/c`, while this PR deploys only to the existing `b/c` subnets.

Pipeline-side `retry()` and `eu-central-1a` subnet enablement remain separate follow-ups under the same ticket; this PR only widens the spot pools behind the existing label.

## Tickets

- [PKG-1333](https://perconadev.atlassian.net/browse/PKG-1333) (this)


[PKG-1333]: https://perconadev.atlassian.net/browse/PKG-1333?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ