### PR TITLE
PXB-3796: modernize ps80 aarch64 EC2 templates to Graviton4 m8g.2xlarge

### DIFF
--- a/IaC/ps80.cd/init.groovy.d/cloud.groovy
+++ b/IaC/ps80.cd/init.groovy.d/cloud.groovy
@@ -191,7 +191,7 @@ priceMap['c5d.4xlarge'] = '0.40'  // type=c5d.4xlarge, vCPU=16, memory=32GiB, sa
 priceMap['r5a.4xlarge'] = '0.65' // type=r5a.4xlarge, vCPU=16, memory=128GiB, saving=67%, interruption='<5%', price=0.583900
 priceMap['m5n.2xlarge'] = '0.37' // type=m5n.2xlarge, vCPU=8, memory=32GiB, saving=64%, interruption='<5%', price=0.201900
 
-priceMap['i4g.2xlarge'] = '0.34' // aarch
+priceMap['m8g.2xlarge'] = '0.30' // aarch (Graviton4, 8 vCPU, 32 GB; on-demand cap, spot-price-auto-updater refines)
 
 userMap = [:]
 userMap['docker']            = 'ec2-user'
@@ -755,7 +755,7 @@ capMap = [:]
 capMap['c5d.4xlarge'] = '80'
 capMap['r5a.4xlarge'] = '60'
 capMap['m5n.2xlarge'] = '60'
-capMap['i4g.2xlarge'] = '40'
+capMap['m8g.2xlarge'] = '40'
 
 typeMap = [:]
 typeMap['micro-amazon']      = 't2.medium'
@@ -789,15 +789,15 @@ typeMap['min-bookworm-x64']  = typeMap['docker']
 typeMap['min-trixie-x64']    = typeMap['docker']
 typeMap['min-rhel-10-x64']   = typeMap['micro-amazon']
 
-typeMap['docker-32gb-aarch64']  = 'i4g.2xlarge'
-typeMap['docker-64gb-aarch64']  = 'i4g.2xlarge'
-typeMap['min-al2023-aarch64']   = 'i4g.2xlarge'
-typeMap['min-jammy-aarch64']    = 'i4g.2xlarge'
-typeMap['min-noble-aarch64']    = 'i4g.2xlarge'
-typeMap['min-resolute-aarch64']    = 'i4g.2xlarge'
-typeMap['min-bullseye-aarch64'] = 'i4g.2xlarge'
-typeMap['min-bookworm-aarch64'] = 'i4g.2xlarge'
-typeMap['min-trixie-aarch64']   = 'i4g.2xlarge'
+typeMap['docker-32gb-aarch64']  = 'm8g.2xlarge'
+typeMap['docker-64gb-aarch64']  = 'm8g.2xlarge'
+typeMap['min-al2023-aarch64']   = 'm8g.2xlarge'
+typeMap['min-jammy-aarch64']    = 'm8g.2xlarge'
+typeMap['min-noble-aarch64']    = 'm8g.2xlarge'
+typeMap['min-resolute-aarch64']    = 'm8g.2xlarge'
+typeMap['min-bullseye-aarch64'] = 'm8g.2xlarge'
+typeMap['min-bookworm-aarch64'] = 'm8g.2xlarge'
+typeMap['min-trixie-aarch64']   = 'm8g.2xlarge'
 
 execMap = [:]
 execMap['docker']            = '1'


### PR DESCRIPTION
**⚠️ WARNING: THIS PR WAS IMPLEMENTED WITH AI AGENT ASSISTANCE. PLEASE REVIEW THOROUGHLY BEFORE MERGE.**

**Scope**
- Modernise ps80's 8 aarch64 EC2 templates from `i4g.2xlarge` (Graviton2 storage-optimized) to `m8g.2xlarge` (Graviton4 general-purpose). Updates 8 typeMap + 1 priceMap + 1 capMap entry in `IaC/ps80.cd/init.groovy.d/cloud.groovy`.

**Why**
- Graviton4 vs Graviton2: two gens newer, better perf per dollar. Same vCPU (8), half RAM (32 GB vs 64 GB; sufficient for docker image builds with peak 8 to 16 GB). Drops the unused 1875 GB local NVMe.
- Spot price (us-west-2b): `m8g.2xlarge` $0.121 vs `i4g.2xlarge` $0.147, around 18% cheaper at equivalent CPU.
- The `spot-price-auto-updater` job (every 15 min) re-bids based on current spot + $0.07, so the `priceMap` initial is just a safety cap.

**Tickets**
- [PXB-3796](https://perconadev.atlassian.net/browse/PXB-3796) (ARM enablement; umbrella [PXB-3745](https://perconadev.atlassian.net/browse/PXB-3745)). Companion: [PR 4093](https://github.com/Percona-Lab/jenkins-pipelines/pull/4093). Follow-up: psmdb.cd uses `i4g.2xlarge` too, modernisation tracked separately.


[PXB-3796]: https://perconadev.atlassian.net/browse/PXB-3796?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[PXB-3745]: https://perconadev.atlassian.net/browse/PXB-3745?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
