### PR TITLE
PS-11173: Fan out durability.groovy to the 9 non-ps3 masters

### DIFF
--- a/IaC/cloud.cd/init.groovy.d/durability.groovy
+++ b/IaC/cloud.cd/init.groovy.d/durability.groovy
@@ -1,0 +1,53 @@
+/**
+ * Persist the global pipeline durability hint as MAX_SURVIVABILITY at
+ * every JVM boot, by calling the GlobalDefaultFlowDurabilityLevel
+ * descriptor's setDurabilityHint() + save() so the value lands in
+ * $JENKINS_HOME/org.jenkinsci.plugins.workflow.flow.GlobalDefaultFlowDurabilityLevel.xml
+ * (the descriptor's standard config file). Idempotent on the happy
+ * path: when the hint already matches the target, the script is a no-op.
+ *
+ * Background. Pipeline builds use one of three durability hints:
+ *   PERFORMANCE_OPTIMIZED  - FlowNode state kept in memory until the
+ *                            build finishes; an abrupt JVM stop
+ *                            (kill -9, AWS spot interrupt) loses the
+ *                            whole in-flight build.
+ *   SURVIVABLE_NONATOMIC   - persists eventually, weaker ordering.
+ *   MAX_SURVIVABILITY      - persists each FlowNode as it executes, so
+ *                            a build resumes at the same step on JVM
+ *                            return.
+ *
+ * Why explicit when workflow-api already advertises MAX_SURVIVABILITY
+ * as the default? The default is fragile: any operator change in
+ * Manage Jenkins -> System silently writes the descriptor's XML and
+ * can replace the hint with no IaC trace. Writing the value ourselves
+ * at every boot anchors the canary's resilience guarantee.
+ *
+ * Note on the descriptor: when no XML exists, the descriptor's in-memory
+ * field is null (the MAX_SURVIVABILITY default lives at a higher
+ * layer in workflow-api). So `current != target` correctly fires the
+ * write path on a fresh master, and the resulting save() materialises
+ * the on-disk XML.
+ *
+ * Scope: ps3 canary only. PS-11173 Phase 2.
+ */
+import org.jenkinsci.plugins.workflow.flow.FlowDurabilityHint
+import jenkins.model.Jenkins
+
+def descCls = Class.forName('org.jenkinsci.plugins.workflow.flow.GlobalDefaultFlowDurabilityLevel$DescriptorImpl')
+def descriptors = Jenkins.instance.getExtensionList(descCls)
+if (descriptors.isEmpty()) {
+    println "durability.groovy: GlobalDefaultFlowDurabilityLevel descriptor missing (workflow-api plugin not installed?)"
+    return
+}
+
+def d = descriptors[0]
+def current = d.durabilityHint
+def target = FlowDurabilityHint.MAX_SURVIVABILITY
+
+if (current != target) {
+    d.setDurabilityHint(target)
+    d.save()
+    println "durability.groovy: ${current} -> ${target}"
+} else {
+    println "durability.groovy: GlobalDefaultFlowDurabilityLevel already ${target}"
+}

--- a/IaC/pg.cd/init.groovy.d/durability.groovy
+++ b/IaC/pg.cd/init.groovy.d/durability.groovy
@@ -1,0 +1,53 @@
+/**
+ * Persist the global pipeline durability hint as MAX_SURVIVABILITY at
+ * every JVM boot, by calling the GlobalDefaultFlowDurabilityLevel
+ * descriptor's setDurabilityHint() + save() so the value lands in
+ * $JENKINS_HOME/org.jenkinsci.plugins.workflow.flow.GlobalDefaultFlowDurabilityLevel.xml
+ * (the descriptor's standard config file). Idempotent on the happy
+ * path: when the hint already matches the target, the script is a no-op.
+ *
+ * Background. Pipeline builds use one of three durability hints:
+ *   PERFORMANCE_OPTIMIZED  - FlowNode state kept in memory until the
+ *                            build finishes; an abrupt JVM stop
+ *                            (kill -9, AWS spot interrupt) loses the
+ *                            whole in-flight build.
+ *   SURVIVABLE_NONATOMIC   - persists eventually, weaker ordering.
+ *   MAX_SURVIVABILITY      - persists each FlowNode as it executes, so
+ *                            a build resumes at the same step on JVM
+ *                            return.
+ *
+ * Why explicit when workflow-api already advertises MAX_SURVIVABILITY
+ * as the default? The default is fragile: any operator change in
+ * Manage Jenkins -> System silently writes the descriptor's XML and
+ * can replace the hint with no IaC trace. Writing the value ourselves
+ * at every boot anchors the canary's resilience guarantee.
+ *
+ * Note on the descriptor: when no XML exists, the descriptor's in-memory
+ * field is null (the MAX_SURVIVABILITY default lives at a higher
+ * layer in workflow-api). So `current != target` correctly fires the
+ * write path on a fresh master, and the resulting save() materialises
+ * the on-disk XML.
+ *
+ * Scope: ps3 canary only. PS-11173 Phase 2.
+ */
+import org.jenkinsci.plugins.workflow.flow.FlowDurabilityHint
+import jenkins.model.Jenkins
+
+def descCls = Class.forName('org.jenkinsci.plugins.workflow.flow.GlobalDefaultFlowDurabilityLevel$DescriptorImpl')
+def descriptors = Jenkins.instance.getExtensionList(descCls)
+if (descriptors.isEmpty()) {
+    println "durability.groovy: GlobalDefaultFlowDurabilityLevel descriptor missing (workflow-api plugin not installed?)"
+    return
+}
+
+def d = descriptors[0]
+def current = d.durabilityHint
+def target = FlowDurabilityHint.MAX_SURVIVABILITY
+
+if (current != target) {
+    d.setDurabilityHint(target)
+    d.save()
+    println "durability.groovy: ${current} -> ${target}"
+} else {
+    println "durability.groovy: GlobalDefaultFlowDurabilityLevel already ${target}"
+}

--- a/IaC/pmm.cd/init.groovy.d/durability.groovy
+++ b/IaC/pmm.cd/init.groovy.d/durability.groovy
@@ -1,0 +1,53 @@
+/**
+ * Persist the global pipeline durability hint as MAX_SURVIVABILITY at
+ * every JVM boot, by calling the GlobalDefaultFlowDurabilityLevel
+ * descriptor's setDurabilityHint() + save() so the value lands in
+ * $JENKINS_HOME/org.jenkinsci.plugins.workflow.flow.GlobalDefaultFlowDurabilityLevel.xml
+ * (the descriptor's standard config file). Idempotent on the happy
+ * path: when the hint already matches the target, the script is a no-op.
+ *
+ * Background. Pipeline builds use one of three durability hints:
+ *   PERFORMANCE_OPTIMIZED  - FlowNode state kept in memory until the
+ *                            build finishes; an abrupt JVM stop
+ *                            (kill -9, AWS spot interrupt) loses the
+ *                            whole in-flight build.
+ *   SURVIVABLE_NONATOMIC   - persists eventually, weaker ordering.
+ *   MAX_SURVIVABILITY      - persists each FlowNode as it executes, so
+ *                            a build resumes at the same step on JVM
+ *                            return.
+ *
+ * Why explicit when workflow-api already advertises MAX_SURVIVABILITY
+ * as the default? The default is fragile: any operator change in
+ * Manage Jenkins -> System silently writes the descriptor's XML and
+ * can replace the hint with no IaC trace. Writing the value ourselves
+ * at every boot anchors the canary's resilience guarantee.
+ *
+ * Note on the descriptor: when no XML exists, the descriptor's in-memory
+ * field is null (the MAX_SURVIVABILITY default lives at a higher
+ * layer in workflow-api). So `current != target` correctly fires the
+ * write path on a fresh master, and the resulting save() materialises
+ * the on-disk XML.
+ *
+ * Scope: ps3 canary only. PS-11173 Phase 2.
+ */
+import org.jenkinsci.plugins.workflow.flow.FlowDurabilityHint
+import jenkins.model.Jenkins
+
+def descCls = Class.forName('org.jenkinsci.plugins.workflow.flow.GlobalDefaultFlowDurabilityLevel$DescriptorImpl')
+def descriptors = Jenkins.instance.getExtensionList(descCls)
+if (descriptors.isEmpty()) {
+    println "durability.groovy: GlobalDefaultFlowDurabilityLevel descriptor missing (workflow-api plugin not installed?)"
+    return
+}
+
+def d = descriptors[0]
+def current = d.durabilityHint
+def target = FlowDurabilityHint.MAX_SURVIVABILITY
+
+if (current != target) {
+    d.setDurabilityHint(target)
+    d.save()
+    println "durability.groovy: ${current} -> ${target}"
+} else {
+    println "durability.groovy: GlobalDefaultFlowDurabilityLevel already ${target}"
+}

--- a/IaC/ps57.cd/init.groovy.d/durability.groovy
+++ b/IaC/ps57.cd/init.groovy.d/durability.groovy
@@ -1,0 +1,53 @@
+/**
+ * Persist the global pipeline durability hint as MAX_SURVIVABILITY at
+ * every JVM boot, by calling the GlobalDefaultFlowDurabilityLevel
+ * descriptor's setDurabilityHint() + save() so the value lands in
+ * $JENKINS_HOME/org.jenkinsci.plugins.workflow.flow.GlobalDefaultFlowDurabilityLevel.xml
+ * (the descriptor's standard config file). Idempotent on the happy
+ * path: when the hint already matches the target, the script is a no-op.
+ *
+ * Background. Pipeline builds use one of three durability hints:
+ *   PERFORMANCE_OPTIMIZED  - FlowNode state kept in memory until the
+ *                            build finishes; an abrupt JVM stop
+ *                            (kill -9, AWS spot interrupt) loses the
+ *                            whole in-flight build.
+ *   SURVIVABLE_NONATOMIC   - persists eventually, weaker ordering.
+ *   MAX_SURVIVABILITY      - persists each FlowNode as it executes, so
+ *                            a build resumes at the same step on JVM
+ *                            return.
+ *
+ * Why explicit when workflow-api already advertises MAX_SURVIVABILITY
+ * as the default? The default is fragile: any operator change in
+ * Manage Jenkins -> System silently writes the descriptor's XML and
+ * can replace the hint with no IaC trace. Writing the value ourselves
+ * at every boot anchors the canary's resilience guarantee.
+ *
+ * Note on the descriptor: when no XML exists, the descriptor's in-memory
+ * field is null (the MAX_SURVIVABILITY default lives at a higher
+ * layer in workflow-api). So `current != target` correctly fires the
+ * write path on a fresh master, and the resulting save() materialises
+ * the on-disk XML.
+ *
+ * Scope: ps3 canary only. PS-11173 Phase 2.
+ */
+import org.jenkinsci.plugins.workflow.flow.FlowDurabilityHint
+import jenkins.model.Jenkins
+
+def descCls = Class.forName('org.jenkinsci.plugins.workflow.flow.GlobalDefaultFlowDurabilityLevel$DescriptorImpl')
+def descriptors = Jenkins.instance.getExtensionList(descCls)
+if (descriptors.isEmpty()) {
+    println "durability.groovy: GlobalDefaultFlowDurabilityLevel descriptor missing (workflow-api plugin not installed?)"
+    return
+}
+
+def d = descriptors[0]
+def current = d.durabilityHint
+def target = FlowDurabilityHint.MAX_SURVIVABILITY
+
+if (current != target) {
+    d.setDurabilityHint(target)
+    d.save()
+    println "durability.groovy: ${current} -> ${target}"
+} else {
+    println "durability.groovy: GlobalDefaultFlowDurabilityLevel already ${target}"
+}

--- a/IaC/ps80.cd/init.groovy.d/durability.groovy
+++ b/IaC/ps80.cd/init.groovy.d/durability.groovy
@@ -1,0 +1,53 @@
+/**
+ * Persist the global pipeline durability hint as MAX_SURVIVABILITY at
+ * every JVM boot, by calling the GlobalDefaultFlowDurabilityLevel
+ * descriptor's setDurabilityHint() + save() so the value lands in
+ * $JENKINS_HOME/org.jenkinsci.plugins.workflow.flow.GlobalDefaultFlowDurabilityLevel.xml
+ * (the descriptor's standard config file). Idempotent on the happy
+ * path: when the hint already matches the target, the script is a no-op.
+ *
+ * Background. Pipeline builds use one of three durability hints:
+ *   PERFORMANCE_OPTIMIZED  - FlowNode state kept in memory until the
+ *                            build finishes; an abrupt JVM stop
+ *                            (kill -9, AWS spot interrupt) loses the
+ *                            whole in-flight build.
+ *   SURVIVABLE_NONATOMIC   - persists eventually, weaker ordering.
+ *   MAX_SURVIVABILITY      - persists each FlowNode as it executes, so
+ *                            a build resumes at the same step on JVM
+ *                            return.
+ *
+ * Why explicit when workflow-api already advertises MAX_SURVIVABILITY
+ * as the default? The default is fragile: any operator change in
+ * Manage Jenkins -> System silently writes the descriptor's XML and
+ * can replace the hint with no IaC trace. Writing the value ourselves
+ * at every boot anchors the canary's resilience guarantee.
+ *
+ * Note on the descriptor: when no XML exists, the descriptor's in-memory
+ * field is null (the MAX_SURVIVABILITY default lives at a higher
+ * layer in workflow-api). So `current != target` correctly fires the
+ * write path on a fresh master, and the resulting save() materialises
+ * the on-disk XML.
+ *
+ * Scope: ps3 canary only. PS-11173 Phase 2.
+ */
+import org.jenkinsci.plugins.workflow.flow.FlowDurabilityHint
+import jenkins.model.Jenkins
+
+def descCls = Class.forName('org.jenkinsci.plugins.workflow.flow.GlobalDefaultFlowDurabilityLevel$DescriptorImpl')
+def descriptors = Jenkins.instance.getExtensionList(descCls)
+if (descriptors.isEmpty()) {
+    println "durability.groovy: GlobalDefaultFlowDurabilityLevel descriptor missing (workflow-api plugin not installed?)"
+    return
+}
+
+def d = descriptors[0]
+def current = d.durabilityHint
+def target = FlowDurabilityHint.MAX_SURVIVABILITY
+
+if (current != target) {
+    d.setDurabilityHint(target)
+    d.save()
+    println "durability.groovy: ${current} -> ${target}"
+} else {
+    println "durability.groovy: GlobalDefaultFlowDurabilityLevel already ${target}"
+}

--- a/IaC/psmdb.cd/init.groovy.d/durability.groovy
+++ b/IaC/psmdb.cd/init.groovy.d/durability.groovy
@@ -1,0 +1,53 @@
+/**
+ * Persist the global pipeline durability hint as MAX_SURVIVABILITY at
+ * every JVM boot, by calling the GlobalDefaultFlowDurabilityLevel
+ * descriptor's setDurabilityHint() + save() so the value lands in
+ * $JENKINS_HOME/org.jenkinsci.plugins.workflow.flow.GlobalDefaultFlowDurabilityLevel.xml
+ * (the descriptor's standard config file). Idempotent on the happy
+ * path: when the hint already matches the target, the script is a no-op.
+ *
+ * Background. Pipeline builds use one of three durability hints:
+ *   PERFORMANCE_OPTIMIZED  - FlowNode state kept in memory until the
+ *                            build finishes; an abrupt JVM stop
+ *                            (kill -9, AWS spot interrupt) loses the
+ *                            whole in-flight build.
+ *   SURVIVABLE_NONATOMIC   - persists eventually, weaker ordering.
+ *   MAX_SURVIVABILITY      - persists each FlowNode as it executes, so
+ *                            a build resumes at the same step on JVM
+ *                            return.
+ *
+ * Why explicit when workflow-api already advertises MAX_SURVIVABILITY
+ * as the default? The default is fragile: any operator change in
+ * Manage Jenkins -> System silently writes the descriptor's XML and
+ * can replace the hint with no IaC trace. Writing the value ourselves
+ * at every boot anchors the canary's resilience guarantee.
+ *
+ * Note on the descriptor: when no XML exists, the descriptor's in-memory
+ * field is null (the MAX_SURVIVABILITY default lives at a higher
+ * layer in workflow-api). So `current != target` correctly fires the
+ * write path on a fresh master, and the resulting save() materialises
+ * the on-disk XML.
+ *
+ * Scope: ps3 canary only. PS-11173 Phase 2.
+ */
+import org.jenkinsci.plugins.workflow.flow.FlowDurabilityHint
+import jenkins.model.Jenkins
+
+def descCls = Class.forName('org.jenkinsci.plugins.workflow.flow.GlobalDefaultFlowDurabilityLevel$DescriptorImpl')
+def descriptors = Jenkins.instance.getExtensionList(descCls)
+if (descriptors.isEmpty()) {
+    println "durability.groovy: GlobalDefaultFlowDurabilityLevel descriptor missing (workflow-api plugin not installed?)"
+    return
+}
+
+def d = descriptors[0]
+def current = d.durabilityHint
+def target = FlowDurabilityHint.MAX_SURVIVABILITY
+
+if (current != target) {
+    d.setDurabilityHint(target)
+    d.save()
+    println "durability.groovy: ${current} -> ${target}"
+} else {
+    println "durability.groovy: GlobalDefaultFlowDurabilityLevel already ${target}"
+}

--- a/IaC/pxb.cd/init.groovy.d/durability.groovy
+++ b/IaC/pxb.cd/init.groovy.d/durability.groovy
@@ -1,0 +1,53 @@
+/**
+ * Persist the global pipeline durability hint as MAX_SURVIVABILITY at
+ * every JVM boot, by calling the GlobalDefaultFlowDurabilityLevel
+ * descriptor's setDurabilityHint() + save() so the value lands in
+ * $JENKINS_HOME/org.jenkinsci.plugins.workflow.flow.GlobalDefaultFlowDurabilityLevel.xml
+ * (the descriptor's standard config file). Idempotent on the happy
+ * path: when the hint already matches the target, the script is a no-op.
+ *
+ * Background. Pipeline builds use one of three durability hints:
+ *   PERFORMANCE_OPTIMIZED  - FlowNode state kept in memory until the
+ *                            build finishes; an abrupt JVM stop
+ *                            (kill -9, AWS spot interrupt) loses the
+ *                            whole in-flight build.
+ *   SURVIVABLE_NONATOMIC   - persists eventually, weaker ordering.
+ *   MAX_SURVIVABILITY      - persists each FlowNode as it executes, so
+ *                            a build resumes at the same step on JVM
+ *                            return.
+ *
+ * Why explicit when workflow-api already advertises MAX_SURVIVABILITY
+ * as the default? The default is fragile: any operator change in
+ * Manage Jenkins -> System silently writes the descriptor's XML and
+ * can replace the hint with no IaC trace. Writing the value ourselves
+ * at every boot anchors the canary's resilience guarantee.
+ *
+ * Note on the descriptor: when no XML exists, the descriptor's in-memory
+ * field is null (the MAX_SURVIVABILITY default lives at a higher
+ * layer in workflow-api). So `current != target` correctly fires the
+ * write path on a fresh master, and the resulting save() materialises
+ * the on-disk XML.
+ *
+ * Scope: ps3 canary only. PS-11173 Phase 2.
+ */
+import org.jenkinsci.plugins.workflow.flow.FlowDurabilityHint
+import jenkins.model.Jenkins
+
+def descCls = Class.forName('org.jenkinsci.plugins.workflow.flow.GlobalDefaultFlowDurabilityLevel$DescriptorImpl')
+def descriptors = Jenkins.instance.getExtensionList(descCls)
+if (descriptors.isEmpty()) {
+    println "durability.groovy: GlobalDefaultFlowDurabilityLevel descriptor missing (workflow-api plugin not installed?)"
+    return
+}
+
+def d = descriptors[0]
+def current = d.durabilityHint
+def target = FlowDurabilityHint.MAX_SURVIVABILITY
+
+if (current != target) {
+    d.setDurabilityHint(target)
+    d.save()
+    println "durability.groovy: ${current} -> ${target}"
+} else {
+    println "durability.groovy: GlobalDefaultFlowDurabilityLevel already ${target}"
+}

--- a/IaC/pxc.cd/init.groovy.d/durability.groovy
+++ b/IaC/pxc.cd/init.groovy.d/durability.groovy
@@ -1,0 +1,53 @@
+/**
+ * Persist the global pipeline durability hint as MAX_SURVIVABILITY at
+ * every JVM boot, by calling the GlobalDefaultFlowDurabilityLevel
+ * descriptor's setDurabilityHint() + save() so the value lands in
+ * $JENKINS_HOME/org.jenkinsci.plugins.workflow.flow.GlobalDefaultFlowDurabilityLevel.xml
+ * (the descriptor's standard config file). Idempotent on the happy
+ * path: when the hint already matches the target, the script is a no-op.
+ *
+ * Background. Pipeline builds use one of three durability hints:
+ *   PERFORMANCE_OPTIMIZED  - FlowNode state kept in memory until the
+ *                            build finishes; an abrupt JVM stop
+ *                            (kill -9, AWS spot interrupt) loses the
+ *                            whole in-flight build.
+ *   SURVIVABLE_NONATOMIC   - persists eventually, weaker ordering.
+ *   MAX_SURVIVABILITY      - persists each FlowNode as it executes, so
+ *                            a build resumes at the same step on JVM
+ *                            return.
+ *
+ * Why explicit when workflow-api already advertises MAX_SURVIVABILITY
+ * as the default? The default is fragile: any operator change in
+ * Manage Jenkins -> System silently writes the descriptor's XML and
+ * can replace the hint with no IaC trace. Writing the value ourselves
+ * at every boot anchors the canary's resilience guarantee.
+ *
+ * Note on the descriptor: when no XML exists, the descriptor's in-memory
+ * field is null (the MAX_SURVIVABILITY default lives at a higher
+ * layer in workflow-api). So `current != target` correctly fires the
+ * write path on a fresh master, and the resulting save() materialises
+ * the on-disk XML.
+ *
+ * Scope: ps3 canary only. PS-11173 Phase 2.
+ */
+import org.jenkinsci.plugins.workflow.flow.FlowDurabilityHint
+import jenkins.model.Jenkins
+
+def descCls = Class.forName('org.jenkinsci.plugins.workflow.flow.GlobalDefaultFlowDurabilityLevel$DescriptorImpl')
+def descriptors = Jenkins.instance.getExtensionList(descCls)
+if (descriptors.isEmpty()) {
+    println "durability.groovy: GlobalDefaultFlowDurabilityLevel descriptor missing (workflow-api plugin not installed?)"
+    return
+}
+
+def d = descriptors[0]
+def current = d.durabilityHint
+def target = FlowDurabilityHint.MAX_SURVIVABILITY
+
+if (current != target) {
+    d.setDurabilityHint(target)
+    d.save()
+    println "durability.groovy: ${current} -> ${target}"
+} else {
+    println "durability.groovy: GlobalDefaultFlowDurabilityLevel already ${target}"
+}

--- a/IaC/rel.cd/init.groovy.d/durability.groovy
+++ b/IaC/rel.cd/init.groovy.d/durability.groovy
@@ -1,0 +1,53 @@
+/**
+ * Persist the global pipeline durability hint as MAX_SURVIVABILITY at
+ * every JVM boot, by calling the GlobalDefaultFlowDurabilityLevel
+ * descriptor's setDurabilityHint() + save() so the value lands in
+ * $JENKINS_HOME/org.jenkinsci.plugins.workflow.flow.GlobalDefaultFlowDurabilityLevel.xml
+ * (the descriptor's standard config file). Idempotent on the happy
+ * path: when the hint already matches the target, the script is a no-op.
+ *
+ * Background. Pipeline builds use one of three durability hints:
+ *   PERFORMANCE_OPTIMIZED  - FlowNode state kept in memory until the
+ *                            build finishes; an abrupt JVM stop
+ *                            (kill -9, AWS spot interrupt) loses the
+ *                            whole in-flight build.
+ *   SURVIVABLE_NONATOMIC   - persists eventually, weaker ordering.
+ *   MAX_SURVIVABILITY      - persists each FlowNode as it executes, so
+ *                            a build resumes at the same step on JVM
+ *                            return.
+ *
+ * Why explicit when workflow-api already advertises MAX_SURVIVABILITY
+ * as the default? The default is fragile: any operator change in
+ * Manage Jenkins -> System silently writes the descriptor's XML and
+ * can replace the hint with no IaC trace. Writing the value ourselves
+ * at every boot anchors the canary's resilience guarantee.
+ *
+ * Note on the descriptor: when no XML exists, the descriptor's in-memory
+ * field is null (the MAX_SURVIVABILITY default lives at a higher
+ * layer in workflow-api). So `current != target` correctly fires the
+ * write path on a fresh master, and the resulting save() materialises
+ * the on-disk XML.
+ *
+ * Scope: ps3 canary only. PS-11173 Phase 2.
+ */
+import org.jenkinsci.plugins.workflow.flow.FlowDurabilityHint
+import jenkins.model.Jenkins
+
+def descCls = Class.forName('org.jenkinsci.plugins.workflow.flow.GlobalDefaultFlowDurabilityLevel$DescriptorImpl')
+def descriptors = Jenkins.instance.getExtensionList(descCls)
+if (descriptors.isEmpty()) {
+    println "durability.groovy: GlobalDefaultFlowDurabilityLevel descriptor missing (workflow-api plugin not installed?)"
+    return
+}
+
+def d = descriptors[0]
+def current = d.durabilityHint
+def target = FlowDurabilityHint.MAX_SURVIVABILITY
+
+if (current != target) {
+    d.setDurabilityHint(target)
+    d.save()
+    println "durability.groovy: ${current} -> ${target}"
+} else {
+    println "durability.groovy: GlobalDefaultFlowDurabilityLevel already ${target}"
+}


### PR DESCRIPTION
**Feature**
- Adds `IaC/<inst>.cd/init.groovy.d/durability.groovy` to the 9 non-ps3 masters (cloud, pg, pmm, ps57, ps80, psmdb, pxb, pxc, rel), each an identical copy of the master-agnostic file [PR 4101](https://github.com/Percona-Lab/jenkins-pipelines/pull/4101) added for ps3.
- Sets the global Workflow durability hint to `MAX_SURVIVABILITY` at every JVM boot, persisted via `$JENKINS_HOME/org.jenkinsci.plugins.workflow.flow.GlobalDefaultFlowDurabilityLevel.xml`. Idempotent.
- Hot-deploys per master via `jenkins iac deploy durability.groovy -i <inst>`; no JVM restart needed for the durability hint to take effect on subsequent pipelines.

**Why**
- Surfaced today on ps57: `durabilityHint = DEFAULT (PERFORMANCE_OPTIMIZED)`, so a JVM restart drops every in-flight pipeline because flow node state is in-memory only. The same gap exists on the other 8 non-ps3 masters.
- PR 4101 was explicitly scoped to ps3 only; this is the Phase 2 fan-out left implicit by the original [PS-11173](https://perconadev.atlassian.net/browse/PS-11173) plan.

**Tickets**
- [PS-11173](https://perconadev.atlassian.net/browse/PS-11173) Phase 2 fan-out.
- Pattern: [PR 4101](https://github.com/Percona-Lab/jenkins-pipelines/pull/4101) (ps3-only original).

[PS-11173]: https://perconadev.atlassian.net/browse/PS-11173?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[PS-11173]: https://perconadev.atlassian.net/browse/PS-11173?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ