### PR TITLE
PS-11179: Codify ARM Graviton Fleet on ps3 + ps57 (retire classic r6g on ps3)

### DIFF
--- a/IaC/ps3.cd/init.groovy.d/cloud.groovy
+++ b/IaC/ps3.cd/init.groovy.d/cloud.groovy
@@ -93,7 +93,6 @@ imageMap['eu-west-1a.docker-32gb-noble']    = properties.AwsAmi['Ubuntu2404_x86_
 imageMap['eu-west-1a.docker-32gb-resolute'] = properties.AwsAmi['Ubuntu2604_x86_64']['euWest1']
 imageMap['eu-west-1a.docker-32gb-bullseye'] = imageMap['eu-west-1a.min-bullseye-x64']
 
-imageMap['eu-west-1a.docker-32gb-aarch64']  = properties.AwsAmi['AmazonLinux2_aarch64']['euWest1']
 imageMap['eu-west-1a.min-centos-7-aarch64'] = properties.AwsAmi['Centos7_aarch64']['euWest1']
 imageMap['eu-west-1a.min-bookworm-aarch64'] = properties.AwsAmi['Debian12_aarch64']['euWest1']
 imageMap['eu-west-1a.min-bullseye-aarch64'] = properties.AwsAmi['Debian11_aarch64']['euWest1']
@@ -128,7 +127,6 @@ imageMap['eu-west-1b.docker-32gb-noble']    = imageMap['eu-west-1a.docker-32gb-n
 imageMap['eu-west-1b.docker-32gb-resolute'] = imageMap['eu-west-1a.docker-32gb-resolute']
 imageMap['eu-west-1b.docker-32gb-bullseye'] = imageMap['eu-west-1a.docker-32gb-bullseye']
 
-imageMap['eu-west-1b.docker-32gb-aarch64']    = imageMap['eu-west-1a.docker-32gb-aarch64']
 imageMap['eu-west-1b.min-centos-7-aarch64']   = imageMap['eu-west-1a.min-centos-7-aarch64']
 imageMap['eu-west-1b.min-bookworm-aarch64']   = imageMap['eu-west-1a.min-bookworm-aarch64']
 imageMap['eu-west-1b.min-bullseye-aarch64']   = imageMap['eu-west-1a.min-bullseye-aarch64']
@@ -163,7 +161,6 @@ imageMap['eu-west-1c.docker-32gb-noble']    = imageMap['eu-west-1a.docker-32gb-n
 imageMap['eu-west-1c.docker-32gb-resolute'] = imageMap['eu-west-1a.docker-32gb-resolute']
 imageMap['eu-west-1c.docker-32gb-bullseye'] = imageMap['eu-west-1a.docker-32gb-bullseye']
 
-imageMap['eu-west-1c.docker-32gb-aarch64']    = imageMap['eu-west-1a.docker-32gb-aarch64']
 imageMap['eu-west-1c.min-centos-7-aarch64']   = imageMap['eu-west-1a.min-centos-7-aarch64']
 imageMap['eu-west-1c.min-bookworm-aarch64']   = imageMap['eu-west-1a.min-bookworm-aarch64']
 imageMap['eu-west-1c.min-bullseye-aarch64']   = imageMap['eu-west-1a.min-bullseye-aarch64']
@@ -206,7 +203,6 @@ userMap['docker-32gb-noble']    = properties.AwsAmi['Ubuntu2404_x86_64']['user']
 userMap['docker-32gb-resolute'] = properties.AwsAmi['Ubuntu2604_x86_64']['user']
 userMap['docker-32gb-bullseye'] = properties.AwsAmi['Debian11_x86_64']['user']
 
-userMap['docker-32gb-aarch64']    = properties.AwsAmi['AmazonLinux2_aarch64']['user']
 userMap['min-centos-7-aarch64']   = properties.AwsAmi['Centos7_aarch64']['user']
 userMap['min-bookworm-aarch64']   = properties.AwsAmi['Debian12_aarch64']['user']
 userMap['min-bullseye-aarch64']   = properties.AwsAmi['Debian11_aarch64']['user']
@@ -606,7 +602,6 @@ initMap['min-stretch-x64'] = initMap['debMap']
 initMap['min-xenial-x64']  = initMap['debMap']
 initMap['min-trixie-x64']  = initMap['debMap']
 
-initMap['docker-32gb-aarch64']  = initMap['docker']
 initMap['min-centos-7-aarch64'] = initMap['rpmMap']
 initMap['min-bookworm-aarch64'] = initMap['debMap']
 initMap['min-bullseye-aarch64'] = initMap['debMap']
@@ -648,15 +643,14 @@ typeMap['docker-32gb-noble'] = 'i4i.2xlarge'
 typeMap['docker-32gb-resolute'] = 'i4i.2xlarge'
 typeMap['docker-32gb-bullseye'] = 'i4i.2xlarge'
 
-typeMap['docker-32gb-aarch64']  = 'r6g.2xlarge'
-typeMap['min-centos-7-aarch64'] = typeMap['docker-32gb-aarch64']
-typeMap['min-bookworm-aarch64'] = typeMap['docker-32gb-aarch64']
-typeMap['min-bullseye-aarch64'] = typeMap['docker-32gb-aarch64']
-typeMap['min-jammy-aarch64']    = typeMap['docker-32gb-aarch64']
-typeMap['min-noble-aarch64']    = typeMap['docker-32gb-aarch64']
-typeMap['min-resolute-aarch64'] = typeMap['docker-32gb-aarch64']
-typeMap['min-trixie-aarch64']   = typeMap['docker-32gb-aarch64']
-typeMap['min-al2023-aarch64']   = typeMap['docker-32gb-aarch64']
+typeMap['min-centos-7-aarch64'] = 'r6g.2xlarge'
+typeMap['min-bookworm-aarch64'] = 'r6g.2xlarge'
+typeMap['min-bullseye-aarch64'] = 'r6g.2xlarge'
+typeMap['min-jammy-aarch64']    = 'r6g.2xlarge'
+typeMap['min-noble-aarch64']    = 'r6g.2xlarge'
+typeMap['min-resolute-aarch64'] = 'r6g.2xlarge'
+typeMap['min-trixie-aarch64']   = 'r6g.2xlarge'
+typeMap['min-al2023-aarch64']   = 'r6g.2xlarge'
 
 execMap = [:]
 execMap['docker']            = '1'
@@ -683,7 +677,6 @@ execMap['min-bullseye-x64']  = '1'
 execMap['docker-32gb-bullseye']  = '1'
 execMap['min-trixie-x64']        = '1'
 
-execMap['docker-32gb-aarch64']  = '1'
 execMap['min-centos-7-aarch64'] = '1'
 execMap['min-bookworm-aarch64'] = '1'
 execMap['min-bullseye-aarch64'] = '1'
@@ -719,7 +712,6 @@ devMap['min-trixie-x64']    = '/dev/xvda=:8:true:gp2,/dev/xvdd=:80:true:gp2'
 devMap['docker-32gb-resolute'] = devMap['docker']
 devMap['docker-32gb-bullseye']  = '/dev/xvda=:8:true:gp2,/dev/xvdd=:80:true:gp2'
 
-devMap['docker-32gb-aarch64']  = '/dev/xvda=:8:true:gp2,/dev/xvdd=:80:true:gp2'
 devMap['min-centos-7-aarch64'] = '/dev/xvda=:8:true:gp2,/dev/xvdd=:80:true:gp2'
 devMap['min-bookworm-aarch64'] = '/dev/xvda=:8:true:gp2,/dev/xvdd=:80:true:gp2'
 devMap['min-bullseye-aarch64'] = '/dev/xvda=:8:true:gp2,/dev/xvdd=:80:true:gp2'
@@ -754,7 +746,6 @@ labelMap['min-bullseye-x64']  = ''
 labelMap['min-trixie-x64']    = ''
 labelMap['docker-32gb-bullseye']  = ''
 
-labelMap['docker-32gb-aarch64']  = ''
 labelMap['min-centos-7-aarch64'] = ''
 labelMap['min-bookworm-aarch64'] = ''
 labelMap['min-bullseye-aarch64'] = ''
@@ -789,7 +780,6 @@ jvmoptsMap['min-bullseye-x64']  = jvmoptsMap['docker']
 jvmoptsMap['min-trixie-x64']    = '-Xmx512m -Xms512m --add-opens=java.base/java.lang=ALL-UNNAMED --add-opens=java.base/java.lang.reflect=ALL-UNNAMED'
 jvmoptsMap['docker-32gb-bullseye']  = jvmoptsMap['docker']
 
-jvmoptsMap['docker-32gb-aarch64']  = jvmoptsMap['docker']
 jvmoptsMap['min-centos-7-aarch64'] = jvmoptsMap['docker']
 jvmoptsMap['min-bookworm-aarch64'] = jvmoptsMap['docker']
 jvmoptsMap['min-bullseye-aarch64'] = jvmoptsMap['docker']
@@ -889,7 +879,6 @@ String region = 'eu-west-1'
             getTemplate('docker-32gb-noble',    "${region}${it}"),
             getTemplate('docker-32gb-resolute', "${region}${it}"),
             getTemplate('docker-32gb-bullseye', "${region}${it}"),
-            getTemplate('docker-32gb-aarch64',  "${region}${it}"),
             getTemplate('min-centos-7-aarch64', "${region}${it}"),
             getTemplate('min-bookworm-aarch64', "${region}${it}"),
             getTemplate('min-bullseye-aarch64', "${region}${it}"),

--- a/IaC/ps3.cd/init.groovy.d/ec2FleetCloud.groovy
+++ b/IaC/ps3.cd/init.groovy.d/ec2FleetCloud.groovy
@@ -54,7 +54,7 @@ def fleet = new EC2FleetCloud(
     LABEL,
     '/mnt/jenkins',              // fsRoot
     sshConn,                     // computerConnector
-    false,                       // privateIpUsed
+    true,                        // privateIpUsed -- master + worker share the master VPC; public-IP SSH egress is not guaranteed across regions (ps57 smoke confirmed this)
     false,                       // alwaysReconnect
     (Integer) 10,                // idleMinutes (NON-zero: 0 = never scale down)
     0,                           // minSize

--- a/IaC/ps3.cd/init.groovy.d/ec2FleetCloud.groovy
+++ b/IaC/ps3.cd/init.groovy.d/ec2FleetCloud.groovy
@@ -1,0 +1,77 @@
+// ec2FleetCloud.groovy  (PS-11179)
+//
+// Registers the diversified Graviton EC2 Fleet (ASG-backed via the ec2-fleet
+// plugin) as a Jenkins Cloud serving the `docker-32gb-aarch64` label, replacing
+// the classic single-SKU `r6g.2xlarge` SlaveTemplate that previously served the
+// same label (retired from cloud.groovy in the same commit).
+//
+// Multi-SKU only: this is the uniform fallback path. AWS chooses from
+// `m8g/m7g/m6g.2xlarge` per the capacity-optimized MixedInstancesPolicy on the
+// `jenkins-ps3-arm-graviton` ASG (Terraform module: jenkins-arm-fleet).
+//
+// IAM: the `Ec2FleetPluginAutoScaling` policy is attached to this master's role
+// by the TF module, so `awsCredentialsId = ""` (use the master IAM instance
+// profile, not a stored AWS credential).
+//
+// SSH: the `percona-jenkins` private-key credential must be present in
+// Jenkins; it must match the AWS key pair set on the Launch Template
+// (`key_name = "percona-jenkins"`).
+//
+// Idempotent: re-applying via `jenkins iac deploy` removes the prior cloud
+// instance with the same name before adding the fresh one.
+
+import com.amazon.jenkins.ec2fleet.EC2FleetCloud
+import hudson.plugins.sshslaves.SSHConnector
+import hudson.plugins.sshslaves.verifiers.NonVerifyingKeyVerificationStrategy
+import jenkins.model.Jenkins
+import java.util.logging.Logger
+
+final Logger LOG = Logger.getLogger('ec2FleetCloud')
+final String CLOUD_NAME   = 'arm-graviton-fleet'
+final String REGION       = 'eu-west-1'
+final String ASG_NAME     = 'jenkins-ps3-arm-graviton'
+final String LABEL        = 'docker-32gb-aarch64'
+final String SSH_CRED_ID  = 'percona-jenkins'
+
+Jenkins.instance.clouds.findAll { it.name == CLOUD_NAME }.each {
+    Jenkins.instance.clouds.remove(it)
+}
+
+def sshConn = new SSHConnector(
+    22, SSH_CRED_ID,
+    '', '', '', '',
+    null, null, null,
+    new NonVerifyingKeyVerificationStrategy()
+)
+
+def fleet = new EC2FleetCloud(
+    CLOUD_NAME,
+    '',                          // awsCredentialsId (empty -> master IAM instance profile)
+    '',                          // credentialsId (legacy field, kept empty)
+    REGION,
+    '',                          // endpoint
+    ASG_NAME,
+    LABEL,
+    '/mnt/jenkins',              // fsRoot
+    sshConn,                     // computerConnector
+    false,                       // privateIpUsed
+    false,                       // alwaysReconnect
+    (Integer) 10,                // idleMinutes (NON-zero: 0 = never scale down)
+    0,                           // minSize
+    16,                          // maxSize (matches TF)
+    0,                           // minSpareSize
+    1,                           // numExecutors
+    true,                        // addNodeOnlyIfRunning
+    false,                       // restrictUsage
+    '-1',                        // maxTotalUses (-1 = unlimited)
+    false,                       // disableTaskResubmit
+    (Integer) 600,               // initOnlineTimeoutSec
+    (Integer) 15,                // initOnlineCheckIntervalSec
+    (Integer) 10,                // cloudStatusIntervalSec
+    false,                       // noDelayProvision
+    false,                       // scaleExecutorsByWeight
+    new EC2FleetCloud.NoScaler()
+)
+
+Jenkins.instance.clouds.add(fleet)
+LOG.info("ec2FleetCloud: registered cloud='${CLOUD_NAME}' label='${LABEL}' fleet='${ASG_NAME}' region='${REGION}'")

--- a/IaC/ps57.cd/init.groovy.d/ec2FleetCloud.groovy
+++ b/IaC/ps57.cd/init.groovy.d/ec2FleetCloud.groovy
@@ -1,0 +1,76 @@
+// ec2FleetCloud.groovy  (PS-11179)
+//
+// Registers the diversified Graviton EC2 Fleet (ASG-backed via the ec2-fleet
+// plugin) as a Jenkins Cloud serving the `docker-32gb-aarch64` label on ps57.
+// Uniform multi-SKU fallback path with ps3 (sibling PR 4126) and ps80
+// (post-PS-11206 cutover follow-up).
+//
+// IAM: the `Ec2FleetPluginAutoScaling` policy is attached to the CFN-managed
+// jenkins-ps57-master role by the standalone TF block in
+// terraform/master-ps57.tf (jenkins-arm-fleet module). The plugin uses the
+// master IAM instance profile (`awsCredentialsId = ""`).
+//
+// SSH: the `percona-jenkins` private-key credential is loaded into ps57; it
+// matches the AWS key pair on the Launch Template (`key_name = "percona-jenkins"`).
+// `privateIpUsed = true` because the eu-central-1 master's egress does not
+// reliably reach the worker's public IP; master + worker share the same VPC
+// (vpc-017b8f29d90593313 / 10.177.0.0/22), so private IP routing works.
+//
+// Idempotent: re-applying via `jenkins iac deploy` removes the prior cloud
+// instance with the same name before adding the fresh one.
+
+import com.amazon.jenkins.ec2fleet.EC2FleetCloud
+import hudson.plugins.sshslaves.SSHConnector
+import hudson.plugins.sshslaves.verifiers.NonVerifyingKeyVerificationStrategy
+import jenkins.model.Jenkins
+import java.util.logging.Logger
+
+final Logger LOG = Logger.getLogger('ec2FleetCloud')
+final String CLOUD_NAME   = 'arm-graviton-fleet'
+final String REGION       = 'eu-central-1'
+final String ASG_NAME     = 'jenkins-ps57-arm-graviton'
+final String LABEL        = 'docker-32gb-aarch64'
+final String SSH_CRED_ID  = 'percona-jenkins'
+
+Jenkins.instance.clouds.findAll { it.name == CLOUD_NAME }.each {
+    Jenkins.instance.clouds.remove(it)
+}
+
+def sshConn = new SSHConnector(
+    22, SSH_CRED_ID,
+    '', '', '', '',
+    null, null, null,
+    new NonVerifyingKeyVerificationStrategy()
+)
+
+def fleet = new EC2FleetCloud(
+    CLOUD_NAME,
+    '',                          // awsCredentialsId (empty -> master IAM instance profile)
+    '',                          // credentialsId (legacy field, kept empty)
+    REGION,
+    '',                          // endpoint
+    ASG_NAME,
+    LABEL,
+    '/mnt/jenkins',              // fsRoot
+    sshConn,                     // computerConnector
+    true,                        // privateIpUsed -- master + worker share the master VPC; public-IP SSH egress is not reliable in eu-central-1
+    false,                       // alwaysReconnect
+    (Integer) 10,                // idleMinutes (NON-zero: 0 = never scale down)
+    0,                           // minSize
+    16,                          // maxSize (matches TF)
+    0,                           // minSpareSize
+    1,                           // numExecutors
+    true,                        // addNodeOnlyIfRunning
+    false,                       // restrictUsage
+    '-1',                        // maxTotalUses (-1 = unlimited)
+    false,                       // disableTaskResubmit
+    (Integer) 600,               // initOnlineTimeoutSec
+    (Integer) 15,                // initOnlineCheckIntervalSec
+    (Integer) 10,                // cloudStatusIntervalSec
+    false,                       // noDelayProvision
+    false,                       // scaleExecutorsByWeight
+    new EC2FleetCloud.NoScaler()
+)
+
+Jenkins.instance.clouds.add(fleet)
+LOG.info("ec2FleetCloud: registered cloud='${CLOUD_NAME}' label='${LABEL}' fleet='${ASG_NAME}' region='${REGION}'")


### PR DESCRIPTION
**Feature**
- Adds `IaC/ps3.cd/init.groovy.d/ec2FleetCloud.groovy` and `IaC/ps57.cd/init.groovy.d/ec2FleetCloud.groovy`: registers the diversified Graviton EC2 Fleet on each master (`jenkins-ps3-arm-graviton` / `jenkins-ps57-arm-graviton`) as a Jenkins Cloud serving the `docker-32gb-aarch64` label. `privateIpUsed=true` on both (master + worker share the master VPC; public-IP SSH egress is not reliable in all regions).
- Retires the classic `r6g.2xlarge` `docker-32gb-aarch64` SlaveTemplate from ps3's `cloud.groovy` (9 map entries + the `getTemplate` registration); ps57 had no classic aarch64 template to retire. `typeMap` aliases for the other 8 aarch64 labels are refactored to use the literal `r6g.2xlarge` value rather than chaining through the removed anchor.

**Why**
- Uniform multi-SKU Graviton fallback path for [PS-11179](https://perconadev.atlassian.net/browse/PS-11179): AWS picks from `m8g`/`m7g`/`m6g.2xlarge` per the capacity-optimized MixedInstancesPolicy on each ASG, giving the fallback the spot-availability headroom that is the whole point of the insurance.
- Validated end-to-end on **both** masters today: a Graviton `m7g.2xlarge` (ps3) and `m8g.2xlarge` (ps57) provisioned from the diversified pool, build SUCCESS on aarch64 in each case.
- ps80 follows in a separate PR after the Friday [PS-11206](https://perconadev.atlassian.net/browse/PS-11206) cutover (when ps80 is TF-managed).

**Tickets**
- [PS-11179](https://perconadev.atlassian.net/browse/PS-11179)

[PS-11179]: https://perconadev.atlassian.net/browse/PS-11179?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[PS-11206]: https://perconadev.atlassian.net/browse/PS-11206?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ