### PR TITLE
PS-11179: Auto AWS Graviton fallback for ARM builds

### DIFF
--- a/IaC/ps3.cd/init.groovy.d/hetznerArmHealth.groovy
+++ b/IaC/ps3.cd/init.groovy.d/hetznerArmHealth.groovy
@@ -1,0 +1,145 @@
+// hetznerArmHealth.groovy  (PS-11179)
+//
+// Master-side health probe that publishes whether Hetzner arm64 (CAX) capacity is
+// currently usable, as Jenkins GLOBAL env vars consumed by vars/resolveArmWorker:
+//
+//     HETZNER_ARM64_HEALTHY    "true" | "false"
+//     HETZNER_ARM64_HEALTH_AT  epoch seconds of the last SUCCESSFUL observation
+//     HETZNER_ARM64_REASON     short human-readable verdict
+//
+// Runs ON THIS CONTROLLER (not a worker). Every 60s on the Jenkins Timer pool it
+// reads this master's OWN loopback metrics endpoint
+// (http://127.0.0.1:8080/hetzner-prometheus) and inspects
+// hetzner_dc_circuit_breaker_state{arch="arm64"} for every arm64 DC.
+//
+// Verdict:
+//   - UNHEALTHY when every arm64 DC breaker is non-CLOSED (state >= 1, i.e. OPEN or
+//     HALF_OPEN): no German DC can currently fulfil an arm64 server.
+//   - HEALTHY otherwise (at least one arm64 DC breaker CLOSED, or no arm64 series yet).
+// It reads the metrics TEXT only; it never calls DcCircuitBreaker.getState() from
+// Groovy (that would mutate breaker state / arm a HALF_OPEN probe lease).
+//
+// Hysteresis: flip to UNHEALTHY immediately (divert away from dead capacity fast),
+// but require CLEAR_POLLS consecutive healthy observations before flipping back to
+// HEALTHY (avoid flapping a half-recovered DC back and forth).
+//
+// Fail-safe by OMISSION: on any fetch/parse error we DO NOT touch the flag, so it
+// goes stale and resolveArmWorker treats stale/absent as healthy (-> Hetzner, the
+// current behaviour). UNHEALTHY is published only on POSITIVE fresh evidence, so a
+// metrics glitch can never force the costly AWS fallback on.
+//
+// In-memory by design: the env vars live in globalNodeProperties and are NOT saved
+// to disk (no per-minute config churn). After a restart this script republishes
+// within ~1 min; until then resolveArmWorker's stale/absent fail-safe holds.
+//
+// Idempotent re-deploy: re-evaluating this file (jenkins iac deploy / boot) bumps a
+// generation token; the previously scheduled task sees the mismatch on its next tick
+// and self-terminates, so exactly one probe converges within 60s.
+
+import jenkins.model.Jenkins
+import jenkins.util.Timer
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.CancellationException
+import java.util.logging.Logger
+
+final Logger LOG = Logger.getLogger('hetznerArmHealth')
+final String METRICS_URL = 'http://127.0.0.1:8080/hetzner-prometheus/'   // trailing slash avoids a 302
+final int CLEAR_POLLS = 2          // consecutive healthy polls before re-enabling Hetzner
+final long PERIOD_SEC = 60L
+final long INITIAL_DELAY_SEC = 15L
+
+// Generation token: supersede any schedule left by an earlier eval of this file.
+final String GEN = UUID.randomUUID().toString()
+System.setProperty('hetznerArmHealth.gen', GEN)
+
+def parseArmBreakerStates = { String body ->
+    def states = []
+    body.eachLine { String line ->
+        if (line.startsWith('hetzner_dc_circuit_breaker_state') && line.contains('arch="arm64"')) {
+            def m = (line =~ /\}\s+([0-9.eE+-]+)\s*$/)
+            if (m.find()) { states << (m.group(1) as double) }
+        }
+    }
+    return states
+}
+
+def publishEnv = { boolean healthy, long atSec, String reason ->
+    def props = Jenkins.instance.globalNodeProperties
+    def envProp = props.get(hudson.slaves.EnvironmentVariablesNodeProperty)
+    if (envProp == null) {
+        envProp = new hudson.slaves.EnvironmentVariablesNodeProperty()
+        props.add(envProp)
+    }
+    def vars = envProp.envVars
+    vars.put('HETZNER_ARM64_HEALTHY', healthy ? 'true' : 'false')
+    vars.put('HETZNER_ARM64_HEALTH_AT', atSec.toString())
+    vars.put('HETZNER_ARM64_REASON', reason)
+}
+
+Runnable probe = {
+    try {
+        if (System.getProperty('hetznerArmHealth.gen') != GEN) {
+            throw new CancellationException('superseded by newer hetznerArmHealth eval')
+        }
+
+        String body
+        try {
+            def conn = (java.net.HttpURLConnection) new URL(METRICS_URL).openConnection()
+            conn.connectTimeout = 4000
+            conn.readTimeout = 4000
+            int code = conn.responseCode
+            if (code != 200) {
+                LOG.warning("hetznerArmHealth: metrics HTTP ${code}; leaving flag untouched (stale->healthy fail-safe)")
+                return
+            }
+            body = conn.inputStream.getText('UTF-8')
+        } catch (CancellationException ce) {
+            throw ce
+        } catch (Exception fe) {
+            LOG.warning("hetznerArmHealth: metrics fetch failed (${fe.message}); leaving flag untouched (stale->healthy fail-safe)")
+            return
+        }
+
+        def states = parseArmBreakerStates(body)
+        boolean observedHealthy
+        String reason
+        if (states.isEmpty()) {
+            observedHealthy = true
+            reason = 'no arm64 DC breaker series (assuming healthy)'
+        } else {
+            int closed = states.count { it < 1.0d }
+            observedHealthy = (closed > 0)
+            reason = observedHealthy ?
+                "${closed}/${states.size()} arm64 DC breakers CLOSED".toString() :
+                "all ${states.size()} arm64 DC breakers non-CLOSED (OPEN/HALF_OPEN)".toString()
+        }
+
+        boolean priorHealthy = (System.getProperty('hetznerArmHealth.published', 'true') != 'false')
+        int priorStreak = (System.getProperty('hetznerArmHealth.streak', '0')) as int
+        boolean publishHealthy
+        int streak
+        if (!observedHealthy) {
+            publishHealthy = false
+            streak = 0
+        } else {
+            streak = priorStreak + 1
+            publishHealthy = priorHealthy || (streak >= CLEAR_POLLS)
+            if (!publishHealthy) {
+                reason = "recovering (${streak}/${CLEAR_POLLS} healthy polls); holding AWS fallback".toString()
+            }
+        }
+        System.setProperty('hetznerArmHealth.published', publishHealthy ? 'true' : 'false')
+        System.setProperty('hetznerArmHealth.streak', streak.toString())
+
+        long nowSec = (long) (System.currentTimeMillis() / 1000L)
+        publishEnv(publishHealthy, nowSec, reason)
+        LOG.fine("hetznerArmHealth: healthy=${publishHealthy} (${reason})")
+    } catch (CancellationException supersede) {
+        throw supersede   // let scheduleAtFixedRate suppress this stale generation
+    } catch (Throwable t) {
+        LOG.warning("hetznerArmHealth: unexpected ${t}")   // swallow so the probe keeps running
+    }
+}
+
+Timer.get().scheduleAtFixedRate(probe, INITIAL_DELAY_SEC, PERIOD_SEC, TimeUnit.SECONDS)
+LOG.info("hetznerArmHealth: scheduled (gen=${GEN}, every ${PERIOD_SEC}s, loopback ${METRICS_URL})")

--- a/IaC/ps57.cd/init.groovy.d/hetznerArmHealth.groovy
+++ b/IaC/ps57.cd/init.groovy.d/hetznerArmHealth.groovy
@@ -1,0 +1,145 @@
+// hetznerArmHealth.groovy  (PS-11179)
+//
+// Master-side health probe that publishes whether Hetzner arm64 (CAX) capacity is
+// currently usable, as Jenkins GLOBAL env vars consumed by vars/resolveArmWorker:
+//
+//     HETZNER_ARM64_HEALTHY    "true" | "false"
+//     HETZNER_ARM64_HEALTH_AT  epoch seconds of the last SUCCESSFUL observation
+//     HETZNER_ARM64_REASON     short human-readable verdict
+//
+// Runs ON THIS CONTROLLER (not a worker). Every 60s on the Jenkins Timer pool it
+// reads this master's OWN loopback metrics endpoint
+// (http://127.0.0.1:8080/hetzner-prometheus) and inspects
+// hetzner_dc_circuit_breaker_state{arch="arm64"} for every arm64 DC.
+//
+// Verdict:
+//   - UNHEALTHY when every arm64 DC breaker is non-CLOSED (state >= 1, i.e. OPEN or
+//     HALF_OPEN): no German DC can currently fulfil an arm64 server.
+//   - HEALTHY otherwise (at least one arm64 DC breaker CLOSED, or no arm64 series yet).
+// It reads the metrics TEXT only; it never calls DcCircuitBreaker.getState() from
+// Groovy (that would mutate breaker state / arm a HALF_OPEN probe lease).
+//
+// Hysteresis: flip to UNHEALTHY immediately (divert away from dead capacity fast),
+// but require CLEAR_POLLS consecutive healthy observations before flipping back to
+// HEALTHY (avoid flapping a half-recovered DC back and forth).
+//
+// Fail-safe by OMISSION: on any fetch/parse error we DO NOT touch the flag, so it
+// goes stale and resolveArmWorker treats stale/absent as healthy (-> Hetzner, the
+// current behaviour). UNHEALTHY is published only on POSITIVE fresh evidence, so a
+// metrics glitch can never force the costly AWS fallback on.
+//
+// In-memory by design: the env vars live in globalNodeProperties and are NOT saved
+// to disk (no per-minute config churn). After a restart this script republishes
+// within ~1 min; until then resolveArmWorker's stale/absent fail-safe holds.
+//
+// Idempotent re-deploy: re-evaluating this file (jenkins iac deploy / boot) bumps a
+// generation token; the previously scheduled task sees the mismatch on its next tick
+// and self-terminates, so exactly one probe converges within 60s.
+
+import jenkins.model.Jenkins
+import jenkins.util.Timer
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.CancellationException
+import java.util.logging.Logger
+
+final Logger LOG = Logger.getLogger('hetznerArmHealth')
+final String METRICS_URL = 'http://127.0.0.1:8080/hetzner-prometheus/'   // trailing slash avoids a 302
+final int CLEAR_POLLS = 2          // consecutive healthy polls before re-enabling Hetzner
+final long PERIOD_SEC = 60L
+final long INITIAL_DELAY_SEC = 15L
+
+// Generation token: supersede any schedule left by an earlier eval of this file.
+final String GEN = UUID.randomUUID().toString()
+System.setProperty('hetznerArmHealth.gen', GEN)
+
+def parseArmBreakerStates = { String body ->
+    def states = []
+    body.eachLine { String line ->
+        if (line.startsWith('hetzner_dc_circuit_breaker_state') && line.contains('arch="arm64"')) {
+            def m = (line =~ /\}\s+([0-9.eE+-]+)\s*$/)
+            if (m.find()) { states << (m.group(1) as double) }
+        }
+    }
+    return states
+}
+
+def publishEnv = { boolean healthy, long atSec, String reason ->
+    def props = Jenkins.instance.globalNodeProperties
+    def envProp = props.get(hudson.slaves.EnvironmentVariablesNodeProperty)
+    if (envProp == null) {
+        envProp = new hudson.slaves.EnvironmentVariablesNodeProperty()
+        props.add(envProp)
+    }
+    def vars = envProp.envVars
+    vars.put('HETZNER_ARM64_HEALTHY', healthy ? 'true' : 'false')
+    vars.put('HETZNER_ARM64_HEALTH_AT', atSec.toString())
+    vars.put('HETZNER_ARM64_REASON', reason)
+}
+
+Runnable probe = {
+    try {
+        if (System.getProperty('hetznerArmHealth.gen') != GEN) {
+            throw new CancellationException('superseded by newer hetznerArmHealth eval')
+        }
+
+        String body
+        try {
+            def conn = (java.net.HttpURLConnection) new URL(METRICS_URL).openConnection()
+            conn.connectTimeout = 4000
+            conn.readTimeout = 4000
+            int code = conn.responseCode
+            if (code != 200) {
+                LOG.warning("hetznerArmHealth: metrics HTTP ${code}; leaving flag untouched (stale->healthy fail-safe)")
+                return
+            }
+            body = conn.inputStream.getText('UTF-8')
+        } catch (CancellationException ce) {
+            throw ce
+        } catch (Exception fe) {
+            LOG.warning("hetznerArmHealth: metrics fetch failed (${fe.message}); leaving flag untouched (stale->healthy fail-safe)")
+            return
+        }
+
+        def states = parseArmBreakerStates(body)
+        boolean observedHealthy
+        String reason
+        if (states.isEmpty()) {
+            observedHealthy = true
+            reason = 'no arm64 DC breaker series (assuming healthy)'
+        } else {
+            int closed = states.count { it < 1.0d }
+            observedHealthy = (closed > 0)
+            reason = observedHealthy ?
+                "${closed}/${states.size()} arm64 DC breakers CLOSED".toString() :
+                "all ${states.size()} arm64 DC breakers non-CLOSED (OPEN/HALF_OPEN)".toString()
+        }
+
+        boolean priorHealthy = (System.getProperty('hetznerArmHealth.published', 'true') != 'false')
+        int priorStreak = (System.getProperty('hetznerArmHealth.streak', '0')) as int
+        boolean publishHealthy
+        int streak
+        if (!observedHealthy) {
+            publishHealthy = false
+            streak = 0
+        } else {
+            streak = priorStreak + 1
+            publishHealthy = priorHealthy || (streak >= CLEAR_POLLS)
+            if (!publishHealthy) {
+                reason = "recovering (${streak}/${CLEAR_POLLS} healthy polls); holding AWS fallback".toString()
+            }
+        }
+        System.setProperty('hetznerArmHealth.published', publishHealthy ? 'true' : 'false')
+        System.setProperty('hetznerArmHealth.streak', streak.toString())
+
+        long nowSec = (long) (System.currentTimeMillis() / 1000L)
+        publishEnv(publishHealthy, nowSec, reason)
+        LOG.fine("hetznerArmHealth: healthy=${publishHealthy} (${reason})")
+    } catch (CancellationException supersede) {
+        throw supersede   // let scheduleAtFixedRate suppress this stale generation
+    } catch (Throwable t) {
+        LOG.warning("hetznerArmHealth: unexpected ${t}")   // swallow so the probe keeps running
+    }
+}
+
+Timer.get().scheduleAtFixedRate(probe, INITIAL_DELAY_SEC, PERIOD_SEC, TimeUnit.SECONDS)
+LOG.info("hetznerArmHealth: scheduled (gen=${GEN}, every ${PERIOD_SEC}s, loopback ${METRICS_URL})")

--- a/IaC/ps80.cd/init.groovy.d/hetznerArmHealth.groovy
+++ b/IaC/ps80.cd/init.groovy.d/hetznerArmHealth.groovy
@@ -1,0 +1,145 @@
+// hetznerArmHealth.groovy  (PS-11179)
+//
+// Master-side health probe that publishes whether Hetzner arm64 (CAX) capacity is
+// currently usable, as Jenkins GLOBAL env vars consumed by vars/resolveArmWorker:
+//
+//     HETZNER_ARM64_HEALTHY    "true" | "false"
+//     HETZNER_ARM64_HEALTH_AT  epoch seconds of the last SUCCESSFUL observation
+//     HETZNER_ARM64_REASON     short human-readable verdict
+//
+// Runs ON THIS CONTROLLER (not a worker). Every 60s on the Jenkins Timer pool it
+// reads this master's OWN loopback metrics endpoint
+// (http://127.0.0.1:8080/hetzner-prometheus) and inspects
+// hetzner_dc_circuit_breaker_state{arch="arm64"} for every arm64 DC.
+//
+// Verdict:
+//   - UNHEALTHY when every arm64 DC breaker is non-CLOSED (state >= 1, i.e. OPEN or
+//     HALF_OPEN): no German DC can currently fulfil an arm64 server.
+//   - HEALTHY otherwise (at least one arm64 DC breaker CLOSED, or no arm64 series yet).
+// It reads the metrics TEXT only; it never calls DcCircuitBreaker.getState() from
+// Groovy (that would mutate breaker state / arm a HALF_OPEN probe lease).
+//
+// Hysteresis: flip to UNHEALTHY immediately (divert away from dead capacity fast),
+// but require CLEAR_POLLS consecutive healthy observations before flipping back to
+// HEALTHY (avoid flapping a half-recovered DC back and forth).
+//
+// Fail-safe by OMISSION: on any fetch/parse error we DO NOT touch the flag, so it
+// goes stale and resolveArmWorker treats stale/absent as healthy (-> Hetzner, the
+// current behaviour). UNHEALTHY is published only on POSITIVE fresh evidence, so a
+// metrics glitch can never force the costly AWS fallback on.
+//
+// In-memory by design: the env vars live in globalNodeProperties and are NOT saved
+// to disk (no per-minute config churn). After a restart this script republishes
+// within ~1 min; until then resolveArmWorker's stale/absent fail-safe holds.
+//
+// Idempotent re-deploy: re-evaluating this file (jenkins iac deploy / boot) bumps a
+// generation token; the previously scheduled task sees the mismatch on its next tick
+// and self-terminates, so exactly one probe converges within 60s.
+
+import jenkins.model.Jenkins
+import jenkins.util.Timer
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.CancellationException
+import java.util.logging.Logger
+
+final Logger LOG = Logger.getLogger('hetznerArmHealth')
+final String METRICS_URL = 'http://127.0.0.1:8080/hetzner-prometheus/'   // trailing slash avoids a 302
+final int CLEAR_POLLS = 2          // consecutive healthy polls before re-enabling Hetzner
+final long PERIOD_SEC = 60L
+final long INITIAL_DELAY_SEC = 15L
+
+// Generation token: supersede any schedule left by an earlier eval of this file.
+final String GEN = UUID.randomUUID().toString()
+System.setProperty('hetznerArmHealth.gen', GEN)
+
+def parseArmBreakerStates = { String body ->
+    def states = []
+    body.eachLine { String line ->
+        if (line.startsWith('hetzner_dc_circuit_breaker_state') && line.contains('arch="arm64"')) {
+            def m = (line =~ /\}\s+([0-9.eE+-]+)\s*$/)
+            if (m.find()) { states << (m.group(1) as double) }
+        }
+    }
+    return states
+}
+
+def publishEnv = { boolean healthy, long atSec, String reason ->
+    def props = Jenkins.instance.globalNodeProperties
+    def envProp = props.get(hudson.slaves.EnvironmentVariablesNodeProperty)
+    if (envProp == null) {
+        envProp = new hudson.slaves.EnvironmentVariablesNodeProperty()
+        props.add(envProp)
+    }
+    def vars = envProp.envVars
+    vars.put('HETZNER_ARM64_HEALTHY', healthy ? 'true' : 'false')
+    vars.put('HETZNER_ARM64_HEALTH_AT', atSec.toString())
+    vars.put('HETZNER_ARM64_REASON', reason)
+}
+
+Runnable probe = {
+    try {
+        if (System.getProperty('hetznerArmHealth.gen') != GEN) {
+            throw new CancellationException('superseded by newer hetznerArmHealth eval')
+        }
+
+        String body
+        try {
+            def conn = (java.net.HttpURLConnection) new URL(METRICS_URL).openConnection()
+            conn.connectTimeout = 4000
+            conn.readTimeout = 4000
+            int code = conn.responseCode
+            if (code != 200) {
+                LOG.warning("hetznerArmHealth: metrics HTTP ${code}; leaving flag untouched (stale->healthy fail-safe)")
+                return
+            }
+            body = conn.inputStream.getText('UTF-8')
+        } catch (CancellationException ce) {
+            throw ce
+        } catch (Exception fe) {
+            LOG.warning("hetznerArmHealth: metrics fetch failed (${fe.message}); leaving flag untouched (stale->healthy fail-safe)")
+            return
+        }
+
+        def states = parseArmBreakerStates(body)
+        boolean observedHealthy
+        String reason
+        if (states.isEmpty()) {
+            observedHealthy = true
+            reason = 'no arm64 DC breaker series (assuming healthy)'
+        } else {
+            int closed = states.count { it < 1.0d }
+            observedHealthy = (closed > 0)
+            reason = observedHealthy ?
+                "${closed}/${states.size()} arm64 DC breakers CLOSED".toString() :
+                "all ${states.size()} arm64 DC breakers non-CLOSED (OPEN/HALF_OPEN)".toString()
+        }
+
+        boolean priorHealthy = (System.getProperty('hetznerArmHealth.published', 'true') != 'false')
+        int priorStreak = (System.getProperty('hetznerArmHealth.streak', '0')) as int
+        boolean publishHealthy
+        int streak
+        if (!observedHealthy) {
+            publishHealthy = false
+            streak = 0
+        } else {
+            streak = priorStreak + 1
+            publishHealthy = priorHealthy || (streak >= CLEAR_POLLS)
+            if (!publishHealthy) {
+                reason = "recovering (${streak}/${CLEAR_POLLS} healthy polls); holding AWS fallback".toString()
+            }
+        }
+        System.setProperty('hetznerArmHealth.published', publishHealthy ? 'true' : 'false')
+        System.setProperty('hetznerArmHealth.streak', streak.toString())
+
+        long nowSec = (long) (System.currentTimeMillis() / 1000L)
+        publishEnv(publishHealthy, nowSec, reason)
+        LOG.fine("hetznerArmHealth: healthy=${publishHealthy} (${reason})")
+    } catch (CancellationException supersede) {
+        throw supersede   // let scheduleAtFixedRate suppress this stale generation
+    } catch (Throwable t) {
+        LOG.warning("hetznerArmHealth: unexpected ${t}")   // swallow so the probe keeps running
+    }
+}
+
+Timer.get().scheduleAtFixedRate(probe, INITIAL_DELAY_SEC, PERIOD_SEC, TimeUnit.SECONDS)
+LOG.info("hetznerArmHealth: scheduled (gen=${GEN}, every ${PERIOD_SEC}s, loopback ${METRICS_URL})")

--- a/vars/resolveArmWorker.groovy
+++ b/vars/resolveArmWorker.groovy
@@ -1,0 +1,109 @@
+// resolveArmWorker: pick the build-worker label, the dispatcher (micro) label, and the
+// effective cloud for an ARM (or x86) build, with automatic Hetzner -> AWS Graviton
+// fallback when CLOUD=auto and Hetzner ARM (CAX) capacity is unavailable (PS-11179).
+//
+// Drop-in for the fleet-wide ternary. The whole fleet uses one shape:
+//     label params.CLOUD == 'Hetzner' ? 'docker-aarch64' : 'docker-64gb-aarch64'
+//     agent { label params.CLOUD == 'Hetzner' ? 'launcher-x64' : 'micro-amazon' }
+// and re-reads params.CLOUD downstream for credentials (HTZ_STASH vs AWS), the ccache
+// S3 bucket/endpoint, etc. So this returns the EFFECTIVE cloud, not just a label:
+//
+//     def w = resolveArmWorker(cloud: params.CLOUD, arch: params.ARCH,
+//                              awsLabel: 'docker-64gb-aarch64')   // keep the caller's size
+//     // outer:  agent { label w.microLabel }
+//     // inner:  node(w.label) { ... }
+//     // creds/S3/ccache: use w.cloudChosen wherever params.CLOUD was read
+//
+// It preserves each caller's existing label pair (docker-32gb vs docker-64gb aarch64),
+// so it is a no-behaviour-change drop-in for explicit Hetzner/AWS and only adds the
+// auto-routing. Only `docker-aarch64` is actually requested fleet-wide (the other CAX
+// aarch64 label atoms have no consumers), so no per-label mapping table is needed.
+//
+// Returns: [label, microLabel, cloudChosen, reason, fellBack].
+//
+// CLOUD contract:
+//   auto      (new default) - aarch64 may fall back to AWS when the controller flag
+//                             reports Hetzner arm64 down; x86 always stays on Hetzner.
+//   Hetzner                 - always Hetzner; never fall back (lets infra issues surface).
+//   AWS                     - always AWS.
+//   epyc9654                - bare-metal AMD; unchanged.
+//
+// Health flag (HETZNER_ARM64_HEALTHY / _HEALTH_AT / _REASON) is published by the
+// controller HetznerArmHealth PeriodicWork. Fail-safe: an absent or stale flag is
+// treated as healthy, so a flag outage never strands builds (keeps current behaviour).
+
+def call(Map config = [:]) {
+    String cloud  = (config.get('cloud', env.CLOUD) ?: 'auto').toString().trim()
+    String arch   = (config.get('arch', env.ARCH) ?: 'x86_64').toString().trim()
+    boolean isArm = (arch == 'aarch64')
+
+    // Caller's two label sides; defaults match the common ternary. awsLabel carries the
+    // caller's sizing intent (docker-32gb-aarch64 for MTR, docker-64gb-aarch64 for others).
+    String hetznerLabel = config.get('hetznerLabel', isArm ? 'docker-aarch64' : 'docker-x64')
+    String awsLabel     = config.get('awsLabel', isArm ? 'docker-32gb-aarch64' : 'docker-32gb')
+    String epycLabel    = config.get('epycLabel', 'as-1015cs-tnr')
+    // Parse defensively: a bad caller value must not throw before the fail-safe runs.
+    long flagTtlSeconds
+    try { flagTtlSeconds = ((config.get('flagTtlSeconds', 600L) ?: 600L) as long) }
+    catch (ignored) { flagTtlSeconds = 600L }
+
+    Map r
+    switch (cloud) {
+        case 'AWS':
+            r = [label: awsLabel, microLabel: 'micro-amazon', cloudChosen: 'AWS',
+                 reason: 'explicit CLOUD=AWS', fellBack: false]
+            break
+        case 'epyc9654':
+            r = [label: epycLabel, microLabel: 'launcher-x64', cloudChosen: 'epyc9654',
+                 reason: 'explicit CLOUD=epyc9654', fellBack: false]
+            break
+        case 'Hetzner':
+            r = [label: hetznerLabel, microLabel: 'launcher-x64', cloudChosen: 'Hetzner',
+                 reason: 'explicit CLOUD=Hetzner (no fallback)', fellBack: false]
+            break
+        default: // 'auto' and any unknown value
+            if (isArm && !hetznerArmHealthy(flagTtlSeconds)) {
+                r = [label: awsLabel, microLabel: 'micro-amazon', cloudChosen: 'AWS', fellBack: true,
+                     reason: "auto: Hetzner arm64 unavailable (${env.HETZNER_ARM64_REASON ?: 'flag=false'}) -> Graviton"]
+            } else {
+                r = [label: hetznerLabel, microLabel: 'launcher-x64', cloudChosen: 'Hetzner', fellBack: false,
+                     reason: isArm ? 'auto: Hetzner arm64 healthy' : 'auto: x86 routes to Hetzner']
+            }
+            break
+    }
+
+    echo "resolveArmWorker: cloud=${cloud} arch=${arch} -> ${r.cloudChosen} " +
+         "label=${r.label} micro=${r.microLabel} (${r.reason})"
+    try {
+        String tag = r.fellBack ? "[FALLBACK ${r.cloudChosen}:${r.label}]" : "[${r.cloudChosen}:${r.label}]"
+        currentBuild.description = currentBuild.description ? "${currentBuild.description} ${tag}" : tag
+    } catch (ignored) { }
+    return r
+}
+
+// True if Hetzner arm64 is healthy. Fail-safe to TRUE when the flag is absent, stale, or
+// unparseable, so a flag outage keeps current Hetzner behaviour rather than stranding builds.
+boolean hetznerArmHealthy(long ttlSeconds) {
+    String healthy = env.HETZNER_ARM64_HEALTHY
+    String at      = env.HETZNER_ARM64_HEALTH_AT
+    if (healthy == null || at == null) {
+        echo 'resolveArmWorker: HETZNER_ARM64 flag absent; assuming healthy (fail-safe)'
+        return true
+    }
+    long ageSec
+    try {
+        ageSec = (long) (System.currentTimeMillis() / 1000L) - (at as long)
+    } catch (ignored) {
+        echo 'resolveArmWorker: HETZNER_ARM64_HEALTH_AT unparseable; assuming healthy (fail-safe)'
+        return true
+    }
+    if (ageSec < 0L) {
+        echo 'resolveArmWorker: HETZNER_ARM64_HEALTH_AT in the future (clock skew/corrupt); assuming healthy (fail-safe)'
+        return true
+    }
+    if (ageSec > ttlSeconds) {
+        echo "resolveArmWorker: HETZNER_ARM64 flag stale (${ageSec}s > ${ttlSeconds}s); assuming healthy (fail-safe)"
+        return true
+    }
+    return !healthy.equalsIgnoreCase('false')
+}


### PR DESCRIPTION
**Feature**
- Adds the ARM routing layer that auto-falls back from Hetzner to AWS Graviton when Hetzner CAX capacity is unavailable, with no human re-run.
- `vars/resolveArmWorker`: picks the build-worker label, dispatcher label, and effective cloud for a build; preserves each caller's label pair and returns `cloudChosen` so creds/ccache/dispatcher stay on one cloud.
- Controller probe `init.groovy.d/hetznerArmHealth.groovy` (ps80, ps57, ps3) reads loopback `/hetzner-prometheus` every 60s and publishes `HETZNER_ARM64_HEALTHY`.

**Why**
- Hetzner ARM (CAX) capacity has been intermittently unavailable; ARM validation builds otherwise sit queued until a human re-runs with `CLOUD=AWS`.
- Under `CLOUD=auto`, routing is fail-safe: an absent, stale, or unparseable flag is treated as healthy, so a flag outage never strands builds and a metrics glitch never forces the costly fallback on.
- Additive only (new `vars/` file plus new init scripts), so explicit `Hetzner`/`AWS`/`epyc9654` callers are unchanged.

**Tickets**
- [PS-11179](https://perconadev.atlassian.net/browse/PS-11179)

[PS-11179]: https://perconadev.atlassian.net/browse/PS-11179?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ