### PR TITLE
PS-11179: Add EC2FleetCloud Groovy on ps57 (mirror of ps3 codification)

### DIFF
--- a/IaC/ps57.cd/init.groovy.d/ec2FleetCloud.groovy
+++ b/IaC/ps57.cd/init.groovy.d/ec2FleetCloud.groovy
@@ -1,0 +1,76 @@
+// ec2FleetCloud.groovy  (PS-11179)
+//
+// Registers the diversified Graviton EC2 Fleet (ASG-backed via the ec2-fleet
+// plugin) as a Jenkins Cloud serving the `docker-32gb-aarch64` label on ps57.
+// Uniform multi-SKU fallback path with ps3 (sibling PR 4126) and ps80
+// (post-PS-11206 cutover follow-up).
+//
+// IAM: the `Ec2FleetPluginAutoScaling` policy is attached to the CFN-managed
+// jenkins-ps57-master role by the standalone TF block in
+// terraform/master-ps57.tf (jenkins-arm-fleet module). The plugin uses the
+// master IAM instance profile (`awsCredentialsId = ""`).
+//
+// SSH: the `percona-jenkins` private-key credential is loaded into ps57; it
+// matches the AWS key pair on the Launch Template (`key_name = "percona-jenkins"`).
+// `privateIpUsed = true` because the eu-central-1 master's egress does not
+// reliably reach the worker's public IP; master + worker share the same VPC
+// (vpc-017b8f29d90593313 / 10.177.0.0/22), so private IP routing works.
+//
+// Idempotent: re-applying via `jenkins iac deploy` removes the prior cloud
+// instance with the same name before adding the fresh one.
+
+import com.amazon.jenkins.ec2fleet.EC2FleetCloud
+import hudson.plugins.sshslaves.SSHConnector
+import hudson.plugins.sshslaves.verifiers.NonVerifyingKeyVerificationStrategy
+import jenkins.model.Jenkins
+import java.util.logging.Logger
+
+final Logger LOG = Logger.getLogger('ec2FleetCloud')
+final String CLOUD_NAME   = 'arm-graviton-fleet'
+final String REGION       = 'eu-central-1'
+final String ASG_NAME     = 'jenkins-ps57-arm-graviton'
+final String LABEL        = 'docker-32gb-aarch64'
+final String SSH_CRED_ID  = 'percona-jenkins'
+
+Jenkins.instance.clouds.findAll { it.name == CLOUD_NAME }.each {
+    Jenkins.instance.clouds.remove(it)
+}
+
+def sshConn = new SSHConnector(
+    22, SSH_CRED_ID,
+    '', '', '', '',
+    null, null, null,
+    new NonVerifyingKeyVerificationStrategy()
+)
+
+def fleet = new EC2FleetCloud(
+    CLOUD_NAME,
+    '',                          // awsCredentialsId (empty -> master IAM instance profile)
+    '',                          // credentialsId (legacy field, kept empty)
+    REGION,
+    '',                          // endpoint
+    ASG_NAME,
+    LABEL,
+    '/mnt/jenkins',              // fsRoot
+    sshConn,                     // computerConnector
+    true,                        // privateIpUsed -- master + worker share the master VPC; public-IP SSH egress is not reliable in eu-central-1
+    false,                       // alwaysReconnect
+    (Integer) 10,                // idleMinutes (NON-zero: 0 = never scale down)
+    0,                           // minSize
+    16,                          // maxSize (matches TF)
+    0,                           // minSpareSize
+    1,                           // numExecutors
+    true,                        // addNodeOnlyIfRunning
+    false,                       // restrictUsage
+    '-1',                        // maxTotalUses (-1 = unlimited)
+    false,                       // disableTaskResubmit
+    (Integer) 600,               // initOnlineTimeoutSec
+    (Integer) 15,                // initOnlineCheckIntervalSec
+    (Integer) 10,                // cloudStatusIntervalSec
+    false,                       // noDelayProvision
+    false,                       // scaleExecutorsByWeight
+    new EC2FleetCloud.NoScaler()
+)
+
+Jenkins.instance.clouds.add(fleet)
+LOG.info("ec2FleetCloud: registered cloud='${CLOUD_NAME}' label='${LABEL}' fleet='${ASG_NAME}' region='${REGION}'")


### PR DESCRIPTION
**Feature**
- Adds `IaC/ps57.cd/init.groovy.d/ec2FleetCloud.groovy`: registers the diversified Graviton EC2 Fleet on ps57 (ASG `jenkins-ps57-arm-graviton` in eu-central-1) as a Jenkins Cloud serving the `docker-32gb-aarch64` label, sibling to [PR 4126](https://github.com/Percona-Lab/jenkins-pipelines/pull/4126) for ps3.
- Sets `privateIpUsed=true` so the `SSHConnector` uses the worker's private IP; master and worker share the ps57 VPC, and the eu-central-1 master's egress does not reliably reach the worker's public IP.
- Validated end-to-end today: ASG `desired=1` triggered, AWS picked a Graviton `m8g.2xlarge` from the diversified `m8g/m7g/m6g` pool, SSH connect via `percona-jenkins`, aarch64 build executed and finished SUCCESS.

**Why**
- ps57 has the `ec2-fleet` plugin installed and the ASG/LT/IAM substrate live; this codifies the in-memory `EC2FleetCloud` so it survives JVM restarts.
- Uniform multi-SKU Graviton fallback across ps3 + ps57 (ps80 follows after the Friday PS-11206 cutover), per the no-mixed-SKU directive.

**Tickets**
- [PS-11179](https://perconadev.atlassian.net/browse/PS-11179)

[PS-11179]: https://perconadev.atlassian.net/browse/PS-11179?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ