### PR TITLE
K8SPSMDB-1676 fix aws deletion

### DIFF
--- a/cloud/aws-functions/func_alarms.bash
+++ b/cloud/aws-functions/func_alarms.bash
@@ -1,0 +1,59 @@
+REGION="eu-west-3"
+ACCOUNT="119175775298"
+
+# 1. create SNS topic
+TOPIC_ARN=$(aws sns create-topic \
+  --name lambda-failures \
+  --region $REGION \
+  --query 'TopicArn' --output text)
+
+echo "Topic: $TOPIC_ARN"
+
+# 2. subscribe emails
+EMAILS=(
+  "natalia.marukovich@percona.com"
+  "eleonora.zinchenko@percona.com"
+  "julio.pasinatto@percona.com"
+  "valmira.nogueira@percona.com"
+)
+
+for EMAIL in "${EMAILS[@]}"; do
+  aws sns subscribe \
+    --topic-arn $TOPIC_ARN \
+    --protocol email \
+    --notification-endpoint $EMAIL \
+    --region $REGION
+  echo "Subscribed $EMAIL"
+done
+
+echo "Each recipient must confirm subscription via email link"
+
+# 3. create alarms for all functions except deleteLB (old one, we don't need it.)
+FUNCTIONS=(
+  "deleteOrphanedResource"
+  "deleteOrphanedUsers"
+  "deleteOrphanedEIp"
+  "deleteOrphanedOIDC"
+  "deleteOrphandedVpc"
+  "deleteOrphanedResourcesOpenshift"
+  "deleteOrphanedCloudformation"
+)
+
+for FUNC in "${FUNCTIONS[@]}"; do
+  aws cloudwatch put-metric-alarm \
+    --alarm-name "Lambda-${FUNC}-Failures" \
+    --alarm-description "Lambda ${FUNC} failed" \
+    --metric-name Errors \
+    --namespace AWS/Lambda \
+    --dimensions Name=FunctionName,Value=$FUNC \
+    --statistic Sum \
+    --period 3600 \
+    --threshold 1 \
+    --comparison-operator GreaterThanOrEqualToThreshold \
+    --evaluation-periods 1 \
+    --alarm-actions $TOPIC_ARN \
+    --treat-missing-data notBreaching \
+    --region $REGION
+
+  echo "Alarm created for $FUNC"
+done

--- a/cloud/aws-functions/orphaned_cloudformation.py
+++ b/cloud/aws-functions/orphaned_cloudformation.py
@@ -68,18 +68,15 @@ def delete_stack(stack_name, aws_region):
     cf_client = boto3.client("cloudformation", region_name=aws_region)
     try:
         logging.info(f"Removing cloudformation stack: {stack_name}")
-        waiter_config = {
-            "Delay": 30,  # Time (in seconds) to wait between attempts
-            "MaxAttempts": 10,  # Maximum number of attempts (30s * 10 = 300s or 5 minutes)
-        }
         cf_client.update_termination_protection(
             EnableTerminationProtection=False, StackName=stack_name
         )
-        waiter = cf_client.get_waiter("stack_delete_complete")
-        print(f"Waiting for stack {stack_name} to be deleted...")
         cf_client.delete_stack(StackName=stack_name)
-        waiter.wait(StackName=stack_name, WaiterConfig=waiter_config)
+        logging.info(f"Stack {stack_name} deletion initiated.")
     except ClientError as e:
+        if "does not exist" in str(e):
+            logging.info(f"Stack {stack_name} no longer exists, skipping.")
+            return
         logging.error(f"Error deleting stack: {e}")
         raise
 
@@ -90,7 +87,14 @@ def delete_stack_resources(stack_name, aws_region):
 
     try:
         resources = cf_client.describe_stack_resources(StackName=stack_name)
-        for resource in resources["StackResources"]:
+    except ClientError as e:
+        if "does not exist" in str(e):
+            logging.info(f"Stack {stack_name} no longer exists, skipping resource cleanup.")
+            return
+        logging.error(f"Error describing stack resources: {e}")
+        raise
+
+    for resource in resources["StackResources"]:
             resource_id = resource["PhysicalResourceId"]
             resource_type = resource["ResourceType"]
             try:
@@ -120,7 +124,7 @@ def delete_stack_resources(stack_name, aws_region):
                                     f"Role attached to instance profile {resource_id}: {role['RoleName']}"
                                 )
                                 iam_client.remove_role_from_instance_profile(
-                                    InstanceProfileName=resource_id, RoleName=role
+                                    InstanceProfileName=resource_id, RoleName=role["RoleName"]
                                 )
                         else:
                             logging.info(f"No roles are attached to instance profile {resource_id}.")
@@ -134,9 +138,6 @@ def delete_stack_resources(stack_name, aws_region):
                 sleep(2)  # Sleep to avoid hitting rate limits
             except ClientError as e:
                 logging.error(f"Failed to delete resource: {resource_id}. Error: {e}")
-    except ClientError as e:
-        logging.error(f"Error describing stack resources: {e}")
-        raise
 
 
 def lambda_handler(event, context):

--- a/cloud/aws-functions/orphaned_cloudformation.py
+++ b/cloud/aws-functions/orphaned_cloudformation.py
@@ -67,18 +67,21 @@ def get_cloudformation_to_terminate(aws_region):
 def delete_stack(stack_name, aws_region):
     cf_client = boto3.client("cloudformation", region_name=aws_region)
     try:
-        # Initiate the delete operation add timeout
         logging.info(f"Removing cloudformation stack: {stack_name}")
         waiter_config = {
             "Delay": 30,  # Time (in seconds) to wait between attempts
-            "MaxAttempts": 10,  # Maximum number of attempts (30s * 40 = 1200s or 20 minutes)
+            "MaxAttempts": 10,  # Maximum number of attempts (30s * 10 = 300s or 5 minutes)
         }
+        cf_client.update_termination_protection(
+            EnableTerminationProtection=False, StackName=stack_name
+        )
         waiter = cf_client.get_waiter("stack_delete_complete")
         print(f"Waiting for stack {stack_name} to be deleted...")
-        response = cf_client.delete_stack(StackName=stack_name)
+        cf_client.delete_stack(StackName=stack_name)
         waiter.wait(StackName=stack_name, WaiterConfig=waiter_config)
     except ClientError as e:
         logging.error(f"Error deleting stack: {e}")
+        raise
 
 
 def delete_stack_resources(stack_name, aws_region):
@@ -95,6 +98,13 @@ def delete_stack_resources(stack_name, aws_region):
                     f"Attempting to delete resource: {resource_id} of type: {resource_type}"
                 )
                 if resource_type == "AWS::IAM::Role":
+                    attached_policies = iam_client.list_attached_role_policies(
+                        RoleName=resource_id
+                    )["AttachedPolicies"]
+                    for policy in attached_policies:
+                        iam_client.detach_role_policy(
+                            RoleName=resource_id, PolicyArn=policy["PolicyArn"]
+                        )
                     iam_client.delete_role(RoleName=resource_id)
                 elif resource_type == "AWS::IAM::Policy":
                     iam_client.delete_policy(PolicyArn=resource_id)
@@ -126,6 +136,7 @@ def delete_stack_resources(stack_name, aws_region):
                 logging.error(f"Failed to delete resource: {resource_id}. Error: {e}")
     except ClientError as e:
         logging.error(f"Error describing stack resources: {e}")
+        raise
 
 
 def lambda_handler(event, context):
@@ -141,6 +152,6 @@ def lambda_handler(event, context):
                 logging.info(f"Deleting cloudformation stacks.")
                 delete_stack_resources(cloudformation_stack, aws_region)
                 delete_stack(cloudformation_stack, aws_region)
-            except ClientError as e:
-                logging.info(f"Failed to delete resource: {resource_id}. Error: {e}")
-                continue
+            except Exception as e:
+                logging.error(f"Failed to delete cloudformation stack {cloudformation_stack}. Error: {e}")
+                raise

--- a/cloud/aws-functions/orphaned_eks_clusters.py
+++ b/cloud/aws-functions/orphaned_eks_clusters.py
@@ -65,7 +65,7 @@ def wait_for_node_group_delete(autoscaling_client, autoscaling_group_name):
         sleep(sleep_time)
         attempt += 1
     else:
-        logging.error(
+        raise RuntimeError(
             f"Node group {autoscaling_group_name} was not deleted in {timeout} seconds."
         )
 
@@ -80,6 +80,7 @@ def delete_nodegroup(aws_region):
             tags = group.get("Tags", [])
             team_value = False
             delete_cluster = False
+            creation_time = None
 
             for tag in tags:
                 if tag["Key"] == "team" and tag["Value"] == "cloud":
@@ -94,7 +95,7 @@ def delete_nodegroup(aws_region):
                         creation_time = float(tag["Value"])
                     except ValueError as e:
                         logging.error(
-                            f"Could not get creation_time for {auto_scaling_group} failed with error: {e}"
+                            f"Could not get creation_time for {group['AutoScalingGroupName']} failed with error: {e}"
                         )
 
             current_time = datetime.datetime.now().timestamp()
@@ -102,6 +103,7 @@ def delete_nodegroup(aws_region):
             if (
                 team_value
                 and delete_cluster
+                and creation_time is not None
                 and (current_time - creation_time) / 3600 > cluster_lifetime
             ):
                 auto_scaling_groups.append(group["AutoScalingGroupName"])

--- a/cloud/aws-functions/orphaned_oidc.py
+++ b/cloud/aws-functions/orphaned_oidc.py
@@ -46,7 +46,4 @@ def lambda_handler(event, context):
         }
     except Exception as e:
         print(f"Error: {str(e)}")
-        return {
-            "statusCode": 500,
-            "body": json.dumps(f"Error: {str(e)}")
-        }
+        raise

--- a/cloud/aws-functions/orphaned_openshift_eip.py
+++ b/cloud/aws-functions/orphaned_openshift_eip.py
@@ -41,7 +41,8 @@ def get_ip_to_release(client, aws_region):
         ips = client.describe_addresses()["Addresses"]
     except Exception as e:
         logging.error(f"The ips can't be received because of the error {e}")
-        
+        raise
+
     if not ips:
         logging.info(f"There are no ips in region {aws_region}")
         return ips_for_release
@@ -63,6 +64,7 @@ def release_ip(client, aws_region, allocation_id):
         )
     except Exception as e:
         logging.error(f"Error releasing Elastic IP: {e}")
+        raise
 
 
 def lambda_handler(event, context):

--- a/cloud/aws-functions/orphaned_openshift_users.py
+++ b/cloud/aws-functions/orphaned_openshift_users.py
@@ -38,6 +38,7 @@ def delete_user(client, user_name):
         client.delete_user(UserName=user_name)
     except client.exceptions.NoSuchEntityException as e:
         logging.error(f"Delete of user failed with error: {e}")
+        raise
 
 def delete_user_policies(client, user_name):
     user_policies = client.list_user_policies(UserName=user_name)['PolicyNames']

--- a/cloud/aws-functions/orphaned_vpcs.py
+++ b/cloud/aws-functions/orphaned_vpcs.py
@@ -255,7 +255,7 @@ def wait_for_nat_gateway_delete(ec2, nat_gateway_id):
         attempt += 1
 
     else:
-        logging.error(
+        raise RuntimeError(
             f"NAT gateway with id {nat_gateway_id} was not deleted in {timeout} seconds."
         )
 
@@ -314,6 +314,4 @@ def lambda_handler(event, context):
 
         for vpc in vpcs:
             logging.info(f"Deleting all resources and VPC.")
-            response = terminate_vpc(vpc, aws_region)
-            logging.info(f"Failed to delete vpc. The error was: {response}")
-            continue
+            terminate_vpc(vpc, aws_region)


### PR DESCRIPTION
Add raise to all silent error handlers across orphaned-resource Lambda functions so that failures are visible as Lambda errors (previously functions returned "Succeeded" even when operations failed).

Set up CloudWatch alarms + SNS email notifications for all cleanup Lambda functions so that QA team receives an email when any function fails.