### PR TITLE
PMM-7: Use client package release 1 for PMM 3.8.1+

### DIFF
--- a/pmm/v3/vars/pmmClientPackageRelease.groovy
+++ b/pmm/v3/vars/pmmClientPackageRelease.groovy
@@ -1,0 +1,27 @@
+/**
+ * RPM/DEB release suffix for pinned pmm-client package installs.
+ * Matches percona/pmm build-client-packages after PMM-7 (RPM_RELEASE/DEB_RELEASE reset to 1 for 3.8.1+).
+ */
+String call(String clientVersion) {
+    if (!(clientVersion ==~ /^3\.\d+\.\d+$/)) {
+        return null
+    }
+    if (clientVersion in ['3.7.1', '3.8.0']) {
+        return '8'
+    }
+    if (compareSemver(clientVersion, '3.8.0') > 0) {
+        return '1'
+    }
+    return '7'
+}
+
+private static int compareSemver(String left, String right) {
+    def leftParts = left.tokenize('.').collect { it as int }
+    def rightParts = right.tokenize('.').collect { it as int }
+    for (int i = 0; i < 3; i++) {
+        if (leftParts[i] != rightParts[i]) {
+            return leftParts[i] <=> rightParts[i]
+        }
+    }
+    return 0
+}

--- a/pmm/v3/vars/pmmClientPackageRelease.groovy
+++ b/pmm/v3/vars/pmmClientPackageRelease.groovy
@@ -9,19 +9,9 @@ String call(String clientVersion) {
     if (clientVersion in ['3.7.1', '3.8.0']) {
         return '8'
     }
-    if (compareSemver(clientVersion, '3.8.0') > 0) {
+    def minor = clientVersion.tokenize('.')[1] as int
+    if (clientVersion == '3.8.1' || minor > 8) {
         return '1'
     }
     return '7'
-}
-
-private static int compareSemver(String left, String right) {
-    def leftParts = left.tokenize('.').collect { it as int }
-    def rightParts = right.tokenize('.').collect { it as int }
-    for (int i = 0; i < 3; i++) {
-        if (leftParts[i] != rightParts[i]) {
-            return leftParts[i] <=> rightParts[i]
-        }
-    }
-    return 0
 }

--- a/pmm/v3/vars/setupPMM3Client.groovy
+++ b/pmm/v3/vars/setupPMM3Client.groovy
@@ -1,4 +1,5 @@
 def call(String SERVER_IP, String CLIENT_VERSION, String PMM_VERSION, String ENABLE_PULL_MODE, String ENABLE_TESTING_REPO, String CLIENT_INSTANCE, String SETUP_TYPE, String ADMIN_PASSWORD = 'admin', String ENABLE_EXPERIMENTAL_REPO = 'yes') {
+   def clientPackageRelease = pmmClientPackageRelease(CLIENT_VERSION) ?: ''
    withCredentials([[$class: 'AmazonWebServicesCredentialsBinding', accessKeyVariable: 'AWS_ACCESS_KEY_ID', credentialsId: 'AMI/OVF', secretKeyVariable: 'AWS_SECRET_ACCESS_KEY']]) {
         withEnv([
             "SERVER_IP=${SERVER_IP}",
@@ -10,6 +11,7 @@ def call(String SERVER_IP, String CLIENT_VERSION, String PMM_VERSION, String ENA
             "SETUP_TYPE=${SETUP_TYPE}",
             "ADMIN_PASSWORD=${ADMIN_PASSWORD}",
             "ENABLE_EXPERIMENTAL_REPO=${ENABLE_EXPERIMENTAL_REPO}",
+            "PMM_CLIENT_PACKAGE_RELEASE=${clientPackageRelease}",
         ]) {
         sh '''
             set -o errexit
@@ -79,8 +81,12 @@ def call(String SERVER_IP, String CLIENT_VERSION, String PMM_VERSION, String ENA
                     sudo percona-release enable-only pmm3-client release
                 fi
 
-                export FULL_CLIENT_VERSION=$(dnf list pmm-client --showduplicates | grep -w "${CLIENT_VERSION}" | awk '{print $2}')
-                retry_dnf_install "pmm-client-${FULL_CLIENT_VERSION}"
+                if [[ -n "${PMM_CLIENT_PACKAGE_RELEASE}" ]]; then
+                    retry_dnf_install "pmm-client-${CLIENT_VERSION}-${PMM_CLIENT_PACKAGE_RELEASE}.el9.x86_64"
+                else
+                    export FULL_CLIENT_VERSION=$(dnf list pmm-client --showduplicates | grep -w "${CLIENT_VERSION}" | awk '{print $2}')
+                    retry_dnf_install "pmm-client-${FULL_CLIENT_VERSION}"
+                fi
                 sleep 10
             else
                 if [[ "${CLIENT_VERSION}" = http* ]]; then


### PR DESCRIPTION
## Summary
- Add \pmmClientPackageRelease\ and use it in \setupPMM3Client\ when installing pinned PMM 3.x client RPMs.
- Release suffix: \7\ before 3.8.0, \8\ for 3.8.0 (and 3.7.1), \1\ for 3.8.1+ after percona/pmm#5433.

## Related
- Depends on percona/pmm#5433