### PR TITLE
PXB-3798: Enable cross-arch helper containers on AWS ARM64 workers

### DIFF
--- a/IaC/cloud.cd/init.groovy.d/cloud.groovy
+++ b/IaC/cloud.cd/init.groovy.d/cloud.groovy
@@ -124,6 +124,10 @@ initMap['docker'] = '''
     echo '{"experimental": true, "ipv6": true, "fixed-cidr-v6": "fd3c:a8b0:18eb:5c06::/64"}' | sudo tee /etc/docker/daemon.json
     sudo systemctl status docker || sudo systemctl start docker
     sudo service docker status || sudo service docker start
+    # PXB-3798: qemu-x86_64 for x86_64 helper containers on aarch64 (AL2 path)
+    if [ "$(uname -m)" = "aarch64" ]; then
+        sudo yum install -y qemu-user-static
+    fi
     echo "* * * * * root /usr/sbin/route add default gw 10.177.1.1 eth0" | sudo tee /etc/cron.d/fix-default-route
 '''
 initMap['docker2'] = initMap['docker']
@@ -287,6 +291,20 @@ initMap['min-al2023-x64'] = '''
     echo '{"experimental": true, "ipv6": true, "fixed-cidr-v6": "fd3c:a8b0:18eb:5c06::/64"}' | sudo tee /etc/docker/daemon.json
     sudo systemctl status docker || sudo systemctl start docker
     sudo service docker status || sudo service docker start
+    # PXB-3798: extract qemu-x86_64 from tonistiigi/binfmt:qemu-v10.2.1-65 (mirrored to Percona ECR Public, pinned by index digest for supply-chain hygiene). AL2023 has no qemu-user-static in main repos.
+    if [ "$(uname -m)" = "aarch64" ] && [ ! -e /proc/sys/fs/binfmt_misc/qemu-x86_64 ]; then
+        until sudo docker pull --platform linux/arm64 public.ecr.aws/e7j3v3n0/qemu-binfmt@sha256:d3b963f787999e6c0219a48dba02978769286ff61a5f4d26245cb6a6e5567ea3; do sleep 5; done
+        cid=$(sudo docker create --platform linux/arm64 public.ecr.aws/e7j3v3n0/qemu-binfmt@sha256:d3b963f787999e6c0219a48dba02978769286ff61a5f4d26245cb6a6e5567ea3)
+        sudo docker cp "${cid}":/usr/bin/qemu-x86_64 /usr/local/bin/qemu-x86_64
+        sudo docker rm -f "${cid}"
+        sudo chmod 0755 /usr/local/bin/qemu-x86_64
+        if file /usr/local/bin/qemu-x86_64 | grep -Fq 'BuildID[sha1]=3ce82273ab59ab77b04b0bee9060c5b194769f4c'; then
+            echo ':qemu-x86_64:M::\\x7fELF\\x02\\x01\\x01\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x02\\x00\\x3e\\x00:\\xff\\xff\\xff\\xff\\xff\\xfe\\xfe\\x00\\xff\\xff\\xff\\xff\\xff\\xff\\xff\\xff\\xfe\\xff\\xff\\xff:/usr/local/bin/qemu-x86_64:POCF' | sudo tee /proc/sys/fs/binfmt_misc/register >/dev/null
+        else
+            echo "qemu-x86_64 BuildID mismatch from /usr/local/bin/qemu-x86_64; skipping binfmt registration" >&2
+            sudo rm -f /usr/local/bin/qemu-x86_64
+        fi
+    fi
     echo "* * * * * root /usr/sbin/route add default gw 10.177.1.1 eth0" | sudo tee /etc/cron.d/fix-default-route
 '''
 initMap['min-al2023-aarch64'] = initMap['min-al2023-x64']

--- a/IaC/ps3.cd/init.groovy.d/cloud.groovy
+++ b/IaC/ps3.cd/init.groovy.d/cloud.groovy
@@ -277,6 +277,10 @@ initMap['docker'] = '''
     echo '{"experimental": true}' | sudo tee /etc/docker/daemon.json
     sudo systemctl status docker || sudo systemctl start docker
     sudo service docker status || sudo service docker start
+    # PXB-3798: qemu-x86_64 for x86_64 helper containers on aarch64 (AL2 path)
+    if [ "$(uname -m)" = "aarch64" ]; then
+        sudo yum install -y qemu-user-static
+    fi
     echo "* * * * * root /usr/sbin/route add default gw 10.177.1.1 eth0" | sudo tee /etc/cron.d/fix-default-route
 '''
 
@@ -454,6 +458,7 @@ initMap['rpmMap'] = '''
     sudo yum -y install git tzdata-java || :
     sudo yum -y install aws-cli || :
     sudo install -o $(id -u -n) -g $(id -g -n) -d /mnt/jenkins
+    # PXB-3798: not applicable; this init block has no docker installed, see PXB-3798 description.
 
 '''
 
@@ -514,6 +519,20 @@ initMap['min-al2023-x64'] = '''
     echo '{"experimental": true, "ipv6": true, "fixed-cidr-v6": "fd3c:a8b0:18eb:5c06::/64"}' | sudo tee /etc/docker/daemon.json
     sudo systemctl status docker || sudo systemctl start docker
     sudo service docker status || sudo service docker start
+    # PXB-3798: extract qemu-x86_64 from tonistiigi/binfmt:qemu-v10.2.1-65 (mirrored to Percona ECR Public, pinned by index digest for supply-chain hygiene). AL2023 has no qemu-user-static in main repos.
+    if [ "$(uname -m)" = "aarch64" ] && [ ! -e /proc/sys/fs/binfmt_misc/qemu-x86_64 ]; then
+        until sudo docker pull --platform linux/arm64 public.ecr.aws/e7j3v3n0/qemu-binfmt@sha256:d3b963f787999e6c0219a48dba02978769286ff61a5f4d26245cb6a6e5567ea3; do sleep 5; done
+        cid=$(sudo docker create --platform linux/arm64 public.ecr.aws/e7j3v3n0/qemu-binfmt@sha256:d3b963f787999e6c0219a48dba02978769286ff61a5f4d26245cb6a6e5567ea3)
+        sudo docker cp "${cid}":/usr/bin/qemu-x86_64 /usr/local/bin/qemu-x86_64
+        sudo docker rm -f "${cid}"
+        sudo chmod 0755 /usr/local/bin/qemu-x86_64
+        if file /usr/local/bin/qemu-x86_64 | grep -Fq 'BuildID[sha1]=3ce82273ab59ab77b04b0bee9060c5b194769f4c'; then
+            echo ':qemu-x86_64:M::\\x7fELF\\x02\\x01\\x01\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x02\\x00\\x3e\\x00:\\xff\\xff\\xff\\xff\\xff\\xfe\\xfe\\x00\\xff\\xff\\xff\\xff\\xff\\xff\\xff\\xff\\xfe\\xff\\xff\\xff:/usr/local/bin/qemu-x86_64:POCF' | sudo tee /proc/sys/fs/binfmt_misc/register >/dev/null
+        else
+            echo "qemu-x86_64 BuildID mismatch from /usr/local/bin/qemu-x86_64; skipping binfmt registration" >&2
+            sudo rm -f /usr/local/bin/qemu-x86_64
+        fi
+    fi
     #echo "* * * * * root /usr/sbin/route add default gw 10.177.1.1 eth0" | sudo tee /etc/cron.d/fix-default-route
 '''
 
@@ -561,6 +580,10 @@ initMap['debMap'] = '''
         sudo apt-get -y install ${JAVA_VER} git
     fi
 
+    # PXB-3798: qemu-x86_64 for x86_64 helper containers on aarch64 (Debian/Ubuntu path)
+    if [ "$(uname -m)" = "aarch64" ]; then
+        sudo DEBIAN_FRONTEND=noninteractive apt-get install -y qemu-user-static binfmt-support
+    fi
     sudo install -o $(id -u -n) -g $(id -g -n) -d /mnt/jenkins
 '''
 

--- a/IaC/ps80.cd/init.groovy.d/cloud.groovy
+++ b/IaC/ps80.cd/init.groovy.d/cloud.groovy
@@ -342,6 +342,10 @@ initMap['docker'] = '''
     echo '{"experimental": true, "ipv6": true, "fixed-cidr-v6": "fd3c:a8b0:18eb:5c06::/64"}' | sudo tee /etc/docker/daemon.json
     sudo systemctl status docker || sudo systemctl start docker
     sudo service docker status || sudo service docker start
+    # PXB-3798: qemu-x86_64 for x86_64 helper containers on aarch64 (AL2 path)
+    if [ "$(uname -m)" = "aarch64" ]; then
+        sudo yum install -y qemu-user-static
+    fi
     echo "* * * * * root /usr/sbin/route add default gw 10.177.1.1 eth0" | sudo tee /etc/cron.d/fix-default-route
 '''
 initMap['docker-32gb'] = initMap['docker']
@@ -590,6 +594,20 @@ initMap['min-al2023-x64'] = '''
     echo '{"experimental": true, "ipv6": true, "fixed-cidr-v6": "fd3c:a8b0:18eb:5c06::/64"}' | sudo tee /etc/docker/daemon.json
     sudo systemctl status docker || sudo systemctl start docker
     sudo service docker status || sudo service docker start
+    # PXB-3798: extract qemu-x86_64 from tonistiigi/binfmt:qemu-v10.2.1-65 (mirrored to Percona ECR Public, pinned by index digest for supply-chain hygiene). AL2023 has no qemu-user-static in main repos.
+    if [ "$(uname -m)" = "aarch64" ] && [ ! -e /proc/sys/fs/binfmt_misc/qemu-x86_64 ]; then
+        until sudo docker pull --platform linux/arm64 public.ecr.aws/e7j3v3n0/qemu-binfmt@sha256:d3b963f787999e6c0219a48dba02978769286ff61a5f4d26245cb6a6e5567ea3; do sleep 5; done
+        cid=$(sudo docker create --platform linux/arm64 public.ecr.aws/e7j3v3n0/qemu-binfmt@sha256:d3b963f787999e6c0219a48dba02978769286ff61a5f4d26245cb6a6e5567ea3)
+        sudo docker cp "${cid}":/usr/bin/qemu-x86_64 /usr/local/bin/qemu-x86_64
+        sudo docker rm -f "${cid}"
+        sudo chmod 0755 /usr/local/bin/qemu-x86_64
+        if file /usr/local/bin/qemu-x86_64 | grep -Fq 'BuildID[sha1]=3ce82273ab59ab77b04b0bee9060c5b194769f4c'; then
+            echo ':qemu-x86_64:M::\\x7fELF\\x02\\x01\\x01\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x02\\x00\\x3e\\x00:\\xff\\xff\\xff\\xff\\xff\\xfe\\xfe\\x00\\xff\\xff\\xff\\xff\\xff\\xff\\xff\\xff\\xfe\\xff\\xff\\xff:/usr/local/bin/qemu-x86_64:POCF' | sudo tee /proc/sys/fs/binfmt_misc/register >/dev/null
+        else
+            echo "qemu-x86_64 BuildID mismatch from /usr/local/bin/qemu-x86_64; skipping binfmt registration" >&2
+            sudo rm -f /usr/local/bin/qemu-x86_64
+        fi
+    fi
     #echo "* * * * * root /usr/sbin/route add default gw 10.177.1.1 eth0" | sudo tee /etc/cron.d/fix-default-route
 '''
 initMap['min-al2023-aarch64'] = initMap['min-al2023-x64']
@@ -651,6 +669,10 @@ initMap['min-bionic-x64'] = '''
         echo try again
     done
     sudo DEBIAN_FRONTEND=noninteractive apt-get -y install openjdk-17-jre-headless git
+    # PXB-3798: qemu-x86_64 for x86_64 helper containers on aarch64 (Debian/Ubuntu path)
+    if [ "$(uname -m)" = "aarch64" ]; then
+        sudo DEBIAN_FRONTEND=noninteractive apt-get install -y qemu-user-static binfmt-support
+    fi
     sudo install -o $(id -u -n) -g $(id -g -n) -d /mnt/jenkins
 
     echo '10.30.6.9 repo.ci.percona.com' | sudo tee -a /etc/hosts
@@ -700,6 +722,10 @@ initMap['min-buster-x64'] = '''
         sudo DEBIAN_FRONTEND=noninteractive sudo apt-get -y install ${JAVA_VER}
     else
         sudo DEBIAN_FRONTEND=noninteractive sudo apt-get -y install ${JAVA_VER} git
+    fi
+    # PXB-3798: qemu-x86_64 for x86_64 helper containers on aarch64 (Debian/Ubuntu path)
+    if [ "$(uname -m)" = "aarch64" ]; then
+        sudo DEBIAN_FRONTEND=noninteractive apt-get install -y qemu-user-static binfmt-support
     fi
     sudo install -o $(id -u -n) -g $(id -g -n) -d /mnt/jenkins
 

--- a/IaC/psmdb.cd/init.groovy.d/cloud.groovy
+++ b/IaC/psmdb.cd/init.groovy.d/cloud.groovy
@@ -229,6 +229,20 @@ initMap['docker-32gb'] = '''
     echo '{"experimental": true}' | sudo tee /etc/docker/daemon.json
     sudo systemctl status docker || sudo systemctl start docker
     sudo service docker status || sudo service docker start
+    # PXB-3798: extract qemu-x86_64 from tonistiigi/binfmt:qemu-v10.2.1-65 (mirrored to Percona ECR Public, pinned by index digest for supply-chain hygiene). AL2023 has no qemu-user-static in main repos.
+    if [ "$(uname -m)" = "aarch64" ] && [ ! -e /proc/sys/fs/binfmt_misc/qemu-x86_64 ]; then
+        until sudo docker pull --platform linux/arm64 public.ecr.aws/e7j3v3n0/qemu-binfmt@sha256:d3b963f787999e6c0219a48dba02978769286ff61a5f4d26245cb6a6e5567ea3; do sleep 5; done
+        cid=$(sudo docker create --platform linux/arm64 public.ecr.aws/e7j3v3n0/qemu-binfmt@sha256:d3b963f787999e6c0219a48dba02978769286ff61a5f4d26245cb6a6e5567ea3)
+        sudo docker cp "${cid}":/usr/bin/qemu-x86_64 /usr/local/bin/qemu-x86_64
+        sudo docker rm -f "${cid}"
+        sudo chmod 0755 /usr/local/bin/qemu-x86_64
+        if file /usr/local/bin/qemu-x86_64 | grep -Fq 'BuildID[sha1]=3ce82273ab59ab77b04b0bee9060c5b194769f4c'; then
+            echo ':qemu-x86_64:M::\\x7fELF\\x02\\x01\\x01\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x02\\x00\\x3e\\x00:\\xff\\xff\\xff\\xff\\xff\\xfe\\xfe\\x00\\xff\\xff\\xff\\xff\\xff\\xff\\xff\\xff\\xfe\\xff\\xff\\xff:/usr/local/bin/qemu-x86_64:POCF' | sudo tee /proc/sys/fs/binfmt_misc/register >/dev/null
+        else
+            echo "qemu-x86_64 BuildID mismatch from /usr/local/bin/qemu-x86_64; skipping binfmt registration" >&2
+            sudo rm -f /usr/local/bin/qemu-x86_64
+        fi
+    fi
     echo "* * * * * root /usr/sbin/route add default gw 10.188.1.1 eth0" | sudo tee /etc/cron.d/fix-default-route
 '''
 
@@ -291,6 +305,7 @@ initMap['rpmMap'] = '''
     fi
 
     sudo install -o $(id -u -n) -g $(id -g -n) -d /mnt/jenkins
+    # PXB-3798: not applicable; this init block has no docker installed, see PXB-3798 description.
 '''
 
 initMap['debMap'] = '''
@@ -340,6 +355,10 @@ initMap['debMap'] = '''
         sudo DEBIAN_FRONTEND=noninteractive sudo apt-get -y install ${JAVA_VER}
     else
         sudo DEBIAN_FRONTEND=noninteractive sudo apt-get -y install ${JAVA_VER} git
+    fi
+    # PXB-3798: qemu-x86_64 for x86_64 helper containers on aarch64 (Debian/Ubuntu path)
+    if [ "$(uname -m)" = "aarch64" ]; then
+        sudo DEBIAN_FRONTEND=noninteractive apt-get install -y qemu-user-static binfmt-support
     fi
     sudo install -o $(id -u -n) -g $(id -g -n) -d /mnt/jenkins
 

--- a/IaC/pxb.cd/init.groovy.d/cloud.groovy
+++ b/IaC/pxb.cd/init.groovy.d/cloud.groovy
@@ -188,6 +188,20 @@ initMap['docker-aarch64'] = '''
     echo '{"experimental": true}' | sudo tee /etc/docker/daemon.json
     sudo systemctl status docker || sudo systemctl start docker
     sudo service docker status || sudo service docker start
+    # PXB-3798: extract qemu-x86_64 from tonistiigi/binfmt:qemu-v10.2.1-65 (mirrored to Percona ECR Public, pinned by index digest for supply-chain hygiene). AL2023 has no qemu-user-static in main repos.
+    if [ "$(uname -m)" = "aarch64" ] && [ ! -e /proc/sys/fs/binfmt_misc/qemu-x86_64 ]; then
+        until sudo docker pull --platform linux/arm64 public.ecr.aws/e7j3v3n0/qemu-binfmt@sha256:d3b963f787999e6c0219a48dba02978769286ff61a5f4d26245cb6a6e5567ea3; do sleep 5; done
+        cid=$(sudo docker create --platform linux/arm64 public.ecr.aws/e7j3v3n0/qemu-binfmt@sha256:d3b963f787999e6c0219a48dba02978769286ff61a5f4d26245cb6a6e5567ea3)
+        sudo docker cp "${cid}":/usr/bin/qemu-x86_64 /usr/local/bin/qemu-x86_64
+        sudo docker rm -f "${cid}"
+        sudo chmod 0755 /usr/local/bin/qemu-x86_64
+        if file /usr/local/bin/qemu-x86_64 | grep -Fq 'BuildID[sha1]=3ce82273ab59ab77b04b0bee9060c5b194769f4c'; then
+            echo ':qemu-x86_64:M::\\x7fELF\\x02\\x01\\x01\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x02\\x00\\x3e\\x00:\\xff\\xff\\xff\\xff\\xff\\xfe\\xfe\\x00\\xff\\xff\\xff\\xff\\xff\\xff\\xff\\xff\\xfe\\xff\\xff\\xff:/usr/local/bin/qemu-x86_64:POCF' | sudo tee /proc/sys/fs/binfmt_misc/register >/dev/null
+        else
+            echo "qemu-x86_64 BuildID mismatch from /usr/local/bin/qemu-x86_64; skipping binfmt registration" >&2
+            sudo rm -f /usr/local/bin/qemu-x86_64
+        fi
+    fi
     echo "* * * * * root /usr/sbin/route add default gw 10.177.1.1 eth0" | sudo tee /etc/cron.d/fix-default-route
 '''
 initMap['docker-32gb-aarch64'] = initMap['docker-aarch64']

--- a/IaC/pxc.cd/init.groovy.d/cloud.groovy
+++ b/IaC/pxc.cd/init.groovy.d/cloud.groovy
@@ -434,6 +434,10 @@ initMap['metalDebMap'] = '''
         bridge-utils virtinst cpu-checker
     sudo usermod -aG libvirt,kvm $(id -u -n)
     sudo systemctl enable --now libvirtd
+    # PXB-3798: qemu-x86_64 for x86_64 helper containers on aarch64 (Debian/Ubuntu path)
+    if [ "$(uname -m)" = "aarch64" ]; then
+        sudo DEBIAN_FRONTEND=noninteractive apt-get install -y qemu-user-static binfmt-support
+    fi
     sudo install -o $(id -u -n) -g $(id -g -n) -d /mnt/jenkins
 '''
 
@@ -562,6 +566,20 @@ initMap['min-al2023-x64'] = '''
     echo '{"experimental": true, "ipv6": true, "fixed-cidr-v6": "fd3c:a8b0:18eb:5c06::/64"}' | sudo tee /etc/docker/daemon.json
     sudo systemctl status docker || sudo systemctl start docker
     sudo service docker status || sudo service docker start
+    # PXB-3798: extract qemu-x86_64 from tonistiigi/binfmt:qemu-v10.2.1-65 (mirrored to Percona ECR Public, pinned by index digest for supply-chain hygiene). AL2023 has no qemu-user-static in main repos.
+    if [ "$(uname -m)" = "aarch64" ] && [ ! -e /proc/sys/fs/binfmt_misc/qemu-x86_64 ]; then
+        until sudo docker pull --platform linux/arm64 public.ecr.aws/e7j3v3n0/qemu-binfmt@sha256:d3b963f787999e6c0219a48dba02978769286ff61a5f4d26245cb6a6e5567ea3; do sleep 5; done
+        cid=$(sudo docker create --platform linux/arm64 public.ecr.aws/e7j3v3n0/qemu-binfmt@sha256:d3b963f787999e6c0219a48dba02978769286ff61a5f4d26245cb6a6e5567ea3)
+        sudo docker cp "${cid}":/usr/bin/qemu-x86_64 /usr/local/bin/qemu-x86_64
+        sudo docker rm -f "${cid}"
+        sudo chmod 0755 /usr/local/bin/qemu-x86_64
+        if file /usr/local/bin/qemu-x86_64 | grep -Fq 'BuildID[sha1]=3ce82273ab59ab77b04b0bee9060c5b194769f4c'; then
+            echo ':qemu-x86_64:M::\\x7fELF\\x02\\x01\\x01\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x02\\x00\\x3e\\x00:\\xff\\xff\\xff\\xff\\xff\\xfe\\xfe\\x00\\xff\\xff\\xff\\xff\\xff\\xff\\xff\\xff\\xfe\\xff\\xff\\xff:/usr/local/bin/qemu-x86_64:POCF' | sudo tee /proc/sys/fs/binfmt_misc/register >/dev/null
+        else
+            echo "qemu-x86_64 BuildID mismatch from /usr/local/bin/qemu-x86_64; skipping binfmt registration" >&2
+            sudo rm -f /usr/local/bin/qemu-x86_64
+        fi
+    fi
     #echo "* * * * * root /usr/sbin/route add default gw 10.177.1.1 eth0" | sudo tee /etc/cron.d/fix-default-route
 '''
 initMap['min-al2023-aarch64'] = initMap['min-al2023-x64']

--- a/IaC/rel.cd/init.groovy.d/cloud.groovy
+++ b/IaC/rel.cd/init.groovy.d/cloud.groovy
@@ -243,6 +243,10 @@ initMap['docker'] = '''
     echo '{"experimental": true, "ipv6": true, "fixed-cidr-v6": "fd3c:a8b0:18eb:5c06::/64"}' | sudo tee /etc/docker/daemon.json
     sudo systemctl status docker || sudo systemctl start docker
     sudo service docker status || sudo service docker start
+    # PXB-3798: qemu-x86_64 for x86_64 helper containers on aarch64 (AL2 path)
+    if [ "$(uname -m)" = "aarch64" ]; then
+        sudo yum install -y qemu-user-static
+    fi
     echo "* * * * * root /usr/sbin/route add default gw 10.199.1.1 eth0" | sudo tee /etc/cron.d/fix-default-route
 '''
 initMap['docker-32gb'] = initMap['docker']
@@ -286,6 +290,7 @@ initMap['micro-amazon'] = '''
     sudo yum -y install git || :
     sudo yum -y install aws-cli || :
     sudo install -o $(id -u -n) -g $(id -g -n) -d /mnt/jenkins
+    # PXB-3798: not applicable; this init block has no docker installed, see PXB-3798 description.
 '''
 initMap['min-amazon-2-x64']  = initMap['micro-amazon']
 initMap['min-al2023-x64']    = initMap['micro-amazon']
@@ -392,6 +397,10 @@ initMap['min-buster-x64'] = '''
         sudo apt-get -y install ${JAVA_VER} git
     fi
 
+    # PXB-3798: qemu-x86_64 for x86_64 helper containers on aarch64 (Debian/Ubuntu path)
+    if [ "$(uname -m)" = "aarch64" ]; then
+        sudo DEBIAN_FRONTEND=noninteractive apt-get install -y qemu-user-static binfmt-support
+    fi
     sudo install -o $(id -u -n) -g $(id -g -n) -d /mnt/jenkins
 '''
 initMap['min-jammy-x64'] = initMap['min-bionic-x64']


### PR DESCRIPTION
**Feature**

- Adds `qemu-user-static` (+ `binfmt-support` on Debian/Ubuntu, static-binary extract from Percona ECR mirror on AL2023) to 7 EC2 aarch64 worker cloud-init scripts.
- Lets x86_64 Docker images run on ARM64 EC2 hosts via CPU emulation, needed for PXB ARM64 tests whose supporting services (Minio, Vault, KMIP) ship only as x86_64 containers.

**Why**

- PXB ARM64 test pipelines on EC2 currently fail to start their helper services (`exec format error`) because no aarch64-native helper images exist; rebuilding them is out of scope.

**Tickets**

- [PXB-3798](https://perconadev.atlassian.net/browse/PXB-3798) (this), [PXB-3613](https://perconadev.atlassian.net/browse/PXB-3613) (consumer), [PXB-3745](https://perconadev.atlassian.net/browse/PXB-3745) (umbrella), [PXB-3797](https://perconadev.atlassian.net/browse/PXB-3797) / [PR 4116](https://github.com/Percona-Lab/jenkins-pipelines/pull/4116) (Hetzner companion).

[PXB-3798]: https://perconadev.atlassian.net/browse/PXB-3798?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[PXB-3613]: https://perconadev.atlassian.net/browse/PXB-3613?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[PXB-3745]: https://perconadev.atlassian.net/browse/PXB-3745?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[PXB-3797]: https://perconadev.atlassian.net/browse/PXB-3797?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ