### PR TITLE
PG-2373  Upload artifacts and standardize build retention across all PPG test pipeline jobs

### DIFF
--- a/ppg/component-generic-parallel.groovy
+++ b/ppg/component-generic-parallel.groovy
@@ -78,6 +78,8 @@ pipeline {
     }
     options {
         withCredentials(moleculeDistributionJenkinsCreds())
+        buildDiscarder(logRotator(numToKeepStr: '100'))
+        retry(conditions: [agent()], count: 2)
     }
     stages {
         stage('Set build name') {

--- a/ppg/component-generic.groovy
+++ b/ppg/component-generic.groovy
@@ -83,6 +83,8 @@ pipeline {
     }
     options {
         withCredentials(moleculeDistributionJenkinsCreds())
+        buildDiscarder(logRotator(numToKeepStr: '100'))
+        retry(conditions: [agent()], count: 2)
     }
     stages {
         stage('Set build name') {

--- a/ppg/component-multi-parallel.groovy
+++ b/ppg/component-multi-parallel.groovy
@@ -32,6 +32,8 @@ pipeline {
 
     options {
         withCredentials(moleculeDistributionJenkinsCreds())
+        buildDiscarder(logRotator(numToKeepStr: '100'))
+        retry(conditions: [agent()], count: 2)
     }
 
     stages {

--- a/ppg/docker-component-multiOS.groovy
+++ b/ppg/docker-component-multiOS.groovy
@@ -75,7 +75,9 @@ pipeline {
     }
     options {
         withCredentials(moleculeDistributionJenkinsCreds())
+        buildDiscarder(logRotator(numToKeepStr: '100'))
         disableConcurrentBuilds()
+        retry(conditions: [agent()], count: 2)
     }
     stages {
         stage('Set build name') {

--- a/ppg/docker-component-parallel.groovy
+++ b/ppg/docker-component-parallel.groovy
@@ -75,6 +75,8 @@ pipeline {
     }
     options {
         withCredentials(moleculeDistributionJenkinsCreds())
+        buildDiscarder(logRotator(numToKeepStr: '100'))
+        retry(conditions: [agent()], count: 2)
     }
     stages {
         stage('Set build name') {

--- a/ppg/docker-component.groovy
+++ b/ppg/docker-component.groovy
@@ -82,6 +82,8 @@ pipeline {
     }
     options {
         withCredentials(moleculeDistributionJenkinsCreds())
+        buildDiscarder(logRotator(numToKeepStr: '100'))
+        retry(conditions: [agent()], count: 2)
     }
     stages {
         stage('Set build name') {

--- a/ppg/docker-cve-scan.groovy
+++ b/ppg/docker-cve-scan.groovy
@@ -275,7 +275,10 @@ docker.io/percona/percona-distribution-postgresql-with-postgis:18
 docker.io/percona/percona-distribution-postgresql-with-postgis:17
 docker.io/percona/percona-distribution-postgresql-with-postgis:16
 docker.io/percona/percona-distribution-postgresql-with-postgis:15
-docker.io/percona/percona-distribution-postgresql-with-postgis:14''', description: 'List of percona official images to scan (one per line)')
+docker.io/percona/percona-distribution-postgresql-with-postgis:14
+docker.io/percona/percona-distribution-postgresql-upgrade:18-17-16-15-14
+docker.io/percona/percona-pgbouncer:latest
+docker.io/percona/percona-pgbackrest:latest''', description: 'List of percona official images to scan (one per line)')
 
         booleanParam(name: 'SCAN_PERCONALAB_OFFICIAL', defaultValue: false, description: 'Scan perconalab official images (perconalab/percona-distribution-postgresql) — manual use only')
         text(name: 'PERCONALAB_OFFICIAL_IMAGES', defaultValue: '''\

--- a/ppg/docker-server-multiOS.groovy
+++ b/ppg/docker-server-multiOS.groovy
@@ -57,7 +57,9 @@ pipeline {
     }
     options {
         withCredentials(moleculeDistributionJenkinsCreds())
+        buildDiscarder(logRotator(numToKeepStr: '100'))
         disableConcurrentBuilds()
+        retry(conditions: [agent()], count: 2)
     }
     stages {
         stage('Set build name') {

--- a/ppg/docker-server-parallel-custom-upgrade.groovy
+++ b/ppg/docker-server-parallel-custom-upgrade.groovy
@@ -44,7 +44,9 @@ pipeline {
     options {
         // Ensure this shared library function returns the correct wrapper
         withCredentials(moleculeDistributionJenkinsCreds())
+        buildDiscarder(logRotator(numToKeepStr: '100'))
         timestamps()
+        retry(conditions: [agent()], count: 2)
     }
 
     stages {

--- a/ppg/docker-server-parallel-custom.groovy
+++ b/ppg/docker-server-parallel-custom.groovy
@@ -38,7 +38,9 @@ pipeline {
     options {
         // Ensure this shared library function returns the correct wrapper
         withCredentials(moleculeDistributionJenkinsCreds())
-        timestamps() 
+        buildDiscarder(logRotator(numToKeepStr: '100'))
+        timestamps()
+        retry(conditions: [agent()], count: 2)
     }
 
     stages {

--- a/ppg/docker-server-parallel-generic.groovy
+++ b/ppg/docker-server-parallel-generic.groovy
@@ -44,6 +44,8 @@ pipeline {
     }
     options {
         withCredentials(moleculeDistributionJenkinsCreds())
+        buildDiscarder(logRotator(numToKeepStr: '100'))
+        retry(conditions: [agent()], count: 2)
     }
     stages {
         stage('Set build name') {

--- a/ppg/docker-server-parallel-upgrade.groovy
+++ b/ppg/docker-server-parallel-upgrade.groovy
@@ -46,7 +46,9 @@ pipeline {
     options {
         // Ensure this shared library function returns the correct wrapper
         withCredentials(moleculeDistributionJenkinsCreds())
+        buildDiscarder(logRotator(numToKeepStr: '100'))
         timestamps()
+        retry(conditions: [agent()], count: 2)
     }
 
     stages {

--- a/ppg/docker-server-parallel.groovy
+++ b/ppg/docker-server-parallel.groovy
@@ -57,6 +57,8 @@ pipeline {
     }
     options {
         withCredentials(moleculeDistributionJenkinsCreds())
+        buildDiscarder(logRotator(numToKeepStr: '100'))
+        retry(conditions: [agent()], count: 2)
     }
     stages {
         stage('Set build name') {

--- a/ppg/docker-server.groovy
+++ b/ppg/docker-server.groovy
@@ -64,6 +64,8 @@ pipeline {
     }
     options {
         withCredentials(moleculeDistributionJenkinsCreds())
+        buildDiscarder(logRotator(numToKeepStr: '100'))
+        retry(conditions: [agent()], count: 2)
     }
     stages {
         stage('Set build name') {

--- a/ppg/pgsm-multiOS.groovy
+++ b/ppg/pgsm-multiOS.groovy
@@ -68,6 +68,11 @@ pipeline {
     options {
         withCredentials(moleculeDistributionJenkinsCreds())
         disableConcurrentBuilds()
+        buildDiscarder(logRotator(
+            numToKeepStr: '30',
+            artifactNumToKeepStr: '30'
+        ))
+        retry(conditions: [agent()], count: 2)
     }
     stages {
         stage('Set build name') {
@@ -104,6 +109,10 @@ pipeline {
                 moleculeParallelPostDestroyPPG(ppgOperatingSystemsALL(), env.MOLECULE_DIR)
                 sendSlackNotification(env.PGSM_REPO, env.PGSM_BRANCH, env.PGSM_PACKAGE_INSTALL, env.VERSION, env.REPO, env.MAJOR_REPO)
             }
+            archiveArtifacts(
+                artifacts: 'pg_stat_monitor/pgsm/artifacts/**/*.tar.gz',
+                allowEmptyArchive: true
+            )
         }
     }
 }

--- a/ppg/pgsm-parallel.groovy
+++ b/ppg/pgsm-parallel.groovy
@@ -62,6 +62,11 @@ pipeline {
     }
     options {
         withCredentials(moleculeDistributionJenkinsCreds())
+        buildDiscarder(logRotator(
+            numToKeepStr: '30',
+            artifactNumToKeepStr: '30'
+        ))
+        retry(conditions: [agent()], count: 2)
     }
     stages {
         stage('Set build name') {
@@ -98,6 +103,10 @@ pipeline {
                 moleculeParallelPostDestroyPPG(ppgOperatingSystemsALL(), env.MOLECULE_DIR)
                 sendSlackNotification(env.PGSM_REPO, env.PGSM_BRANCH, env.PGSM_PACKAGE_INSTALL, env.VERSION, env.REPO, env.MAJOR_REPO)
             }
+            archiveArtifacts(
+                artifacts: 'pg_stat_monitor/pgsm/artifacts/**/*.tar.gz',
+                allowEmptyArchive: true
+            )
         }
     }
 }

--- a/ppg/pgsm-pgdg-parallel.groovy
+++ b/ppg/pgsm-pgdg-parallel.groovy
@@ -45,6 +45,7 @@ pipeline {
     }
     options {
         withCredentials(moleculeDistributionJenkinsCreds())
+        retry(conditions: [agent()], count: 2)
     }
     stages {
         stage('Set build name') {
@@ -81,6 +82,10 @@ pipeline {
                 moleculeParallelPostDestroyPPG(ppgOperatingSystemsALL(), env.MOLECULE_DIR)
                 sendSlackNotification(env.PGSM_REPO, env.PGSM_BRANCH, env.VERSION)
             }
+            archiveArtifacts(
+                artifacts: 'pg_stat_monitor/pgsm_pgdg/artifacts/**/*.tar.gz',
+                allowEmptyArchive: true
+            )
         }
     }
 }

--- a/ppg/pgsm-pgdg.groovy
+++ b/ppg/pgsm-pgdg.groovy
@@ -41,6 +41,7 @@ pipeline {
     }
     options {
         withCredentials(moleculeDistributionJenkinsCreds())
+        retry(conditions: [agent()], count: 2)
     }
     stages {
         stage('Set build name') {
@@ -102,6 +103,10 @@ pipeline {
                     echo "DESTROY_ENV is false. Leaving VMs active for debugging."
                 }
             }
+            archiveArtifacts(
+                artifacts: 'pg_stat_monitor/pgsm_pgdg/artifacts/**/*.tar.gz',
+                allowEmptyArchive: true
+            )
         }
     }
 }

--- a/ppg/pgsm.groovy
+++ b/ppg/pgsm.groovy
@@ -63,6 +63,11 @@ pipeline {
     }
     options {
         withCredentials(moleculeDistributionJenkinsCreds())
+        buildDiscarder(logRotator(
+            numToKeepStr: '30',
+            artifactNumToKeepStr: '30'
+        ))
+        retry(conditions: [agent()], count: 2)
     }
     stages {
         stage('Set build name') {
@@ -124,6 +129,10 @@ pipeline {
                     echo "DESTROY_ENV is false. Leaving VMs active for debugging."
                 }
             }
+            archiveArtifacts(
+                artifacts: 'pg_stat_monitor/pgsm/artifacts/**/*.tar.gz',
+                allowEmptyArchive: true
+            )
         }
     }
 }

--- a/ppg/ppg-multiOS-parallel.groovy
+++ b/ppg/ppg-multiOS-parallel.groovy
@@ -63,6 +63,8 @@ pipeline {
     }
     options {
         withCredentials(moleculeDistributionJenkinsCreds())
+        buildDiscarder(logRotator(numToKeepStr: '100'))
+        retry(conditions: [agent()], count: 2)
     }
     stages {
         stage('Set build name') {

--- a/ppg/ppg-multiOS.groovy
+++ b/ppg/ppg-multiOS.groovy
@@ -63,7 +63,9 @@ pipeline {
     }
     options {
         withCredentials(moleculeDistributionJenkinsCreds())
+        buildDiscarder(logRotator(numToKeepStr: '100'))
         disableConcurrentBuilds()
+        retry(conditions: [agent()], count: 2)
     }
     stages {
         stage('Set build name') {

--- a/ppg/ppg-upgrade-multiOS.groovy
+++ b/ppg/ppg-upgrade-multiOS.groovy
@@ -63,7 +63,9 @@ pipeline {
     }
     options {
         withCredentials(moleculeDistributionJenkinsCreds())
+        buildDiscarder(logRotator(numToKeepStr: '100'))
         disableConcurrentBuilds()
+        retry(conditions: [agent()], count: 2)
     }
     stages {
         stage('Set build name') {

--- a/ppg/ppg-upgrade-parallel.groovy
+++ b/ppg/ppg-upgrade-parallel.groovy
@@ -63,6 +63,8 @@ pipeline {
     }
     options {
         withCredentials(moleculeDistributionJenkinsCreds())
+        buildDiscarder(logRotator(numToKeepStr: '100'))
+        retry(conditions: [agent()], count: 2)
     }
     stages {
         stage('Set build name') {

--- a/ppg/ppg-upgrade.groovy
+++ b/ppg/ppg-upgrade.groovy
@@ -63,6 +63,8 @@ pipeline {
     }
     options {
         withCredentials(moleculeDistributionJenkinsCreds())
+        buildDiscarder(logRotator(numToKeepStr: '100'))
+        retry(conditions: [agent()], count: 2)
     }
     stages {
         stage('Set build name') {

--- a/ppg/ppg.groovy
+++ b/ppg/ppg.groovy
@@ -63,6 +63,8 @@ pipeline {
     }
     options {
         withCredentials(moleculeDistributionJenkinsCreds())
+        buildDiscarder(logRotator(numToKeepStr: '100'))
+        retry(conditions: [agent()], count: 2)
     }
     stages {
         stage('Set build name') {

--- a/ppg/psp-installcheck-world-multiOS.groovy
+++ b/ppg/psp-installcheck-world-multiOS.groovy
@@ -62,7 +62,12 @@ pipeline {
             ]
         )
         string(
-            defaultValue: 'release-2.2.0',
+            defaultValue: 'https://github.com/percona/pg_tde.git',
+            description: 'In case you want to test a different pg_tde repository than the default one.',
+            name: 'TDE_REPO'
+        )
+        string(
+            defaultValue: 'main',
             description: 'Branch for pg_tde repository. Would only be used with check-tde, check-all and installcheck-world testsuites.',
             name: 'TDE_BRANCH'
         )
@@ -74,6 +79,11 @@ pipeline {
     options {
         withCredentials(moleculeDistributionJenkinsCreds())
         disableConcurrentBuilds()
+        buildDiscarder(logRotator(
+            numToKeepStr: '30',
+            artifactNumToKeepStr: '30'
+        ))
+        retry(conditions: [agent()], count: 2)
     }
     stages {
         stage('Set build name') {
@@ -110,6 +120,10 @@ pipeline {
                 moleculeParallelPostDestroyPPG(ppgOperatingSystemsALL(), env.MOLECULE_DIR)
                 sendSlackNotification(env.PSP_REPO, env.PSP_BRANCH, env.VERSION, env.TESTSUITE, env.PERCONA_SERVER_VERSION, env.IO_METHOD, env.TDE_BRANCH)
             }
+            archiveArtifacts(
+                artifacts: 'psp/server_tests/artifacts/**/*.tar.gz',
+                allowEmptyArchive: true
+            )
         }
     }
 }

--- a/ppg/psp-installcheck-world-parallel.groovy
+++ b/ppg/psp-installcheck-world-parallel.groovy
@@ -62,7 +62,12 @@ pipeline {
             ]
         )
         string(
-            defaultValue: 'release-2.2.0',
+            defaultValue: 'https://github.com/percona/pg_tde.git',
+            description: 'In case you want to test a different pg_tde repository than the default one.',
+            name: 'TDE_REPO'
+        )
+        string(
+            defaultValue: 'main',
             description: 'Branch for pg_tde repository. Would only be used with check-tde, check-all and installcheck-world testsuites.',
             name: 'TDE_BRANCH'
         )
@@ -73,6 +78,11 @@ pipeline {
     }
     options {
         withCredentials(moleculeDistributionJenkinsCreds())
+        buildDiscarder(logRotator(
+            numToKeepStr: '30',
+            artifactNumToKeepStr: '30'
+        ))
+        retry(conditions: [agent()], count: 2)
     }
     stages {
         stage('Set build name') {
@@ -109,6 +119,10 @@ pipeline {
                 moleculeParallelPostDestroyPPG(ppgOperatingSystemsALL(), env.MOLECULE_DIR)
                 sendSlackNotification(env.PSP_REPO, env.PSP_BRANCH, env.VERSION, env.TESTSUITE, env.PERCONA_SERVER_VERSION, env.IO_METHOD, env.TDE_BRANCH)
             }
+            archiveArtifacts(
+                artifacts: 'psp/server_tests/artifacts/**/*.tar.gz',
+                allowEmptyArchive: true
+           )
         }
     }
 }

--- a/ppg/psp-installcheck-world.groovy
+++ b/ppg/psp-installcheck-world.groovy
@@ -57,6 +57,16 @@ pipeline {
                 'io_uring'
             ]
         )
+        string(
+            defaultValue: 'https://github.com/percona/pg_tde.git',
+            description: 'In case you want to test a different pg_tde repository than the default one.',
+            name: 'TDE_REPO'
+        )
+        string(
+            defaultValue: 'main',
+            description: 'Branch for pg_tde repository. Would only be used with check-tde, check-all and installcheck-world testsuites.',
+            name: 'TDE_BRANCH'
+        )
         booleanParam(
             name: 'DESTROY_ENV',
             defaultValue: true,
@@ -69,6 +79,11 @@ pipeline {
     }
     options {
         withCredentials(moleculeDistributionJenkinsCreds())
+        buildDiscarder(logRotator(
+            numToKeepStr: '30',
+            artifactNumToKeepStr: '30'
+        ))
+        retry(conditions: [agent()], count: 2)
     }
     stages {
         stage('Set build name') {
@@ -130,6 +145,10 @@ pipeline {
                     echo "DESTROY_ENV is false. Leaving VMs active for debugging."
                 }
             }
+            archiveArtifacts(
+                artifacts: 'psp/server_tests/artifacts/**/*.tar.gz',
+                allowEmptyArchive: true
+            )
         }
     }
 }

--- a/ppg/psp-performance-test.groovy
+++ b/ppg/psp-performance-test.groovy
@@ -83,6 +83,8 @@ pipeline {
     }
     options {
         withCredentials(moleculeDistributionJenkinsCreds())
+        buildDiscarder(logRotator(numToKeepStr: '100'))
+        retry(conditions: [agent()], count: 2)
     }
     stages {
         stage('Set build name') {

--- a/ppg/tarball-multiOS-ssl1.groovy
+++ b/ppg/tarball-multiOS-ssl1.groovy
@@ -57,7 +57,9 @@ pipeline {
     }
     options {
         withCredentials(moleculeDistributionJenkinsCreds())
+        buildDiscarder(logRotator(numToKeepStr: '100'))
         disableConcurrentBuilds()
+        retry(conditions: [agent()], count: 2)
     }
     stages {
         stage('Set build name') {

--- a/ppg/tarball-multiOS-ssl3.groovy
+++ b/ppg/tarball-multiOS-ssl3.groovy
@@ -57,7 +57,9 @@ pipeline {
     }
     options {
         withCredentials(moleculeDistributionJenkinsCreds())
+        buildDiscarder(logRotator(numToKeepStr: '100'))
         disableConcurrentBuilds()
+        retry(conditions: [agent()], count: 2)
     }
     stages {
         stage('Set build name') {

--- a/ppg/tarball-multiOS-ssl35.groovy
+++ b/ppg/tarball-multiOS-ssl35.groovy
@@ -57,7 +57,9 @@ pipeline {
     }
     options {
         withCredentials(moleculeDistributionJenkinsCreds())
+        buildDiscarder(logRotator(numToKeepStr: '100'))
         disableConcurrentBuilds()
+        retry(conditions: [agent()], count: 2)
     }
     stages {
         stage('Set build name') {

--- a/ppg/tarball-parallel-ssl1.groovy
+++ b/ppg/tarball-parallel-ssl1.groovy
@@ -57,6 +57,8 @@ pipeline {
     }
     options {
         withCredentials(moleculeDistributionJenkinsCreds())
+        buildDiscarder(logRotator(numToKeepStr: '100'))
+        retry(conditions: [agent()], count: 2)
     }
     stages {
         stage('Set build name') {

--- a/ppg/tarball-parallel-ssl3.groovy
+++ b/ppg/tarball-parallel-ssl3.groovy
@@ -57,6 +57,8 @@ pipeline {
     }
     options {
         withCredentials(moleculeDistributionJenkinsCreds())
+        buildDiscarder(logRotator(numToKeepStr: '100'))
+        retry(conditions: [agent()], count: 2)
     }
     stages {
         stage('Set build name') {

--- a/ppg/tarball-parallel-ssl35.groovy
+++ b/ppg/tarball-parallel-ssl35.groovy
@@ -57,6 +57,8 @@ pipeline {
     }
     options {
         withCredentials(moleculeDistributionJenkinsCreds())
+        buildDiscarder(logRotator(numToKeepStr: '100'))
+        retry(conditions: [agent()], count: 2)
     }
     stages {
         stage('Set build name') {

--- a/ppg/tarball.groovy
+++ b/ppg/tarball.groovy
@@ -59,6 +59,8 @@ pipeline {
     }
     options {
         withCredentials(moleculeDistributionJenkinsCreds())
+        buildDiscarder(logRotator(numToKeepStr: '100'))
+        retry(conditions: [agent()], count: 2)
     }
     stages {
         stage('Set build name') {

--- a/ppg/tde-auxiliary-parallel.groovy
+++ b/ppg/tde-auxiliary-parallel.groovy
@@ -95,6 +95,11 @@ pipeline {
     }
     options {
         withCredentials(moleculeDistributionJenkinsCreds())
+        buildDiscarder(logRotator(
+            numToKeepStr: '30',
+            artifactNumToKeepStr: '30'
+        ))
+        retry(conditions: [agent()], count: 2)
     }
     stages {
         stage('Set build name') {
@@ -131,6 +136,10 @@ pipeline {
                 moleculeParallelPostDestroyPPG(ppgOperatingSystemsALL(), env.MOLECULE_DIR)
                 sendSlackNotification(env.PSP_REPO, env.PSP_BRANCH, env.VERSION, env.IO_METHOD, env.TDE_BRANCH)
             }
+            archiveArtifacts(
+                artifacts: 'pg_tde/auxiliary/artifacts/**/*.tar.gz',
+                allowEmptyArchive: true
+            )
         }
     }
 }

--- a/ppg/tde-auxiliary.groovy
+++ b/ppg/tde-auxiliary.groovy
@@ -96,6 +96,11 @@ pipeline {
     }
     options {
         withCredentials(moleculeDistributionJenkinsCreds())
+        buildDiscarder(logRotator(
+            numToKeepStr: '30',
+            artifactNumToKeepStr: '30'
+        ))
+        retry(conditions: [agent()], count: 2)
     }
     stages {
         stage('Set build name') {
@@ -157,6 +162,10 @@ pipeline {
                     echo "DESTROY_ENV is false. Leaving VMs active for debugging."
                 }
             }
+            archiveArtifacts(
+                artifacts: 'pg_tde/auxiliary/artifacts/**/*.tar.gz',
+                allowEmptyArchive: true
+            )
         }
     }
 }

--- a/ppg/tde-multiOS.groovy
+++ b/ppg/tde-multiOS.groovy
@@ -68,6 +68,11 @@ pipeline {
     options {
         withCredentials(moleculeDistributionJenkinsCreds())
         disableConcurrentBuilds()
+        buildDiscarder(logRotator(
+            numToKeepStr: '30',
+            artifactNumToKeepStr: '30'
+        ))
+        retry(conditions: [agent()], count: 2)
     }
     stages {
         stage('Set build name') {
@@ -104,6 +109,10 @@ pipeline {
                 moleculeParallelPostDestroyPPG(ppgOperatingSystemsALL(), env.MOLECULE_DIR)
                 sendSlackNotification(env.TDE_REPO, env.TDE_BRANCH, env.VERSION, env.REPO, env.MAJOR_REPO)
             }
+            archiveArtifacts(
+                artifacts: 'pg_tde/tde/artifacts/**/*.tar.gz',
+                allowEmptyArchive: true
+            )
         }
     }
 }

--- a/ppg/tde-parallel.groovy
+++ b/ppg/tde-parallel.groovy
@@ -67,6 +67,11 @@ pipeline {
     }
     options {
         withCredentials(moleculeDistributionJenkinsCreds())
+        buildDiscarder(logRotator(
+            numToKeepStr: '30',
+            artifactNumToKeepStr: '30'
+        ))
+        retry(conditions: [agent()], count: 2)
     }
     stages {
         stage('Set build name') {
@@ -103,6 +108,10 @@ pipeline {
                 moleculeParallelPostDestroyPPG(ppgOperatingSystemsALL(), env.MOLECULE_DIR)
                 sendSlackNotification(env.TDE_REPO, env.TDE_BRANCH, env.VERSION, env.REPO, env.MAJOR_REPO)
             }
+            archiveArtifacts(
+                artifacts: 'pg_tde/tde/artifacts/**/*.tar.gz',
+                allowEmptyArchive: true
+            )
         }
     }
 }

--- a/ppg/tde.groovy
+++ b/ppg/tde.groovy
@@ -68,6 +68,11 @@ pipeline {
     }
     options {
         withCredentials(moleculeDistributionJenkinsCreds())
+        buildDiscarder(logRotator(
+            numToKeepStr: '30',
+            artifactNumToKeepStr: '30'
+        ))
+        retry(conditions: [agent()], count: 2)
     }
     stages {
         stage('Set build name') {
@@ -129,6 +134,10 @@ pipeline {
                     echo "DESTROY_ENV is false. Leaving VMs active for debugging."
                 }
             }
+            archiveArtifacts(
+                artifacts: 'pg_tde/tde/artifacts/**/*.tar.gz',
+                allowEmptyArchive: true
+            )
         }
     }
 }


### PR DESCRIPTION
Set numToKeepStr/artifactNumToKeepStr to '30' for jobs with artifact upload (psp, tde, tde-auxiliary, pgsm variants). Add numToKeepStr '100' to non-artifact jobs that had no retention policy. Remove stale '10' retention settings from remaining jobs. 