### PR TITLE
PSMDB-2089 add docker-buildx-plugin to Hetzner deb-docker agent init

### DIFF
--- a/IaC/psmdb.cd/init.groovy.d/htz.cloud.groovy
+++ b/IaC/psmdb.cd/init.groovy.d/htz.cloud.groovy
@@ -114,7 +114,7 @@ APT_EOF
         sleep 1
         echo try again
     done
-    until sudo apt-get -y install docker-ce docker-ce-cli  docker-compose-plugin containerd.io; do
+    until sudo apt-get -y install docker-ce docker-ce-cli  docker-compose-plugin containerd.io docker-buildx-plugin; do
         sleep 1
         echo try again
     done


### PR DESCRIPTION
Agents provisioned from older images lack buildx entirely, making
`docker buildx build` fails due to a non-uniform Docker setup across the agent fleet.

Install `docker-buildx-plugin` from the same official Docker apt/dnf repo that already supplies `docker-ce` on the agent,
following the canonical install path documented at:
- https://docs.docker.com/engine/install/debian/
- https://docs.docker.com/engine/install/centos/
