### PR TITLE
PS-11173: Stop launch-template changes from replacing Jenkins masters

### DIFF
--- a/IaC/cloud.cd/JenkinsStack.yml
+++ b/IaC/cloud.cd/JenkinsStack.yml
@@ -3,6 +3,11 @@
 AWSTemplateFormatVersion: 2010-09-09
 Parameters:
 
+  MasterLtVersion:
+    Default: "$Latest"
+    Description: SpotFleet launch template version. Latest tracks the newest version (non-disruptive); a specific number pins it (forces one replacement).
+    Type: String
+
   JHostName:
     Default: cloud.cd.percona.com
     Description: Fully Qualified Domain Name
@@ -477,7 +482,7 @@ Resources:
         LaunchTemplateConfigs:
         - LaunchTemplateSpecification:
             LaunchTemplateId: !Ref JMasterTemplate
-            Version: !GetAtt JMasterTemplate.LatestVersionNumber
+            Version: !Ref MasterLtVersion
           Overrides:
           - InstanceType: c5a.xlarge
             AvailabilityZone:

--- a/IaC/pg.cd/JenkinsStack.yml
+++ b/IaC/pg.cd/JenkinsStack.yml
@@ -3,6 +3,11 @@
 AWSTemplateFormatVersion: 2010-09-09
 Parameters:
 
+  MasterLtVersion:
+    Default: "$Latest"
+    Description: SpotFleet launch template version. Latest tracks the newest version (non-disruptive); a specific number pins it (forces one replacement).
+    Type: String
+
   JHostName:
     Default: pg.cd.percona.com
     Description: Fully Qualified Domain Name
@@ -508,7 +513,7 @@ Resources:
         LaunchTemplateConfigs:
         - LaunchTemplateSpecification:
             LaunchTemplateId: !Ref JMasterTemplate
-            Version: !GetAtt JMasterTemplate.LatestVersionNumber
+            Version: !Ref MasterLtVersion
           Overrides:
           - InstanceType: i3en.large
             AvailabilityZone:

--- a/IaC/pmm.cd/JenkinsStack.yml
+++ b/IaC/pmm.cd/JenkinsStack.yml
@@ -5,6 +5,11 @@
 ---
 AWSTemplateFormatVersion: 2010-09-09
 Parameters:
+  MasterLtVersion:
+    Default: "$Latest"
+    Description: SpotFleet launch template version. Latest tracks the newest version (non-disruptive); a specific number pins it (forces one replacement).
+    Type: String
+
   JHostName:
     Default: pmm.cd.percona.com
     Description: Fully Qualified Domain Name
@@ -527,7 +532,7 @@ Resources:
         LaunchTemplateConfigs:
           - LaunchTemplateSpecification:
               LaunchTemplateId: !Ref JMasterTemplate
-              Version: !GetAtt JMasterTemplate.LatestVersionNumber
+              Version: !Ref MasterLtVersion
             Overrides:
               - InstanceType: g4ad.xlarge
                 AvailabilityZone:

--- a/IaC/ps57.cd/JenkinsStack.yml
+++ b/IaC/ps57.cd/JenkinsStack.yml
@@ -3,6 +3,11 @@
 AWSTemplateFormatVersion: 2010-09-09
 Parameters:
 
+  MasterLtVersion:
+    Default: "$Latest"
+    Description: SpotFleet launch template version. Latest tracks the newest version (non-disruptive); a specific number pins it (forces one replacement).
+    Type: String
+
   JHostName:
     Default: ps57.cd.percona.com
     Description: Fully Qualified Domain Name
@@ -459,7 +464,7 @@ Resources:
         LaunchTemplateConfigs:
         - LaunchTemplateSpecification:
             LaunchTemplateId: !Ref JMasterTemplate
-            Version: !GetAtt JMasterTemplate.LatestVersionNumber
+            Version: !Ref MasterLtVersion
           Overrides:
           - InstanceType: m5a.large
             AvailabilityZone:

--- a/IaC/ps80.cd/JenkinsStack.yml
+++ b/IaC/ps80.cd/JenkinsStack.yml
@@ -3,6 +3,11 @@
 AWSTemplateFormatVersion: 2010-09-09
 Parameters:
 
+  MasterLtVersion:
+    Default: "$Latest"
+    Description: SpotFleet launch template version. Latest tracks the newest version (non-disruptive); a specific number pins it (forces one replacement).
+    Type: String
+
   JHostName:
     Default: ps80.cd.percona.com
     Description: Fully Qualified Domain Name
@@ -458,7 +463,7 @@ Resources:
         LaunchTemplateConfigs:
         - LaunchTemplateSpecification:
             LaunchTemplateId: !Ref JMasterTemplate
-            Version: !GetAtt JMasterTemplate.LatestVersionNumber
+            Version: !Ref MasterLtVersion
           Overrides:
           - InstanceType: c5a.xlarge
             AvailabilityZone:

--- a/IaC/psmdb.cd/JenkinsStack.yml
+++ b/IaC/psmdb.cd/JenkinsStack.yml
@@ -3,6 +3,11 @@
 AWSTemplateFormatVersion: 2010-09-09
 Parameters:
 
+  MasterLtVersion:
+    Default: "$Latest"
+    Description: SpotFleet launch template version. Latest tracks the newest version (non-disruptive); a specific number pins it (forces one replacement).
+    Type: String
+
   JHostName:
     Default: psmdb.cd.percona.com
     Description: Fully Qualified Domain Name
@@ -402,7 +407,7 @@ Resources:
         LaunchTemplateConfigs:
         - LaunchTemplateSpecification:
             LaunchTemplateId: !Ref JMasterTemplate
-            Version: !GetAtt JMasterTemplate.LatestVersionNumber
+            Version: !Ref MasterLtVersion
           Overrides:
           - InstanceType: c5d.2xlarge
             AvailabilityZone:

--- a/IaC/pxc.cd/JenkinsStack.yml
+++ b/IaC/pxc.cd/JenkinsStack.yml
@@ -3,6 +3,11 @@
 AWSTemplateFormatVersion: 2010-09-09
 Parameters:
 
+  MasterLtVersion:
+    Default: "$Latest"
+    Description: SpotFleet launch template version. Latest tracks the newest version (non-disruptive); a specific number pins it (forces one replacement).
+    Type: String
+
   JHostName:
     Default: pxc.cd.percona.com
     Description: Fully Qualified Domain Name
@@ -459,7 +464,7 @@ Resources:
         LaunchTemplateConfigs:
         - LaunchTemplateSpecification:
             LaunchTemplateId: !Ref JMasterTemplate
-            Version: !GetAtt JMasterTemplate.LatestVersionNumber
+            Version: !Ref MasterLtVersion
           Overrides:
           - InstanceType: c5a.xlarge
             AvailabilityZone:

--- a/IaC/rel.cd/JenkinsStack.yml
+++ b/IaC/rel.cd/JenkinsStack.yml
@@ -3,6 +3,11 @@
 AWSTemplateFormatVersion: 2010-09-09
 Parameters:
 
+  MasterLtVersion:
+    Default: "$Latest"
+    Description: SpotFleet launch template version. Latest tracks the newest version (non-disruptive); a specific number pins it (forces one replacement).
+    Type: String
+
   JHostName:
     Default: rel.cd.percona.com
     Description: Fully Qualified Domain Name
@@ -456,7 +461,7 @@ Resources:
         LaunchTemplateConfigs:
         - LaunchTemplateSpecification:
             LaunchTemplateId: !Ref JMasterTemplate
-            Version: !GetAtt JMasterTemplate.LatestVersionNumber
+            Version: !Ref MasterLtVersion
           Overrides:
           - InstanceType: c5a.xlarge
             AvailabilityZone:


### PR DESCRIPTION
**Feature**
- Jenkins master SpotFleets read the LT version from a new `MasterLtVersion` parameter (default `$Latest`), so launch-template / userData changes apply on the next launch in place instead of forcing a master replacement.

**Why**
- The pinned `!GetAtt JMasterTemplate.LatestVersionNumber` turned every userData change into a SpotFleet replacement (a multi-minute master outage), surfaced during the [PS-11173](https://perconadev.atlassian.net/browse/PS-11173) rehydrate-flag rollout.
- Default `$Latest` lets CloudFormation publish a new LT version that the SpotFleet adopts on the next launch, no SpotFleet diff and no forced replacement.
- Override `MasterLtVersion` with a specific version number to pin a reviewed LT when you want control (pinning then costs one replacement, by choice).

**Tickets**
- [PS-11173](https://perconadev.atlassian.net/browse/PS-11173): Unblocks its durable rehydrate rollout

[PS-11173]: https://perconadev.atlassian.net/browse/PS-11173?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[PS-11173]: https://perconadev.atlassian.net/browse/PS-11173?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ