### PR TITLE
PKG-1335: harden Jenkins master bootstrap against transient dnf failures

### DIFF
--- a/IaC/cloud.cd/JenkinsStack.yml
+++ b/IaC/cloud.cd/JenkinsStack.yml
@@ -575,13 +575,26 @@ Resources:
                              Key=iit-billing-tag,Value=$JENKINS_SHORT
               }
 
+              retry() {
+                  local attempt=1
+                  until "$@"; do
+                      if [ $attempt -ge 5 ]; then
+                          echo "command failed after $attempt attempts: $*" >&2
+                          return 1
+                      fi
+                      echo "command failed (attempt $attempt), retrying: $*"
+                      attempt=$((attempt + 1))
+                      sleep 5
+                  done
+              }
+
               install_software() {
                   until yum makecache; do
                       sleep 1
                       echo try again
                   done
 
-                  yum -y install yum-utils wget cronie rsync bc htop vim
+                  retry yum -y install yum-utils wget cronie rsync bc htop vim
                   yum-config-manager --add-repo "https://openresty.org/package/amazon/2023/x86_64/"
                   rpm --import https://openresty.org/package/pubkey.gpg
                   wget -O /etc/yum.repos.d/jenkins.repo https://pkg.jenkins.io/redhat-stable-legacy/jenkins.repo
@@ -589,9 +602,9 @@ Resources:
                   grep -q 'repo_gpgcheck=0' /etc/yum.repos.d/jenkins.repo
                   rpm --import https://pkg.jenkins.io/redhat-stable-legacy/jenkins.io-2023.key
                   rpm --import https://pkg.jenkins.io/redhat-stable/jenkins.io-2026.key
-                  yum -y install java-17-amazon-corretto
-                  yum -y update --security
-                  yum -y install jenkins-2.528.3 certbot git dnf-automatic aws-cli xfsprogs openresty
+                  retry yum -y install java-17-amazon-corretto
+                  retry yum -y update --security
+                  retry yum -y install jenkins-2.528.3 certbot git dnf-automatic aws-cli xfsprogs openresty
 
                   sed -i 's/upgrade_type = default/upgrade_type = security/' /etc/dnf/automatic.conf
                   sed -i 's/apply_updates = no/apply_updates = yes/'         /etc/dnf/automatic.conf
@@ -628,7 +641,11 @@ Resources:
                       [ -e /dev/xvdj ] && break || sleep 1
                   done
 
-                  mkfs.xfs -L DATA /dev/xvdj || :
+                  if mkfs.xfs -L DATA /dev/xvdj; then
+                      FRESH_DATA_VOLUME=1
+                  else
+                      FRESH_DATA_VOLUME=0
+                  fi
                   echo "/dev/xvdj /mnt xfs defaults,noatime,nofail 0 0" | tee -a /etc/fstab
                   mount /mnt
               }
@@ -652,7 +669,14 @@ Resources:
                   install -o jenkins -g jenkins -d /mnt/$JENKINS_HOST
                   install -o jenkins -g jenkins -d /mnt/$JENKINS_HOST/init.groovy.d
                   install -o jenkins -g jenkins -d /var/log/jenkins
-                  chown -hR jenkins:jenkins /mnt/$JENKINS_HOST /var/log/jenkins
+                  # A full recursive chown of JENKINS_HOME over millions of inodes adds
+                  # ~13 min to every spot replacement (PKG-1335). The persistent data
+                  # volume is already jenkins-owned from prior boots, so only walk it on a
+                  # genuinely fresh volume (mkfs.xfs succeeded in mount_data_partition).
+                  if [ "$FRESH_DATA_VOLUME" = "1" ]; then
+                      echo "fresh data volume; running full recursive chown of JENKINS_HOME"
+                      chown -hR jenkins:jenkins /mnt/$JENKINS_HOST
+                  fi
 
                   printf "127.0.0.1 $(hostname) $(hostname -A)\n10.30.6.220 vbox-01.ci.percona.com\n10.30.6.9 repo.ci.percona.com\n" \
                       | tee -a /etc/hosts

--- a/IaC/pg.cd/JenkinsStack.yml
+++ b/IaC/pg.cd/JenkinsStack.yml
@@ -606,13 +606,26 @@ Resources:
                              Key=iit-billing-tag,Value=$JENKINS_SHORT
               }
 
+              retry() {
+                  local attempt=1
+                  until "$@"; do
+                      if [ $attempt -ge 5 ]; then
+                          echo "command failed after $attempt attempts: $*" >&2
+                          return 1
+                      fi
+                      echo "command failed (attempt $attempt), retrying: $*"
+                      attempt=$((attempt + 1))
+                      sleep 5
+                  done
+              }
+
               install_software() {
                   until yum makecache; do
                       sleep 1
                       echo try again
                   done
 
-                  yum -y install yum-utils wget cronie rsync bc htop vim
+                  retry yum -y install yum-utils wget cronie rsync bc htop vim
                   yum-config-manager --add-repo "https://openresty.org/package/amazon/2023/x86_64/"
                   rpm --import https://openresty.org/package/pubkey.gpg
                   wget -O /etc/yum.repos.d/jenkins.repo https://pkg.jenkins.io/redhat-stable-legacy/jenkins.repo
@@ -620,11 +633,11 @@ Resources:
                   grep -q 'repo_gpgcheck=0' /etc/yum.repos.d/jenkins.repo
                   rpm --import https://pkg.jenkins.io/redhat-stable-legacy/jenkins.io-2023.key
                   rpm --import https://pkg.jenkins.io/redhat-stable/jenkins.io-2026.key
-                  yum -y install java-17-amazon-corretto
-                  yum -y update --security
-                  yum -y install jenkins-2.528.3 certbot git aws-cli xfsprogs openresty
+                  retry yum -y install java-17-amazon-corretto
+                  retry yum -y update --security
+                  retry yum -y install jenkins-2.528.3 certbot git aws-cli xfsprogs openresty
 
-                  yum -y install dnf-automatic
+                  retry yum -y install dnf-automatic
                   sed -i 's/upgrade_type = default/upgrade_type = security/' /etc/dnf/automatic.conf
                   sed -i 's/apply_updates = no/apply_updates = yes/' /etc/dnf/automatic.conf
                   sed -i '/^exclude=/d' /etc/dnf/automatic.conf
@@ -661,7 +674,11 @@ Resources:
                       [ -e /dev/xvdj ] && break || sleep 1
                   done
 
-                  mkfs.xfs -L DATA /dev/xvdj || :
+                  if mkfs.xfs -L DATA /dev/xvdj; then
+                      FRESH_DATA_VOLUME=1
+                  else
+                      FRESH_DATA_VOLUME=0
+                  fi
                   echo "/dev/xvdj /mnt xfs defaults,noatime,nofail 0 0" | tee -a /etc/fstab
                   mount /mnt
               }
@@ -685,7 +702,14 @@ Resources:
                   install -o jenkins -g jenkins -d /mnt/$JENKINS_HOST
                   install -o jenkins -g jenkins -d /mnt/$JENKINS_HOST/init.groovy.d
                   install -o jenkins -g jenkins -d /var/log/jenkins
-                  chown -hR jenkins:jenkins /mnt/$JENKINS_HOST /var/log/jenkins
+                  # A full recursive chown of JENKINS_HOME over millions of inodes adds
+                  # ~13 min to every spot replacement (PKG-1335). The persistent data
+                  # volume is already jenkins-owned from prior boots, so only walk it on a
+                  # genuinely fresh volume (mkfs.xfs succeeded in mount_data_partition).
+                  if [ "$FRESH_DATA_VOLUME" = "1" ]; then
+                      echo "fresh data volume; running full recursive chown of JENKINS_HOME"
+                      chown -hR jenkins:jenkins /mnt/$JENKINS_HOST
+                  fi
 
                   printf "127.0.0.1 $(hostname) $(hostname -A)\n10.30.6.220 vbox-01.ci.percona.com\n10.30.6.9 repo.ci.percona.com\n" \
                       | tee -a /etc/hosts

--- a/IaC/pmm.cd/JenkinsStack.yml
+++ b/IaC/pmm.cd/JenkinsStack.yml
@@ -622,13 +622,26 @@ Resources:
                            Key=iit-billing-tag,Value=$JENKINS_SHORT
             }
 
+            retry() {
+                local attempt=1
+                until "$@"; do
+                    if [ $attempt -ge 5 ]; then
+                        echo "command failed after $attempt attempts: $*" >&2
+                        return 1
+                    fi
+                    echo "command failed (attempt $attempt), retrying: $*"
+                    attempt=$((attempt + 1))
+                    sleep 5
+                done
+            }
+
             install_software() {
                 until yum makecache; do
                     sleep 1
                     echo try again
                 done
 
-                yum -y install yum-utils wget cronie rsync bc
+                retry yum -y install yum-utils wget cronie rsync bc
                 yum-config-manager --add-repo "https://openresty.org/package/amazon/2023/x86_64/"
                 rpm --import https://openresty.org/package/pubkey.gpg
                 wget -O /etc/yum.repos.d/jenkins.repo https://pkg.jenkins.io/redhat-stable-legacy/jenkins.repo
@@ -636,9 +649,9 @@ Resources:
                 grep -q 'repo_gpgcheck=0' /etc/yum.repos.d/jenkins.repo
                 rpm --import https://pkg.jenkins.io/redhat-stable-legacy/jenkins.io-2023.key
                 rpm --import https://pkg.jenkins.io/redhat-stable/jenkins.io-2026.key
-                yum -y install java-17-amazon-corretto
-                yum -y update --security
-                yum -y install jenkins-2.528.3 certbot git dnf-automatic aws-cli xfsprogs openresty
+                retry yum -y install java-17-amazon-corretto
+                retry yum -y update --security
+                retry yum -y install jenkins-2.528.3 certbot git dnf-automatic aws-cli xfsprogs openresty
 
                 sed -i 's/upgrade_type = default/upgrade_type = security/' /etc/dnf/automatic.conf
                 sed -i 's/apply_updates = no/apply_updates = yes/'         /etc/dnf/automatic.conf
@@ -675,7 +688,11 @@ Resources:
                     [ -e /dev/xvdj ] && break || sleep 1
                 done
 
-                mkfs.xfs -L DATA /dev/xvdj || :
+                if mkfs.xfs -L DATA /dev/xvdj; then
+                    FRESH_DATA_VOLUME=1
+                else
+                    FRESH_DATA_VOLUME=0
+                fi
                 echo "/dev/xvdj /mnt xfs defaults,noatime,nofail 0 0" | tee -a /etc/fstab
                 mount /mnt
             }
@@ -699,7 +716,14 @@ Resources:
                 install -o jenkins -g jenkins -d /mnt/$JENKINS_HOST
                 install -o jenkins -g jenkins -d /mnt/$JENKINS_HOST/init.groovy.d
                 install -o jenkins -g jenkins -d /var/log/jenkins
-                chown -hR jenkins:jenkins /mnt/$JENKINS_HOST /var/log/jenkins
+                # A full recursive chown of JENKINS_HOME over millions of inodes adds
+                # ~13 min to every spot replacement (PKG-1335). The persistent data
+                # volume is already jenkins-owned from prior boots, so only walk it on a
+                # genuinely fresh volume (mkfs.xfs succeeded in mount_data_partition).
+                if [ "$FRESH_DATA_VOLUME" = "1" ]; then
+                    echo "fresh data volume; running full recursive chown of JENKINS_HOME"
+                    chown -hR jenkins:jenkins /mnt/$JENKINS_HOST
+                fi
 
                 printf "127.0.0.1 $(hostname) $(hostname -A)\n10.30.6.220 vbox-01.ci.percona.com\n10.30.6.9 repo.ci.percona.com\n" \
                     | tee -a /etc/hosts

--- a/IaC/psmdb.cd/JenkinsStack.yml
+++ b/IaC/psmdb.cd/JenkinsStack.yml
@@ -500,13 +500,26 @@ Resources:
                              Key=iit-billing-tag,Value=$JENKINS_SHORT
               }
 
+              retry() {
+                  local attempt=1
+                  until "$@"; do
+                      if [ $attempt -ge 5 ]; then
+                          echo "command failed after $attempt attempts: $*" >&2
+                          return 1
+                      fi
+                      echo "command failed (attempt $attempt), retrying: $*"
+                      attempt=$((attempt + 1))
+                      sleep 5
+                  done
+              }
+
               install_software() {
                   until yum makecache; do
                       sleep 1
                       echo try again
                   done
 
-                  yum -y install yum-utils wget cronie rsync bc htop vim
+                  retry yum -y install yum-utils wget cronie rsync bc htop vim
                   yum-config-manager --add-repo "https://openresty.org/package/amazon/2023/x86_64/"
                   rpm --import https://openresty.org/package/pubkey.gpg
                   wget -O /etc/yum.repos.d/jenkins.repo https://pkg.jenkins.io/redhat-stable-legacy/jenkins.repo
@@ -514,9 +527,9 @@ Resources:
                   grep -q 'repo_gpgcheck=0' /etc/yum.repos.d/jenkins.repo
                   rpm --import https://pkg.jenkins.io/redhat-stable-legacy/jenkins.io-2023.key
                   rpm --import https://pkg.jenkins.io/redhat-stable/jenkins.io-2026.key
-                  yum -y install java-17-amazon-corretto
-                  yum -y update --security
-                  yum -y install jenkins-2.528.3 certbot git dnf-automatic aws-cli xfsprogs openresty
+                  retry yum -y install java-17-amazon-corretto
+                  retry yum -y update --security
+                  retry yum -y install jenkins-2.528.3 certbot git dnf-automatic aws-cli xfsprogs openresty
 
                   sed -i 's/upgrade_type = default/upgrade_type = security/' /etc/dnf/automatic.conf
                   sed -i 's/apply_updates = no/apply_updates = yes/'         /etc/dnf/automatic.conf
@@ -553,7 +566,11 @@ Resources:
                       [ -e /dev/xvdj ] && break || sleep 1
                   done
 
-                  mkfs.xfs -L DATA /dev/xvdj || :
+                  if mkfs.xfs -L DATA /dev/xvdj; then
+                      FRESH_DATA_VOLUME=1
+                  else
+                      FRESH_DATA_VOLUME=0
+                  fi
                   echo "/dev/xvdj /mnt xfs defaults,noatime,nofail 0 0" | tee -a /etc/fstab
                   mount /mnt
               }
@@ -577,7 +594,14 @@ Resources:
                   install -o jenkins -g jenkins -d /mnt/$JENKINS_HOST
                   install -o jenkins -g jenkins -d /mnt/$JENKINS_HOST/init.groovy.d
                   install -o jenkins -g jenkins -d /var/log/jenkins
-                  chown -hR jenkins:jenkins /mnt/$JENKINS_HOST /var/log/jenkins
+                  # A full recursive chown of JENKINS_HOME over millions of inodes adds
+                  # ~13 min to every spot replacement (PKG-1335). The persistent data
+                  # volume is already jenkins-owned from prior boots, so only walk it on a
+                  # genuinely fresh volume (mkfs.xfs succeeded in mount_data_partition).
+                  if [ "$FRESH_DATA_VOLUME" = "1" ]; then
+                      echo "fresh data volume; running full recursive chown of JENKINS_HOME"
+                      chown -hR jenkins:jenkins /mnt/$JENKINS_HOST
+                  fi
 
                   wget -O /mnt/$JENKINS_HOST/init.groovy.d/plugins.groovy \
                     https://raw.githubusercontent.com/Percona-Lab/jenkins-pipelines/master/IaC/init.groovy.d/plugins.groovy

--- a/IaC/rel.cd/JenkinsStack.yml
+++ b/IaC/rel.cd/JenkinsStack.yml
@@ -554,13 +554,26 @@ Resources:
                              Key=iit-billing-tag,Value=$JENKINS_SHORT
               }
 
+              retry() {
+                  local attempt=1
+                  until "$@"; do
+                      if [ $attempt -ge 5 ]; then
+                          echo "command failed after $attempt attempts: $*" >&2
+                          return 1
+                      fi
+                      echo "command failed (attempt $attempt), retrying: $*"
+                      attempt=$((attempt + 1))
+                      sleep 5
+                  done
+              }
+
               install_software() {
                   until yum makecache; do
                       sleep 1
                       echo try again
                   done
 
-                  yum -y install yum-utils wget cronie rsync bc htop vim
+                  retry yum -y install yum-utils wget cronie rsync bc htop vim
                   yum-config-manager --add-repo "https://openresty.org/package/amazon/2023/x86_64/"
                   rpm --import https://openresty.org/package/pubkey.gpg
                   wget -O /etc/yum.repos.d/jenkins.repo https://pkg.jenkins.io/redhat-stable-legacy/jenkins.repo
@@ -569,9 +582,9 @@ Resources:
                   # rpm --import https://pkg.jenkins.io/redhat-stable/jenkins.io.key
                   rpm --import https://pkg.jenkins.io/redhat-stable-legacy/jenkins.io-2023.key
                   rpm --import https://pkg.jenkins.io/redhat-stable/jenkins.io-2026.key
-                  yum -y install java-17-amazon-corretto
-                  yum -y update --security
-                  yum -y install jenkins-2.528.3 certbot git dnf-automatic aws-cli xfsprogs openresty
+                  retry yum -y install java-17-amazon-corretto
+                  retry yum -y update --security
+                  retry yum -y install jenkins-2.528.3 certbot git dnf-automatic aws-cli xfsprogs openresty
 
                   sed -i 's/upgrade_type = default/upgrade_type = security/' /etc/dnf/automatic.conf
                   sed -i 's/apply_updates = no/apply_updates = yes/'         /etc/dnf/automatic.conf
@@ -608,7 +621,11 @@ Resources:
                       [ -e /dev/xvdj ] && break || sleep 1
                   done
 
-                  mkfs.xfs -L DATA /dev/xvdj || :
+                  if mkfs.xfs -L DATA /dev/xvdj; then
+                      FRESH_DATA_VOLUME=1
+                  else
+                      FRESH_DATA_VOLUME=0
+                  fi
                   echo "/dev/xvdj /mnt xfs defaults,noatime,nofail 0 0" | tee -a /etc/fstab
                   mount /mnt
               }
@@ -632,7 +649,14 @@ Resources:
                   install -o jenkins -g jenkins -d /mnt/$JENKINS_HOST
                   install -o jenkins -g jenkins -d /mnt/$JENKINS_HOST/init.groovy.d
                   install -o jenkins -g jenkins -d /var/log/jenkins
-                  chown -hR jenkins:jenkins /mnt/$JENKINS_HOST /var/log/jenkins
+                  # A full recursive chown of JENKINS_HOME over millions of inodes adds
+                  # ~13 min to every spot replacement (PKG-1335). The persistent data
+                  # volume is already jenkins-owned from prior boots, so only walk it on a
+                  # genuinely fresh volume (mkfs.xfs succeeded in mount_data_partition).
+                  if [ "$FRESH_DATA_VOLUME" = "1" ]; then
+                      echo "fresh data volume; running full recursive chown of JENKINS_HOME"
+                      chown -hR jenkins:jenkins /mnt/$JENKINS_HOST
+                  fi
 
                   printf "127.0.0.1 $(hostname) $(hostname -A)\n10.30.6.220 vbox-01.ci.percona.com\n10.30.6.9 repo.ci.percona.com\n" \
                       | tee -a /etc/hosts


### PR DESCRIPTION
## Bug

- A Spot Fleet replacement of a Jenkins master ran its cloud-init UserData, which aborted under `set -o errexit` when `yum -y install java-17-amazon-corretto` hit a transient dnf package-cache miss. Jenkins and OpenResty never started and `pmm.cd` was unreachable for ~2.5h.

## Fix

- Add a `retry()` helper (retry up to 5 times, fail fast after) and route every `yum -y install` and `yum -y update --security` through it.
- Gate the recursive `chown` of `JENKINS_HOME` on a `FRESH_DATA_VOLUME` flag, set when `mkfs.xfs` succeeds on a blank volume. Reattached homes skip the ~13 min walk; fresh volumes still get the full chown.
- Applied to the five CFN masters: `cloud`, `pg`, `pmm`, `psmdb`, `rel`. The Terraform-managed masters (`ps3`, `ps80`, `ps57`, `pxb`, `pxc`) are handled in percona-cd-platform, not here.

## Tickets

- [PKG-1335](https://perconadev.atlassian.net/browse/PKG-1335): this
- [PKG-1306](https://perconadev.atlassian.net/browse/PKG-1306): same bootstrap-abort class ([PR 3945](https://github.com/Percona-Lab/jenkins-pipelines/pull/3945))


[PKG-1335]: https://perconadev.atlassian.net/browse/PKG-1335?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[PKG-1306]: https://perconadev.atlassian.net/browse/PKG-1306?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ