### PR TITLE
PMM-7 Fix trivy install again

### DIFF
--- a/pmm/v3/pmm3-image-scanning.groovy
+++ b/pmm/v3/pmm3-image-scanning.groovy
@@ -36,7 +36,7 @@ enabled=1
 gpgkey=https://aquasecurity.github.io/trivy-repo/rpm/public.key
 EOF
 
-                        sudo dnf install -y trivy-0.70.0
+                        sudo dnf install -y trivy-0.71.0
 
                         # Download HTML template for Trivy
                         mkdir -p contrib


### PR DESCRIPTION
It's unclear why Trivy removes packages from their repository. This time again, shortly after the last fix, the package `trivy-0.70.0` was removed, which led to the pipeline failure.

@talhabinrizwan Shall we unpin the version or continue fixing every second week?