### PR TITLE
PMM-7: increase PMM server ready timeout on staging start

### DIFF
--- a/pmm/v3/pmm3-aws-staging-start.groovy
+++ b/pmm/v3/pmm3-aws-staging-start.groovy
@@ -245,15 +245,12 @@ pipeline {
                                         --volume pmm-data:/srv \
                                         -e PMM_WATCHTOWER_HOST=http://watchtower:8080 \
                                         -e PMM_WATCHTOWER_TOKEN=testToken \
+                                        -e GF_SECURITY_ADMIN_PASSWORD="${ADMIN_PASSWORD}" \
                                         ${DOCKER_ENV_VARIABLE} \
                                         ${DOCKER_VERSION}
 
-                                    sleep 30
+                                    timeout 180 bash -c 'until [ "$(curl -ks -o /dev/null -w "%{http_code}" --user "admin:${ADMIN_PASSWORD}" https://127.0.0.1/ping)" = "200" ]; do sleep 5; done'
                                     docker logs pmm-server
-
-                                    if [ ${ADMIN_PASSWORD} != admin ]; then
-                                        docker exec pmm-server change-admin-password ${ADMIN_PASSWORD}
-                                    fi
                                 '''
                             }
                         }

--- a/pmm/v3/pmm3-aws-staging-start.groovy
+++ b/pmm/v3/pmm3-aws-staging-start.groovy
@@ -249,7 +249,7 @@ pipeline {
                                         ${DOCKER_ENV_VARIABLE} \
                                         ${DOCKER_VERSION}
 
-                                    timeout 60 bash -c 'until [ "$(curl -ks -o /dev/null -w "%{http_code}" --user "admin:${ADMIN_PASSWORD}" https://127.0.0.1/ping)" = "200" ]; do sleep 5; done'
+                                    timeout 180 bash -c 'until [ "$(curl -ks -o /dev/null -w "%{http_code}" --user "admin:${ADMIN_PASSWORD}" https://127.0.0.1/ping)" = "200" ]; do sleep 5; done'
                                     docker logs pmm-server
                                 '''
                             }

--- a/pmm/v3/pmm3-aws-staging-start.groovy
+++ b/pmm/v3/pmm3-aws-staging-start.groovy
@@ -249,7 +249,7 @@ pipeline {
                                         ${DOCKER_ENV_VARIABLE} \
                                         ${DOCKER_VERSION}
 
-                                    timeout 180 bash -c 'until [ "$(curl -ks -o /dev/null -w "%{http_code}" --user "admin:${ADMIN_PASSWORD}" https://127.0.0.1/ping)" = "200" ]; do sleep 5; done'
+                                    timeout 60 bash -c 'until [ "$(curl -ks -o /dev/null -w "%{http_code}" --user "admin:${ADMIN_PASSWORD}" https://127.0.0.1/ping)" = "200" ]; do sleep 5; done'
                                     docker logs pmm-server
                                 '''
                             }

--- a/pmm/v3/pmm3-ui-tests.groovy
+++ b/pmm/v3/pmm3-ui-tests.groovy
@@ -235,7 +235,7 @@ pipeline {
                         waitForContainer('pmm-agent_mysql_5_7', "Server hostname (bind-address):")
                         waitForContainer('pmm-agent_postgres', 'PostgreSQL init process complete; ready for start up.')
                         sh '''
-                            docker exec pmm-server change-admin-password ${ADMIN_PASSWORD}
+                            timeout 180 bash -c 'until [ "$(curl -s -o /dev/null -w "%{http_code}" --user "admin:${ADMIN_PASSWORD}" http://127.0.0.1/ping)" = "200" ]; do sleep 5; done'
                         '''
                         dir('codeceptjs-e2e') {
                             sh '''

--- a/pmm/v3/pmm3-ui-tests.groovy
+++ b/pmm/v3/pmm3-ui-tests.groovy
@@ -235,7 +235,7 @@ pipeline {
                         waitForContainer('pmm-agent_mysql_5_7', "Server hostname (bind-address):")
                         waitForContainer('pmm-agent_postgres', 'PostgreSQL init process complete; ready for start up.')
                         sh '''
-                            timeout 180 bash -c 'until [ "$(curl -s -o /dev/null -w "%{http_code}" --user "admin:${ADMIN_PASSWORD}" http://127.0.0.1/ping)" = "200" ]; do sleep 5; done'
+                            timeout 60 bash -c 'until [ "$(curl -s -o /dev/null -w "%{http_code}" --user "admin:${ADMIN_PASSWORD}" http://127.0.0.1/ping)" = "200" ]; do sleep 5; done'
                         '''
                         dir('codeceptjs-e2e') {
                             sh '''


### PR DESCRIPTION
## Summary
- Increase timeout of healthcheck of PMM on stage Run Docker from 60s to 180s.

## Why
Cold start of PMM (ex. `3.8.0-rc`) on same EC2 took longer than 60s and failed multiple instances.