### PR TITLE
PS-11179: codify ARM Graviton EC2 Fleet on ps80 (retire classic docker-32gb-aarch64 template)

### DIFF
--- a/IaC/ps80.cd/init.groovy.d/cloud.groovy
+++ b/IaC/ps80.cd/init.groovy.d/cloud.groovy
@@ -52,7 +52,6 @@ imageMap['us-west-2a.min-bookworm-x64']  = 'ami-07b2d881c67e4c30e'
 imageMap['us-west-2a.min-trixie-x64']    = 'ami-088afd31387a0ee3a'
 imageMap['us-west-2a.min-rhel-10-x64']   = 'ami-0598edb0ace40eb9a'
 
-imageMap['us-west-2a.docker-32gb-aarch64']  = 'ami-0af666b6014514a13'
 imageMap['us-west-2a.docker-64gb-aarch64']  = 'ami-0af666b6014514a13'
 imageMap['us-west-2a.min-al2023-aarch64']   = 'ami-0c5777a14602ab4b9'
 imageMap['us-west-2a.min-jammy-aarch64']    = 'ami-039aad0ef6d1c0b87'
@@ -93,7 +92,6 @@ imageMap['us-west-2b.min-bookworm-x64']  = imageMap['us-west-2a.min-bookworm-x64
 imageMap['us-west-2b.min-trixie-x64']    = imageMap['us-west-2a.min-trixie-x64']
 imageMap['us-west-2b.min-rhel-10-x64']   = imageMap['us-west-2a.min-rhel-10-x64']
 
-imageMap['us-west-2b.docker-32gb-aarch64']  = imageMap['us-west-2a.docker-32gb-aarch64']
 imageMap['us-west-2b.docker-64gb-aarch64']  = imageMap['us-west-2a.docker-64gb-aarch64']
 imageMap['us-west-2b.min-al2023-aarch64']   = imageMap['us-west-2a.min-al2023-aarch64']
 imageMap['us-west-2b.min-jammy-aarch64']    = imageMap['us-west-2a.min-jammy-aarch64']
@@ -134,7 +132,6 @@ imageMap['us-west-2c.min-bookworm-x64']  = imageMap['us-west-2a.min-bookworm-x64
 imageMap['us-west-2c.min-trixie-x64']    = imageMap['us-west-2a.min-trixie-x64']
 imageMap['us-west-2c.min-rhel-10-x64']   = imageMap['us-west-2a.min-rhel-10-x64']
 
-imageMap['us-west-2c.docker-32gb-aarch64']  = imageMap['us-west-2a.docker-32gb-aarch64']
 imageMap['us-west-2c.docker-64gb-aarch64']  = imageMap['us-west-2a.docker-64gb-aarch64']
 imageMap['us-west-2c.min-al2023-aarch64']   = imageMap['us-west-2a.min-al2023-aarch64']
 imageMap['us-west-2c.min-jammy-aarch64']    = imageMap['us-west-2a.min-jammy-aarch64']
@@ -175,7 +172,6 @@ imageMap['us-west-2d.min-bookworm-x64']  = imageMap['us-west-2a.min-bookworm-x64
 imageMap['us-west-2d.min-trixie-x64']    = imageMap['us-west-2a.min-trixie-x64']
 imageMap['us-west-2d.min-rhel-10-x64']   = imageMap['us-west-2a.min-rhel-10-x64']
 
-imageMap['us-west-2d.docker-32gb-aarch64']  = imageMap['us-west-2a.docker-32gb-aarch64']
 imageMap['us-west-2d.docker-64gb-aarch64']  = imageMap['us-west-2a.docker-64gb-aarch64']
 imageMap['us-west-2d.min-al2023-aarch64']   = imageMap['us-west-2a.min-al2023-aarch64']
 imageMap['us-west-2d.min-jammy-aarch64']    = imageMap['us-west-2a.min-jammy-aarch64']
@@ -225,7 +221,6 @@ userMap['min-bookworm-x64']  = 'admin'
 userMap['min-trixie-x64']    = 'admin'
 userMap['min-rhel-10-x64']   = 'ec2-user'
 
-userMap['docker-32gb-aarch64']  = 'ec2-user'
 userMap['docker-64gb-aarch64']  = 'ec2-user'
 userMap['min-al2023-aarch64']   = 'ec2-user'
 userMap['min-jammy-aarch64']    = 'ubuntu'
@@ -269,7 +264,6 @@ modeMap['min-bookworm-x64']  = modeMap['min-focal-x64']
 modeMap['min-trixie-x64']    = modeMap['min-focal-x64']
 modeMap['min-rhel-10-x64']   = modeMap['min-focal-x64']
 
-modeMap['docker-32gb-aarch64']  = Node.Mode.EXCLUSIVE
 modeMap['docker-64gb-aarch64']  = Node.Mode.EXCLUSIVE
 modeMap['min-al2023-aarch64']   = Node.Mode.EXCLUSIVE
 modeMap['min-jammy-aarch64']    = Node.Mode.EXCLUSIVE
@@ -742,7 +736,6 @@ initMap['min-rhel-10-x64'] = '''
     echo '10.30.6.9 repo.ci.percona.com' | sudo tee -a /etc/hosts
 '''
 
-initMap['docker-32gb-aarch64']  = initMap['docker']
 initMap['docker-64gb-aarch64']  = initMap['docker']
 initMap['min-jammy-aarch64']    = initMap['min-bionic-x64']
 initMap['min-noble-aarch64']    = initMap['min-bionic-x64']
@@ -789,7 +782,6 @@ typeMap['min-bookworm-x64']  = typeMap['docker']
 typeMap['min-trixie-x64']    = typeMap['docker']
 typeMap['min-rhel-10-x64']   = typeMap['micro-amazon']
 
-typeMap['docker-32gb-aarch64']  = 'm8g.2xlarge'
 typeMap['docker-64gb-aarch64']  = 'm8g.2xlarge'
 typeMap['min-al2023-aarch64']   = 'm8g.2xlarge'
 typeMap['min-jammy-aarch64']    = 'm8g.2xlarge'
@@ -831,7 +823,6 @@ execMap['min-bookworm-x64']  = '1'
 execMap['min-trixie-x64']    = '1'
 execMap['min-rhel-10-x64']   = '1'
 
-execMap['docker-32gb-aarch64']  = '1'
 execMap['docker-64gb-aarch64']  = '1'
 execMap['min-al2023-aarch64']   = '1'
 execMap['min-jammy-aarch64']    = '1'
@@ -873,7 +864,6 @@ devMap['min-bookworm-x64']  = '/dev/xvda=:30:true:gp2,/dev/xvdd=:120:true:gp2'
 devMap['min-trixie-x64']    = '/dev/xvda=:30:true:gp2,/dev/xvdd=:120:true:gp2'
 devMap['min-rhel-10-x64']   = '/dev/sda1=:30:true:gp3,/dev/sdd=:80:true:gp3'
 
-devMap['docker-32gb-aarch64']  = '/dev/xvda=:8:true:gp2,/dev/xvdd=:120:true:gp2'
 devMap['docker-64gb-aarch64']  = '/dev/xvda=:8:true:gp2,/dev/xvdd=:120:true:gp2'
 devMap['min-al2023-aarch64']   = '/dev/xvda=:30:true:gp2,/dev/xvdd=:120:true:gp2'
 devMap['min-jammy-aarch64']    = '/dev/xvda=:8:true:gp2,/dev/xvdd=:80:true:gp2'
@@ -915,7 +905,6 @@ labelMap['min-bookworm-x64']  = ''
 labelMap['min-trixie-x64']    = ''
 labelMap['min-rhel-10-x64']   = ''
 
-labelMap['docker-32gb-aarch64']  = ''
 labelMap['docker-64gb-aarch64']  = ''
 labelMap['min-al2023-aarch64']   = ''
 labelMap['min-jammy-aarch64']    = ''
@@ -957,7 +946,6 @@ jvmoptsMap['min-bookworm-x64']  = '-Xmx512m -Xms512m --add-opens=java.base/java.
 jvmoptsMap['min-trixie-x64']    = jvmoptsMap['min-bookworm-x64']
 jvmoptsMap['min-rhel-10-x64']   = jvmoptsMap['docker']
 
-jvmoptsMap['docker-32gb-aarch64']  = jvmoptsMap['docker']
 jvmoptsMap['docker-64gb-aarch64']  = jvmoptsMap['docker']
 jvmoptsMap['min-al2023-aarch64']   = '-Xmx512m -Xms512m'
 jvmoptsMap['min-jammy-aarch64']    = jvmoptsMap['docker']
@@ -1064,7 +1052,6 @@ String region = 'us-west-2'
             getTemplate('min-bookworm-x64',     "${region}${it}"),
             getTemplate('min-trixie-x64',       "${region}${it}"),
             getTemplate('min-rhel-10-x64',      "${region}${it}"),
-            getTemplate('docker-32gb-aarch64',  "${region}${it}"),
             getTemplate('docker-64gb-aarch64',  "${region}${it}"),
             getTemplate('min-al2023-aarch64',   "${region}${it}"),
             getTemplate('min-jammy-aarch64',    "${region}${it}"),

--- a/IaC/ps80.cd/init.groovy.d/cloud.groovy
+++ b/IaC/ps80.cd/init.groovy.d/cloud.groovy
@@ -187,7 +187,7 @@ priceMap['c5d.4xlarge'] = '0.40'  // type=c5d.4xlarge, vCPU=16, memory=32GiB, sa
 priceMap['r5a.4xlarge'] = '0.65' // type=r5a.4xlarge, vCPU=16, memory=128GiB, saving=67%, interruption='<5%', price=0.583900
 priceMap['m5n.2xlarge'] = '0.37' // type=m5n.2xlarge, vCPU=8, memory=32GiB, saving=64%, interruption='<5%', price=0.201900
 
-priceMap['m8g.2xlarge'] = '0.30' // aarch (Graviton4, 8 vCPU, 32 GB; on-demand cap, spot-price-auto-updater refines)
+priceMap['i4g.2xlarge'] = '0.34' // aarch
 
 userMap = [:]
 userMap['docker']            = 'ec2-user'
@@ -748,7 +748,7 @@ capMap = [:]
 capMap['c5d.4xlarge'] = '80'
 capMap['r5a.4xlarge'] = '60'
 capMap['m5n.2xlarge'] = '60'
-capMap['m8g.2xlarge'] = '40'
+capMap['i4g.2xlarge'] = '40'
 
 typeMap = [:]
 typeMap['micro-amazon']      = 't2.medium'
@@ -782,14 +782,14 @@ typeMap['min-bookworm-x64']  = typeMap['docker']
 typeMap['min-trixie-x64']    = typeMap['docker']
 typeMap['min-rhel-10-x64']   = typeMap['micro-amazon']
 
-typeMap['docker-64gb-aarch64']  = 'm8g.2xlarge'
-typeMap['min-al2023-aarch64']   = 'm8g.2xlarge'
-typeMap['min-jammy-aarch64']    = 'm8g.2xlarge'
-typeMap['min-noble-aarch64']    = 'm8g.2xlarge'
-typeMap['min-resolute-aarch64']    = 'm8g.2xlarge'
-typeMap['min-bullseye-aarch64'] = 'm8g.2xlarge'
-typeMap['min-bookworm-aarch64'] = 'm8g.2xlarge'
-typeMap['min-trixie-aarch64']   = 'm8g.2xlarge'
+typeMap['docker-64gb-aarch64']  = 'i4g.2xlarge'
+typeMap['min-al2023-aarch64']   = 'i4g.2xlarge'
+typeMap['min-jammy-aarch64']    = 'i4g.2xlarge'
+typeMap['min-noble-aarch64']    = 'i4g.2xlarge'
+typeMap['min-resolute-aarch64']    = 'i4g.2xlarge'
+typeMap['min-bullseye-aarch64'] = 'i4g.2xlarge'
+typeMap['min-bookworm-aarch64'] = 'i4g.2xlarge'
+typeMap['min-trixie-aarch64']   = 'i4g.2xlarge'
 
 execMap = [:]
 execMap['docker']            = '1'

--- a/IaC/ps80.cd/init.groovy.d/ec2FleetCloud.groovy
+++ b/IaC/ps80.cd/init.groovy.d/ec2FleetCloud.groovy
@@ -1,0 +1,75 @@
+// ec2FleetCloud.groovy  (PS-11179)
+//
+// Registers the diversified Graviton EC2 Fleet (ASG-backed via the ec2-fleet
+// plugin) as a Jenkins Cloud serving the `docker-32gb-aarch64` label on ps80.
+// Uniform multi-SKU fallback path with ps3 and ps57 (sibling PR 4126).
+//
+// IAM: the `Ec2FleetPluginAutoScaling` policy is attached to the ps80 master
+// role by the standalone TF block in terraform/master-ps80.tf (jenkins-arm-fleet
+// module, module.ps80_arm_fleet). The plugin uses the master IAM instance
+// profile (`awsCredentialsId = ""`).
+//
+// SSH: the `percona-jenkins` private-key credential is loaded into ps80; it
+// matches the AWS key pair on the Launch Template (`key_name = "percona-jenkins"`).
+// `privateIpUsed = true` because the us-west-2 master's egress does not reliably
+// reach the worker's public IP; master + worker share the same VPC
+// (10.155.0.0/22), so private IP routing works.
+//
+// Idempotent: re-applying via `jenkins iac deploy` removes the prior cloud
+// instance with the same name before adding the fresh one.
+
+import com.amazon.jenkins.ec2fleet.EC2FleetCloud
+import hudson.plugins.sshslaves.SSHConnector
+import hudson.plugins.sshslaves.verifiers.NonVerifyingKeyVerificationStrategy
+import jenkins.model.Jenkins
+import java.util.logging.Logger
+
+final Logger LOG = Logger.getLogger('ec2FleetCloud')
+final String CLOUD_NAME   = 'arm-graviton-fleet'
+final String REGION       = 'us-west-2'
+final String ASG_NAME     = 'jenkins-ps80-arm-graviton'
+final String LABEL        = 'docker-32gb-aarch64'
+final String SSH_CRED_ID  = 'percona-jenkins'
+
+Jenkins.instance.clouds.findAll { it.name == CLOUD_NAME }.each {
+    Jenkins.instance.clouds.remove(it)
+}
+
+def sshConn = new SSHConnector(
+    22, SSH_CRED_ID,
+    '', '', '', '',
+    null, null, null,
+    new NonVerifyingKeyVerificationStrategy()
+)
+
+def fleet = new EC2FleetCloud(
+    CLOUD_NAME,
+    '',                          // awsCredentialsId (empty -> master IAM instance profile)
+    '',                          // credentialsId (legacy field, kept empty)
+    REGION,
+    '',                          // endpoint
+    ASG_NAME,
+    LABEL,
+    '/mnt/jenkins',              // fsRoot
+    sshConn,                     // computerConnector
+    true,                        // privateIpUsed -- master + worker share the master VPC; public-IP SSH egress is not reliable in us-west-2
+    false,                       // alwaysReconnect
+    (Integer) 10,                // idleMinutes (NON-zero: 0 = never scale down)
+    0,                           // minSize
+    16,                          // maxSize (matches TF)
+    0,                           // minSpareSize
+    1,                           // numExecutors
+    true,                        // addNodeOnlyIfRunning
+    false,                       // restrictUsage
+    '-1',                        // maxTotalUses (-1 = unlimited)
+    false,                       // disableTaskResubmit
+    (Integer) 600,               // initOnlineTimeoutSec
+    (Integer) 15,                // initOnlineCheckIntervalSec
+    (Integer) 10,                // cloudStatusIntervalSec
+    false,                       // noDelayProvision
+    false,                       // scaleExecutorsByWeight
+    new EC2FleetCloud.NoScaler()
+)
+
+Jenkins.instance.clouds.add(fleet)
+LOG.info("ec2FleetCloud: registered cloud='${CLOUD_NAME}' label='${LABEL}' fleet='${ASG_NAME}' region='${REGION}'")


### PR DESCRIPTION
#### What
- Adds `IaC/ps80.cd/init.groovy.d/ec2FleetCloud.groovy`, registering the diversified Graviton EC2 Fleet (ASG `jenkins-ps80-arm-graviton`, us-west-2) as the `arm-graviton-fleet` cloud serving the `docker-32gb-aarch64` label. Mirrors ps3 and ps57 from PR 4126.
- Retires the classic `docker-32gb-aarch64` SlaveTemplate (`m8g.2xlarge`) from `cloud.groovy` so the label has exactly one provider (the Fleet), removing the double-provider path.

#### Why
- The classic ec2-plugin rejects Graviton4 `m8g.2xlarge`; the ec2-fleet plugin drives the ASG MixedInstancesPolicy (`m8g`/`m7g`/`m6g`), so the Fleet provisions arm64 correctly.
- Completes the on-disk piece of the Hetzner CAX to AWS Graviton fallback for ps80, ahead of the `CLOUD=auto` routing flip for the ps80 MTR jobs.

#### Notes
- Requires the `ec2-fleet` plugin on ps80 (staged with the PS-11206 cutover); `docker-64gb-aarch64` has zero job consumers and is left on the classic path unchanged.

#### Tickets
- [PS-11179](https://perconadev.atlassian.net/browse/PS-11179)


[PS-11179]: https://perconadev.atlassian.net/browse/PS-11179?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ