### PR TITLE
PS-11206: ps80.cd add DeletionPolicy: Retain to CFN resources (cutover prep)

### DIFF
--- a/IaC/ps80.cd/JenkinsStack.yml
+++ b/IaC/ps80.cd/JenkinsStack.yml
@@ -53,6 +53,8 @@ Resources:
 
   JVPC: # separate virtual network for jenkins instances
     Type: AWS::EC2::VPC
+    DeletionPolicy: Retain
+    UpdateReplacePolicy: Retain
     Properties:
       CidrBlock: 10.155.0.0/22
       EnableDnsSupport: true
@@ -66,6 +68,8 @@ Resources:
 
   JInternetGateway: # Internet Gateway for jenkins VPC
     Type: AWS::EC2::InternetGateway
+    DeletionPolicy: Retain
+    UpdateReplacePolicy: Retain
     Properties:
       Tags:
       - Key: Name
@@ -75,12 +79,16 @@ Resources:
 
   JVPCGatewayAttachment: # Attach Gateway to VPC
     Type: AWS::EC2::VPCGatewayAttachment
+    DeletionPolicy: Retain
+    UpdateReplacePolicy: Retain
     Properties:
       VpcId: !Ref JVPC
       InternetGatewayId: !Ref JInternetGateway
 
   JSubnetB: # create subnet in AZ
     Type: AWS::EC2::Subnet
+    DeletionPolicy: Retain
+    UpdateReplacePolicy: Retain
     Properties:
       VpcId: !Ref JVPC
       CidrBlock: 10.155.1.0/24
@@ -95,6 +103,8 @@ Resources:
 
   JSubnetC: # create subnet in AZ
     Type: AWS::EC2::Subnet
+    DeletionPolicy: Retain
+    UpdateReplacePolicy: Retain
     Properties:
       VpcId: !Ref JVPC
       CidrBlock: 10.155.2.0/24
@@ -109,6 +119,8 @@ Resources:
 
   JRouteTable: # create route table for VPC
     Type: AWS::EC2::RouteTable
+    DeletionPolicy: Retain
+    UpdateReplacePolicy: Retain
     Properties:
       VpcId: !Ref JVPC
       Tags:
@@ -119,6 +131,8 @@ Resources:
 
   JInternetRoute: # add default route
     Type: AWS::EC2::Route
+    DeletionPolicy: Retain
+    UpdateReplacePolicy: Retain
     Properties:
       DestinationCidrBlock: 0.0.0.0/0
       GatewayId: !Ref JInternetGateway
@@ -126,18 +140,24 @@ Resources:
 
   SubnetBRouteTable: # add subnet route
     Type: AWS::EC2::SubnetRouteTableAssociation
+    DeletionPolicy: Retain
+    UpdateReplacePolicy: Retain
     Properties:
       RouteTableId: !Ref JRouteTable
       SubnetId: !Ref JSubnetB
 
   SubnetCRouteTable: # add subnet route
     Type: AWS::EC2::SubnetRouteTableAssociation
+    DeletionPolicy: Retain
+    UpdateReplacePolicy: Retain
     Properties:
       RouteTableId: !Ref JRouteTable
       SubnetId: !Ref JSubnetC
 
   S3Endpoint: # route S3 traffic over private network
     Type: AWS::EC2::VPCEndpoint
+    DeletionPolicy: Retain
+    UpdateReplacePolicy: Retain
     Properties:
       PolicyDocument:
         Version: 2012-10-17
@@ -165,11 +185,15 @@ Resources:
 
   TerminationQueue: # queue for termination notifications
     Type: AWS::SQS::Queue
+    DeletionPolicy: Retain
+    UpdateReplacePolicy: Retain
     Properties:
       QueueName: !Join [ '-', [ !Ref JShortName, 'termination' ]]
 
   TerminationQueuePolicy:
     Type: AWS::SQS::QueuePolicy
+    DeletionPolicy: Retain
+    UpdateReplacePolicy: Retain
     Properties:
       Queues:
         - !Ref TerminationQueue
@@ -190,6 +214,8 @@ Resources:
 
   TerminationRule1: # notify about instance interruption from aws side
     Type: AWS::Events::Rule
+    DeletionPolicy: Retain
+    UpdateReplacePolicy: Retain
     Properties:
       Description: EC2 Spot Instance Interruption Warning
       EventPattern:
@@ -204,6 +230,8 @@ Resources:
 
   SSHSecurityGroup: # allow ssh access (assign when needed)
     Type: AWS::EC2::SecurityGroup
+    DeletionPolicy: Retain
+    UpdateReplacePolicy: Retain
     Properties:
       GroupName: SSH
       GroupDescription: SSH traffic in
@@ -239,6 +267,8 @@ Resources:
 
   HTTPSecurityGroup: # allow http and https access to jenkins master
     Type: AWS::EC2::SecurityGroup
+    DeletionPolicy: Retain
+    UpdateReplacePolicy: Retain
     Properties:
       GroupName: HTTP
       GroupDescription: HTTP and HTTPS traffic in
@@ -258,6 +288,8 @@ Resources:
 
   JWorkerRole: # create Role for jenkins workers (needed for assign tags)
     Type: AWS::IAM::Role
+    DeletionPolicy: Retain
+    UpdateReplacePolicy: Retain
     Properties:
       RoleName: !Join [ '-', [ !Ref JShortName, 'worker' ]]
       AssumeRolePolicyDocument:
@@ -295,6 +327,8 @@ Resources:
 
   JWorkerProfile: # create Profile for jenkins workers (needed for assign tags)
     Type: AWS::IAM::InstanceProfile
+    DeletionPolicy: Retain
+    UpdateReplacePolicy: Retain
     Properties:
       Path: /
       Roles:
@@ -303,6 +337,8 @@ Resources:
 
   JMasterRole: # create Role for jenkins master (needed for run workers)
     Type: AWS::IAM::Role
+    DeletionPolicy: Retain
+    UpdateReplacePolicy: Retain
     Properties:
       RoleName: !Join [ '-', [ !Ref JShortName, 'master' ]]
       AssumeRolePolicyDocument:
@@ -391,6 +427,8 @@ Resources:
 
   JMasterProfile: # create Profile for jenkins master (needed for run workers)
     Type: AWS::IAM::InstanceProfile
+    DeletionPolicy: Retain
+    UpdateReplacePolicy: Retain
     Properties:
       Path: /
       Roles:
@@ -413,12 +451,16 @@ Resources:
 
   MasterIP: # create public IP for jenkins master
     Type: AWS::EC2::EIP
+    DeletionPolicy: Retain
+    UpdateReplacePolicy: Retain
     DependsOn: JVPC
     Properties:
       Domain: vpc
 
   JDNSRecord: # create DNS record for jenkins master
     Type: AWS::Route53::RecordSet
+    DeletionPolicy: Retain
+    UpdateReplacePolicy: Retain
     Properties:
       HostedZoneId: !Ref ZoneId
       Name: !Ref JHostName
@@ -429,7 +471,8 @@ Resources:
 
   JDataVolume: # create volume for jenkins data directory
     Type: AWS::EC2::Volume
-    DeletionPolicy: Snapshot
+    DeletionPolicy: Retain
+    UpdateReplacePolicy: Retain
     Properties:
       AutoEnableIO: false
       AvailabilityZone:


### PR DESCRIPTION
**Feature**
- Adds `DeletionPolicy: Retain` + `UpdateReplacePolicy: Retain` to 22 load-bearing CFN resources in `jenkins-ps80` (VPC, subnets, IGW, route tables, SGs, IAM roles + profiles, EIP, EBS data volume, Route53 record, SQS, EventBridge).

**Why**
- Pre-cutover step for [PS-11206](https://perconadev.atlassian.net/browse/PS-11206), migrating ps80 from CFN spot to Terraform on-demand.
- Without Retain, post-cutover `delete-stack` removes the EBS data volume, EIP, IAM roles, and VPC. With Retain, those resources survive and get adopted into TF state via `tofu import`.
- `SpotFleetRole`, `JMasterTemplate`, `JMasterInstance` intentionally NOT retained so the spot path drops cleanly on `delete-stack`.

**Tickets**
- [PS-11206](https://perconadev.atlassian.net/browse/PS-11206) (this, cutover prep)
- Sibling: [percona-cd-platform PR 7](https://github.com/percona/percona-cd-platform/pull/7) (TF migration + on-demand instance)
- Pattern: [PS-10945](https://perconadev.atlassian.net/browse/PS-10945) (ps3 CFN-to-TF cutover)

[PS-11206]: https://perconadev.atlassian.net/browse/PS-11206?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[PS-11206]: https://perconadev.atlassian.net/browse/PS-11206?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[PS-10945]: https://perconadev.atlassian.net/browse/PS-10945?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ