### PR TITLE
PXC-5234: Install libquadmath-devel for OracleLinux 10 build image

### DIFF
--- a/pxc/docker/install-deps
+++ b/pxc/docker/install-deps
@@ -177,6 +177,9 @@ if [ -f /usr/bin/yum ]; then
 
     if [[ ${RHVER} -eq 10 ]]; then
         PKGLIST+=" lz4 perl-Memoize perl-open valgrind-devel libubsan rpcgen libtirpc-devel boost-devel"
+        if [[ "$(rpm --eval %{_arch})" == "x86_64" ]]; then
+            PKGLIST+=" libquadmath-devel"
+        fi
 
         PKGLIST_DEVTOOLSET15+=" gcc-toolset-15-gcc gcc-toolset-15-gcc-c++ gcc-toolset-15-binutils"
         PKGLIST_DEVTOOLSET15+=" gcc-toolset-15-gcc-plugin-annobin"


### PR DESCRIPTION
**Bug**
- PXC 8.4 builds on the OracleLinux 10 image are missing `libquadmath-devel`. MySQL 8.4's updated Boost requires the `<quadmath.h>` header, the same failure fixed for Percona Server in [PS-11165](https://perconadev.atlassian.net/browse/PS-11165).

**Fix**
- Add `libquadmath-devel` to the OL10 package list in `pxc/docker/install-deps`, guarded to `x86_64`. The package is absent on OL10 aarch64, where Boost does not need the header, so the guard keeps the aarch64 image build green.

**Tickets**
- This fix: [PXC-5234](https://perconadev.atlassian.net/browse/PXC-5234). PS sibling: [PS-11165](https://perconadev.atlassian.net/browse/PS-11165). Origin: [PS-10569](https://perconadev.atlassian.net/browse/PS-10569).
- Companion: [ps-build PR 516](https://github.com/Percona-Lab/ps-build/pull/516).


[PS-11165]: https://perconadev.atlassian.net/browse/PS-11165?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[PXC-5234]: https://perconadev.atlassian.net/browse/PXC-5234?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[PS-11165]: https://perconadev.atlassian.net/browse/PS-11165?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[PS-10569]: https://perconadev.atlassian.net/browse/PS-10569?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ