### PR TITLE
PKG-1334: Stop killing SSH during Hetzner worker bootstrap

### DIFF
--- a/IaC/cloud.cd/init.groovy.d/htz.cloud.groovy
+++ b/IaC/cloud.cd/init.groovy.d/htz.cloud.groovy
@@ -80,7 +80,6 @@ initMap['fedora-docker'] = '''#!/bin/bash -x
     set -o xtrace
     echo -e "nameserver 9.9.9.9\nnameserver 1.1.1.1" | sudo tee /etc/resolv.conf
     echo '10.30.6.9 repo.ci.percona.com' | sudo tee -a /etc/hosts
-    ( sudo systemctl stop sshd; sleep 300; sudo systemctl start sshd ) &
     sudo install -o $(id -u -n) -g $(id -g -n) -d /mnt/jenkins
     sudo fallocate -l 32G /swapfile
     sudo chmod 600 /swapfile
@@ -125,7 +124,6 @@ initMap['fedora-docker'] = '''#!/bin/bash -x
     sudo mkdir -p /etc/docker
     echo '{"experimental": true, "ipv6": true, "fixed-cidr-v6": "fd3c:a8b0:18eb:5c06::/64"}' | sudo tee /etc/docker/daemon.json
     sudo systemctl status docker || sudo systemctl start docker
-    sudo systemctl start sshd
 '''
 initMap['fedora42-x64-nbg1']     = initMap['fedora-docker']
 initMap['fedora42-x64-hel1']     = initMap['fedora-docker']

--- a/IaC/psmdb.cd/init.groovy.d/htz.cloud.groovy
+++ b/IaC/psmdb.cd/init.groovy.d/htz.cloud.groovy
@@ -85,7 +85,6 @@ initMap['deb-docker'] = '''#!/bin/bash -x
     echo "precedence ::ffff:0:0/96 100" | sudo tee -a /etc/gai.conf
     echo -e "nameserver 9.9.9.9\nnameserver 1.1.1.1" | sudo tee /etc/resolv.conf
     echo '10.30.6.9 repo.ci.percona.com' | sudo tee -a /etc/hosts
-    ( sudo systemctl stop sshd; sleep 300; sudo systemctl start sshd ) &
     sudo install -o $(id -u -n) -g $(id -g -n) -d /mnt/jenkins
     sudo fallocate -l 32G /swapfile
     sudo chmod 600 /swapfile
@@ -143,7 +142,6 @@ APT_EOF
     sudo mkdir -p /etc/docker
     echo '{"experimental": true, "ipv6": true, "fixed-cidr-v6": "fd3c:a8b0:18eb:5c06::/64"}' | sudo tee /etc/docker/daemon.json
     sudo systemctl restart docker
-    sudo systemctl start sshd
 '''
 initMap['deb12-x64-nbg1']     = initMap['deb-docker']
 initMap['deb12-x64-hel1']     = initMap['deb-docker']

--- a/IaC/rel.cd/init.groovy.d/htz.cloud.groovy
+++ b/IaC/rel.cd/init.groovy.d/htz.cloud.groovy
@@ -85,7 +85,6 @@ initMap['deb-docker'] = '''#!/bin/bash -x
     echo "precedence ::ffff:0:0/96 100" | sudo tee -a /etc/gai.conf
     echo -e "nameserver 9.9.9.9\nnameserver 1.1.1.1" | sudo tee /etc/resolv.conf
     echo '10.30.6.9 repo.ci.percona.com' | sudo tee -a /etc/hosts
-    ( sudo systemctl stop sshd; sleep 300; sudo systemctl start sshd ) &
     sudo install -o $(id -u -n) -g $(id -g -n) -d /mnt/jenkins
     sudo fallocate -l 32G /swapfile
     sudo chmod 600 /swapfile
@@ -143,7 +142,6 @@ APT_EOF
     sudo mkdir -p /etc/docker
     echo '{"experimental": true, "ipv6": true, "fixed-cidr-v6": "fd3c:a8b0:18eb:5c06::/64"}' | sudo tee /etc/docker/daemon.json
     sudo systemctl restart docker
-    sudo systemctl start sshd
 '''
 initMap['deb12-x64-nbg1']     = initMap['deb-docker']
 initMap['deb12-x64-hel1']     = initMap['deb-docker']


### PR DESCRIPTION
**Bug**

- New Hetzner workers fail to launch on `cloud.cd` Jenkins ~90% of the time (75 fail vs 7 succeed in a 1-hour window)
- Same pattern at lower volume on `psmdb.cd` and `rel.cd`
- Affects PG container builds and OpenShift release jobs that run on `cloud.cd` Fedora workers
- Mechanism: PKG-1045 userdata script intentionally keeps SSH offline for 5 minutes during cloud-init, but Jenkins only retries the connection for ~64 seconds before giving up

**Fix**

- Delete the 5-minute SSH-off block from `cloud.cd`, `psmdb.cd`, `rel.cd` worker userdata (6 lines, 3 files)
- The "wait for Java" reason is now handled inside the patched Hetzner plugin: it waits for cloud-init to finish before launching the agent jar
- The "wait for `/mnt/jenkins`" reason is still handled by the userdata, which creates that directory as its very first command
- Deploy after merge: `jenkins iac deploy htz.cloud.groovy -i cloud,psmdb,rel`

**Tickets**

- [PKG-1334](https://perconadev.atlassian.net/browse/PKG-1334) (this)
- [PKG-1045](https://perconadev.atlassian.net/browse/PKG-1045) (origin, superseded)

[PKG-1334]: https://perconadev.atlassian.net/browse/PKG-1334?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[PKG-1045]: https://perconadev.atlassian.net/browse/PKG-1045?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ