### PR TITLE
PSMDB-2089 add docker-buildx-plugin to AWS docker agent init

### DIFF
--- a/IaC/psmdb.cd/init.groovy.d/cloud.groovy
+++ b/IaC/psmdb.cd/init.groovy.d/cloud.groovy
@@ -121,7 +121,7 @@ initMap['docker'] = '''
     sudo yum -y install java-17-amazon-corretto git cronie unzip dnf-plugins-core
     sudo dnf config-manager --add-repo https://download.docker.com/linux/centos/docker-ce.repo
     sudo sed -i 's/$releasever/9/g' /etc/yum.repos.d/docker-ce.repo
-    until sudo dnf -y install docker-ce docker-ce-cli docker-compose-plugin containerd.io; do
+    until sudo dnf -y install docker-ce docker-ce-cli docker-compose-plugin containerd.io docker-buildx-plugin; do
         sleep 1
         echo try again
     done
@@ -190,7 +190,7 @@ initMap['docker-32gb'] = '''
     sudo yum -y install java-17-amazon-corretto git cronie unzip dnf-plugins-core
     sudo dnf config-manager --add-repo https://download.docker.com/linux/centos/docker-ce.repo
     sudo sed -i 's/$releasever/9/g' /etc/yum.repos.d/docker-ce.repo
-    until sudo dnf -y install docker-ce docker-ce-cli docker-compose-plugin containerd.io; do
+    until sudo dnf -y install docker-ce docker-ce-cli docker-compose-plugin containerd.io docker-buildx-plugin; do
         sleep 1
         echo try again
     done


### PR DESCRIPTION
Agents provisioned from older images lack buildx entirely, making
`docker buildx build` fails due to a non-uniform Docker setup across the agent fleet.

Install `docker-buildx-plugin` from the same official Docker apt/dnf repo that already supplies `docker-ce` on the agent,
following the canonical install path documented at:
- https://docs.docker.com/engine/install/debian/
- https://docs.docker.com/engine/install/centos/
