### PR TITLE
PMM-7: Fix permission denied when creating virtenv in ami-test-runner

### DIFF
--- a/pmm/v3/pmm3-upgrade-ami-test-runner.groovy
+++ b/pmm/v3/pmm3-upgrade-ami-test-runner.groovy
@@ -165,6 +165,7 @@ pipeline {
                     sudo mkdir -p /srv/pmm-qa || :
                     cd  /srv/pmm-qa
                         sudo git clone --single-branch --branch ${PMM_QA_GIT_BRANCH} https://github.com/percona/pmm-qa.git .
+                    sudo chown -R ec2-user:ec2-user /srv/pmm-qa
                     sudo ln -s /usr/bin/chromium-browser /usr/bin/chromium
                 '''
             }


### PR DESCRIPTION
## Summary
Add \sudo chown -R ec2-user:ec2-user /srv/pmm-qa\ after cloning pmm-qa in \pmm3-upgrade-ami-test-runner\, matching other PMM v3 pipelines.

## Why
Issue with ami pipeline:
https://pmm.cd.percona.com/blue/organizations/jenkins/pmm3-upgrade-ami-test-runner/detail/pmm3-upgrade-ami-test-runner/785/pipeline