### PR TITLE
PS-11227: Prune dormant Hetzner aarch64-min worker tier (psmdb + cloud)

### DIFF
--- a/IaC/cloud.cd/init.groovy.d/htz.cloud.groovy
+++ b/IaC/cloud.cd/init.groovy.d/htz.cloud.groovy
@@ -22,9 +22,6 @@ execMap['fedora42-aarch64-fsn1'] = execMap['fedora']
 execMap['fedora42-x64-nbg1-min']     = execMap['fedora']
 execMap['fedora42-x64-hel1-min']     = execMap['fedora']
 execMap['fedora42-x64-fsn1-min']     = execMap['fedora']
-execMap['fedora42-aarch64-nbg1-min'] = execMap['fedora']
-execMap['fedora42-aarch64-hel1-min'] = execMap['fedora']
-execMap['fedora42-aarch64-fsn1-min'] = execMap['fedora']
 execMap['launcher-x64-nbg1']  = 30
 execMap['launcher-x64-hel1']  = 30
 execMap['launcher-x64-fsn1']  = 30
@@ -40,9 +37,6 @@ bootDeadlineMap['fedora42-aarch64-fsn1'] = bootDeadlineMap['default']
 bootDeadlineMap['fedora42-x64-nbg1-min']     = bootDeadlineMap['default']
 bootDeadlineMap['fedora42-x64-hel1-min']     = bootDeadlineMap['default']
 bootDeadlineMap['fedora42-x64-fsn1-min']     = bootDeadlineMap['default']
-bootDeadlineMap['fedora42-aarch64-nbg1-min'] = bootDeadlineMap['default']
-bootDeadlineMap['fedora42-aarch64-hel1-min'] = bootDeadlineMap['default']
-bootDeadlineMap['fedora42-aarch64-fsn1-min'] = bootDeadlineMap['default']
 bootDeadlineMap['launcher-x64-nbg1']  = bootDeadlineMap['default']
 bootDeadlineMap['launcher-x64-hel1']  = bootDeadlineMap['default']
 bootDeadlineMap['launcher-x64-fsn1']  = bootDeadlineMap['default']
@@ -58,16 +52,12 @@ jvmOptsMap['fedora42-aarch64-fsn1'] = jvmOptsMap['fedora42']
 jvmOptsMap['fedora42-x64-nbg1-min']     = jvmOptsMap['fedora42']
 jvmOptsMap['fedora42-x64-hel1-min']     = jvmOptsMap['fedora42']
 jvmOptsMap['fedora42-x64-fsn1-min']     = jvmOptsMap['fedora42']
-jvmOptsMap['fedora42-aarch64-nbg1-min'] = jvmOptsMap['fedora42']
-jvmOptsMap['fedora42-aarch64-hel1-min'] = jvmOptsMap['fedora42']
-jvmOptsMap['fedora42-aarch64-fsn1-min'] = jvmOptsMap['fedora42']
 jvmOptsMap['launcher-x64-nbg1']  = jvmOptsMap['fedora42']
 jvmOptsMap['launcher-x64-hel1']  = jvmOptsMap['fedora42']
 jvmOptsMap['launcher-x64-fsn1']  = jvmOptsMap['fedora42']
 
 labelMap = [:]
 labelMap['fedora42-x64-min']     = 'docker-x64-min docker-fedora42-x64-min fedora42-x64-min'
-labelMap['fedora42-aarch64-min'] = 'docker-aarch64-min docker-fedora42-aarch64-min fedora42-aarch64-min'
 labelMap['fedora42-x64']         = 'docker-x64 docker-fedora42-x64 fedora42-x64'
 labelMap['fedora42-aarch64']     = 'docker-aarch64 docker-fedora42-aarch64 fedora42-aarch64'
 labelMap['launcher-x64']      = 'launcher-x64'
@@ -134,9 +124,6 @@ initMap['fedora42-aarch64-fsn1'] = initMap['fedora-docker']
 initMap['fedora42-x64-nbg1-min']     = initMap['fedora-docker']
 initMap['fedora42-x64-hel1-min']     = initMap['fedora-docker']
 initMap['fedora42-x64-fsn1-min']     = initMap['fedora-docker']
-initMap['fedora42-aarch64-nbg1-min'] = initMap['fedora-docker']
-initMap['fedora42-aarch64-hel1-min'] = initMap['fedora-docker']
-initMap['fedora42-aarch64-fsn1-min'] = initMap['fedora-docker']
 initMap['launcher-x64-nbg1']  = initMap['fedora-docker']
 initMap['launcher-x64-hel1']  = initMap['fedora-docker']
 initMap['launcher-x64-fsn1']  = initMap['fedora-docker']
@@ -145,11 +132,8 @@ def templates = [
        /* new HetznerServerTemplate("ubuntu20-cx21", "java", "name=ubuntu20-docker", "fsn1", "cx21"), */
         //                        tmplName                  tmplLabels                     tmplImage                  region server type
         new HetznerServerTemplate("fedora42-x64-nbg1-min",     labelMap['fedora42-x64-min'],     imageMap['fedora42-x64'],     "nbg1", "cpx42"),
-        new HetznerServerTemplate("fedora42-aarch64-nbg1-min", labelMap['fedora42-aarch64-min'], imageMap['fedora42-aarch64'], "nbg1", "cax31"),
         new HetznerServerTemplate("fedora42-x64-hel1-min",     labelMap['fedora42-x64-min'],     imageMap['fedora42-x64'],     "hel1", "cpx42"),
-        new HetznerServerTemplate("fedora42-aarch64-hel1-min", labelMap['fedora42-aarch64-min'], imageMap['fedora42-aarch64'], "hel1", "cax31"),
         new HetznerServerTemplate("fedora42-x64-fsn1-min",     labelMap['fedora42-x64-min'],     imageMap['fedora42-x64'],     "fsn1", "cpx42"),
-        new HetznerServerTemplate("fedora42-aarch64-fsn1-min", labelMap['fedora42-aarch64-min'], imageMap['fedora42-aarch64'], "fsn1", "cax31"),
         new HetznerServerTemplate("fedora42-x64-nbg1",         labelMap['fedora42-x64'],         imageMap['fedora42-x64'],     "nbg1", "cpx62"),
         new HetznerServerTemplate("fedora42-aarch64-nbg1",     labelMap['fedora42-aarch64'],     imageMap['fedora42-aarch64'], "nbg1", "cax41"),
         new HetznerServerTemplate("fedora42-x64-hel1",         labelMap['fedora42-x64'],         imageMap['fedora42-x64'],     "hel1", "cpx62"),

--- a/IaC/psmdb.cd/init.groovy.d/htz.cloud.groovy
+++ b/IaC/psmdb.cd/init.groovy.d/htz.cloud.groovy
@@ -22,9 +22,6 @@ execMap['deb12-aarch64-fsn1'] = execMap['deb']
 execMap['deb12-x64-nbg1-min']     = execMap['deb']
 execMap['deb12-x64-hel1-min']     = execMap['deb']
 execMap['deb12-x64-fsn1-min']     = execMap['deb']
-execMap['deb12-aarch64-nbg1-min'] = execMap['deb']
-execMap['deb12-aarch64-hel1-min'] = execMap['deb']
-execMap['deb12-aarch64-fsn1-min'] = execMap['deb']
 execMap['launcher-x64-nbg1']  = 30
 execMap['launcher-x64-hel1']  = 30
 execMap['launcher-x64-fsn1']  = 30
@@ -40,9 +37,6 @@ bootDeadlineMap['deb12-aarch64-fsn1'] = bootDeadlineMap['default']
 bootDeadlineMap['deb12-x64-nbg1-min']     = bootDeadlineMap['default']
 bootDeadlineMap['deb12-x64-hel1-min']     = bootDeadlineMap['default']
 bootDeadlineMap['deb12-x64-fsn1-min']     = bootDeadlineMap['default']
-bootDeadlineMap['deb12-aarch64-nbg1-min'] = bootDeadlineMap['default']
-bootDeadlineMap['deb12-aarch64-hel1-min'] = bootDeadlineMap['default']
-bootDeadlineMap['deb12-aarch64-fsn1-min'] = bootDeadlineMap['default']
 bootDeadlineMap['launcher-x64-nbg1']  = bootDeadlineMap['default']
 bootDeadlineMap['launcher-x64-hel1']  = bootDeadlineMap['default']
 bootDeadlineMap['launcher-x64-fsn1']  = bootDeadlineMap['default']
@@ -58,16 +52,12 @@ jvmOptsMap['deb12-aarch64-fsn1'] = jvmOptsMap['deb12']
 jvmOptsMap['deb12-x64-nbg1-min']     = jvmOptsMap['deb12']
 jvmOptsMap['deb12-x64-hel1-min']     = jvmOptsMap['deb12']
 jvmOptsMap['deb12-x64-fsn1-min']     = jvmOptsMap['deb12']
-jvmOptsMap['deb12-aarch64-nbg1-min'] = jvmOptsMap['deb12']
-jvmOptsMap['deb12-aarch64-hel1-min'] = jvmOptsMap['deb12']
-jvmOptsMap['deb12-aarch64-fsn1-min'] = jvmOptsMap['deb12']
 jvmOptsMap['launcher-x64-nbg1']  = jvmOptsMap['deb12']
 jvmOptsMap['launcher-x64-hel1']  = jvmOptsMap['deb12']
 jvmOptsMap['launcher-x64-fsn1']  = jvmOptsMap['deb12']
 
 labelMap = [:]
 labelMap['deb12-x64-min']     = 'docker-x64-min docker-deb12-x64-min deb12-x64-min'
-labelMap['deb12-aarch64-min'] = 'docker-aarch64-min docker-deb12-aarch64-min deb12-aarch64-min'
 labelMap['deb12-x64']         = 'docker-x64 docker-deb12-x64 deb12-x64'
 labelMap['deb12-aarch64']     = 'docker-aarch64 docker-deb12-aarch64 deb12-aarch64'
 labelMap['launcher-x64']      = 'launcher-x64'
@@ -152,9 +142,6 @@ initMap['deb12-aarch64-fsn1'] = initMap['deb-docker']
 initMap['deb12-x64-nbg1-min']     = initMap['deb-docker']
 initMap['deb12-x64-hel1-min']     = initMap['deb-docker']
 initMap['deb12-x64-fsn1-min']     = initMap['deb-docker']
-initMap['deb12-aarch64-nbg1-min'] = initMap['deb-docker']
-initMap['deb12-aarch64-hel1-min'] = initMap['deb-docker']
-initMap['deb12-aarch64-fsn1-min'] = initMap['deb-docker']
 initMap['launcher-x64-nbg1']  = initMap['deb-docker']
 initMap['launcher-x64-hel1']  = initMap['deb-docker']
 initMap['launcher-x64-fsn1']  = initMap['deb-docker']
@@ -163,11 +150,8 @@ def templates = [
        /* new HetznerServerTemplate("ubuntu20-cx21", "java", "name=ubuntu20-docker", "fsn1", "cx21"), */
         //                        tmplName                  tmplLabels                     tmplImage                  region server type
         new HetznerServerTemplate("deb12-x64-nbg1-min",     labelMap['deb12-x64-min'],     imageMap['deb12-x64'],     "nbg1", "cpx42"),
-        new HetznerServerTemplate("deb12-aarch64-nbg1-min", labelMap['deb12-aarch64-min'], imageMap['deb12-aarch64'], "nbg1", "cax31"),
         new HetznerServerTemplate("deb12-x64-hel1-min",     labelMap['deb12-x64-min'],     imageMap['deb12-x64'],     "hel1", "cpx42"),
-        new HetznerServerTemplate("deb12-aarch64-hel1-min", labelMap['deb12-aarch64-min'], imageMap['deb12-aarch64'], "hel1", "cax31"),
         new HetznerServerTemplate("deb12-x64-fsn1-min",     labelMap['deb12-x64-min'],     imageMap['deb12-x64'],     "fsn1", "cpx42"),
-        new HetznerServerTemplate("deb12-aarch64-fsn1-min", labelMap['deb12-aarch64-min'], imageMap['deb12-aarch64'], "fsn1", "cax31"),
         new HetznerServerTemplate("deb12-x64-nbg1",         labelMap['deb12-x64'],         imageMap['deb12-x64'],     "nbg1", "cpx62"),
         new HetznerServerTemplate("deb12-aarch64-nbg1",     labelMap['deb12-aarch64'],     imageMap['deb12-aarch64'], "nbg1", "cax41"),
         new HetznerServerTemplate("deb12-x64-hel1",         labelMap['deb12-x64'],         imageMap['deb12-x64'],     "hel1", "cpx62"),


### PR DESCRIPTION
**Summary**
- Removes the dormant Hetzner aarch64-min worker tier (`deb12-aarch64-*-min` / `fedora42-aarch64-*-min`, server type `cax31`) from `htz.cloud.groovy` on psmdb and cloud.

**Why**
- A 60-day build-activity scan across all 10 masters found this `-min` ARM tier has zero job consumers, and a grep of both branches (`vars/`, `src/`, Jenkinsfiles, JJB) found zero references outside the template definition.
- The ARM fallback path is Hetzner `docker-aarch64` (full, `cax41`) to the Graviton Fleet, never the `-min` tier, so this is not fallback-reserve.
- The full `cax41` aarch64 primary tier is preserved untouched; only the smaller-SKU `-min` tier is removed.

**Tickets**
- [PS-11227](https://perconadev.atlassian.net/browse/PS-11227)


[PS-11227]: https://perconadev.atlassian.net/browse/PS-11227?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ