### PR TITLE
PXB-3797: Enable cross-arch helper containers on Hetzner ARM64 workers

### DIFF
--- a/IaC/cloud.cd/init.groovy.d/htz.cloud.groovy
+++ b/IaC/cloud.cd/init.groovy.d/htz.cloud.groovy
@@ -89,7 +89,7 @@ initMap['fedora-docker'] = '''#!/bin/bash -x
         sleep 1
         echo "try again"
     done
-    until sudo dnf install -y java-21-openjdk-headless ca-certificates curl gnupg unzip git dnf-plugins-core cronie bc npm make; do
+    until sudo dnf install -y java-21-openjdk-headless ca-certificates curl gnupg unzip git dnf-plugins-core cronie bc npm make qemu-user-static; do
         sleep 1
         echo "try again"
     done

--- a/IaC/pg.cd/init.groovy.d/htz.cloud.groovy
+++ b/IaC/pg.cd/init.groovy.d/htz.cloud.groovy
@@ -104,7 +104,7 @@ APT_EOF
         sleep 1
         echo try again
     done
-    until sudo apt-get -y install openjdk-17-jre-headless apt-transport-https ca-certificates curl gnupg lsb-release unzip git; do
+    until sudo apt-get -y install openjdk-17-jre-headless apt-transport-https ca-certificates curl gnupg lsb-release unzip git qemu-user-static binfmt-support; do
         sleep 1
         echo try again
     done

--- a/IaC/pmm.cd/init.groovy.d/htz.cloud.groovy
+++ b/IaC/pmm.cd/init.groovy.d/htz.cloud.groovy
@@ -104,7 +104,7 @@ APT_EOF
         sleep 1
         echo try again
     done
-    until sudo apt-get -y install openjdk-17-jre-headless apt-transport-https ca-certificates curl gnupg lsb-release unzip git; do
+    until sudo apt-get -y install openjdk-17-jre-headless apt-transport-https ca-certificates curl gnupg lsb-release unzip git qemu-user-static binfmt-support; do
         sleep 1
         echo try again
     done

--- a/IaC/ps3.cd/init.groovy.d/htz.cloud.groovy
+++ b/IaC/ps3.cd/init.groovy.d/htz.cloud.groovy
@@ -104,7 +104,7 @@ APT_EOF
         sleep 1
         echo try again
     done
-    until sudo apt-get -y install openjdk-17-jre-headless apt-transport-https ca-certificates curl gnupg lsb-release unzip git; do
+    until sudo apt-get -y install openjdk-17-jre-headless apt-transport-https ca-certificates curl gnupg lsb-release unzip git qemu-user-static binfmt-support; do
         sleep 1
         echo try again
     done

--- a/IaC/ps57.cd/init.groovy.d/htz.cloud.groovy
+++ b/IaC/ps57.cd/init.groovy.d/htz.cloud.groovy
@@ -104,7 +104,7 @@ APT_EOF
         sleep 1
         echo try again
     done
-    until sudo apt-get -y install openjdk-17-jre-headless apt-transport-https ca-certificates curl gnupg lsb-release unzip git; do
+    until sudo apt-get -y install openjdk-17-jre-headless apt-transport-https ca-certificates curl gnupg lsb-release unzip git qemu-user-static binfmt-support; do
         sleep 1
         echo try again
     done

--- a/IaC/ps80.cd/init.groovy.d/htz.cloud.groovy
+++ b/IaC/ps80.cd/init.groovy.d/htz.cloud.groovy
@@ -104,7 +104,7 @@ APT_EOF
         sleep 1
         echo try again
     done
-    until sudo apt-get -y install openjdk-17-jre-headless apt-transport-https ca-certificates curl gnupg lsb-release unzip git; do
+    until sudo apt-get -y install openjdk-17-jre-headless apt-transport-https ca-certificates curl gnupg lsb-release unzip git qemu-user-static binfmt-support; do
         sleep 1
         echo try again
     done

--- a/IaC/psmdb.cd/init.groovy.d/htz.cloud.groovy
+++ b/IaC/psmdb.cd/init.groovy.d/htz.cloud.groovy
@@ -104,7 +104,7 @@ APT_EOF
         sleep 1
         echo try again
     done
-    until sudo apt-get -y install openjdk-17-jre-headless apt-transport-https ca-certificates curl gnupg lsb-release unzip git; do
+    until sudo apt-get -y install openjdk-17-jre-headless apt-transport-https ca-certificates curl gnupg lsb-release unzip git qemu-user-static binfmt-support; do
         sleep 1
         echo try again
     done

--- a/IaC/pxb.cd/init.groovy.d/htz.cloud.groovy
+++ b/IaC/pxb.cd/init.groovy.d/htz.cloud.groovy
@@ -104,7 +104,7 @@ APT_EOF
         sleep 1
         echo try again
     done
-    until sudo apt-get -y install openjdk-17-jre-headless apt-transport-https ca-certificates curl gnupg lsb-release unzip git; do
+    until sudo apt-get -y install openjdk-17-jre-headless apt-transport-https ca-certificates curl gnupg lsb-release unzip git qemu-user-static binfmt-support; do
         sleep 1
         echo try again
     done

--- a/IaC/pxc.cd/init.groovy.d/htz.cloud.groovy
+++ b/IaC/pxc.cd/init.groovy.d/htz.cloud.groovy
@@ -104,7 +104,7 @@ APT_EOF
         sleep 1
         echo try again
     done
-    until sudo apt-get -y install openjdk-17-jre-headless apt-transport-https ca-certificates curl gnupg lsb-release unzip git; do
+    until sudo apt-get -y install openjdk-17-jre-headless apt-transport-https ca-certificates curl gnupg lsb-release unzip git qemu-user-static binfmt-support; do
         sleep 1
         echo try again
     done

--- a/IaC/rel.cd/init.groovy.d/htz.cloud.groovy
+++ b/IaC/rel.cd/init.groovy.d/htz.cloud.groovy
@@ -104,7 +104,7 @@ APT_EOF
         sleep 1
         echo try again
     done
-    until sudo apt-get -y install openjdk-17-jre-headless apt-transport-https ca-certificates curl gnupg lsb-release unzip git; do
+    until sudo apt-get -y install openjdk-17-jre-headless apt-transport-https ca-certificates curl gnupg lsb-release unzip git qemu-user-static binfmt-support; do
         sleep 1
         echo try again
     done


### PR DESCRIPTION
**Feature**

- Adds `qemu-user-static` (+ `binfmt-support` on Debian) to all 10 Hetzner worker cloud-init scripts.
- Lets x86_64 Docker images run on ARM64 hosts via CPU emulation, needed for PXB ARM64 tests whose supporting services (Minio, Vault, KMIP) ship only as x86_64 containers.

**Why**

- PXB ARM64 test pipelines on Hetzner currently fail to start their helper services (`exec format error`) because no aarch64-native helper images exist.

**Tickets**

- [PXB-3797](https://perconadev.atlassian.net/browse/PXB-3797) (this), [PXB-3613](https://perconadev.atlassian.net/browse/PXB-3613) (consumer), [PXB-3745](https://perconadev.atlassian.net/browse/PXB-3745) (umbrella), [PXB-3798](https://perconadev.atlassian.net/browse/PXB-3798) / [PR 4117](https://github.com/Percona-Lab/jenkins-pipelines/pull/4117) (EC2 companion).


[PXB-3797]: https://perconadev.atlassian.net/browse/PXB-3797?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[PXB-3613]: https://perconadev.atlassian.net/browse/PXB-3613?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[PXB-3745]: https://perconadev.atlassian.net/browse/PXB-3745?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[PXB-3798]: https://perconadev.atlassian.net/browse/PXB-3798?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ