### PR TITLE
PS-11257: reap leaked molecule package-testing EC2 instances

### DIFF
--- a/IaC/LambdaEC2Cleanup.yml
+++ b/IaC/LambdaEC2Cleanup.yml
@@ -25,21 +25,6 @@ Parameters:
     Type: Number
     Default: 14
     AllowedValues: [1, 3, 5, 7, 14, 30, 60, 90]
-  MoleculeBillingPattern:
-    Type: String
-    Default: ".*_package_testing$"
-    Description: >-
-      Regex on iit-billing-tag identifying ephemeral package-testing molecule
-      instances. Their tag is non-numeric, so has_valid_billing_tag would
-      otherwise exempt them forever; matches are age-reaped instead.
-  MoleculeMaxAgeHours:
-    Type: Number
-    Default: 7
-    Description: >-
-      Terminate MoleculeBillingPattern instances older than this many hours.
-      7h is derived from real build durations (worst genuine run 4.34h, p99
-      0.93h across 819 completed builds), so it clears live builds while
-      reclaiming aborted or leaked instances.
 
 Resources:
 
@@ -108,8 +93,6 @@ Resources:
         Variables:
           DRY_RUN: !Ref DryRunMode
           EKS_SKIP_PATTERN: !Ref EksSkipPattern
-          MOLECULE_BILLING_PATTERN: !Ref MoleculeBillingPattern
-          MOLECULE_MAX_AGE_HOURS: !Ref MoleculeMaxAgeHours
       Tags:
         - Key: iit-billing-tag
           Value: lambda-ec2-cleanup
@@ -127,17 +110,9 @@ Resources:
 
           EKS_SKIP_PATTERN = os.environ.get("EKS_SKIP_PATTERN", "pe-.*")
           DRY_RUN = os.environ.get("DRY_RUN", "true").lower() == "true"
-          MOLECULE_BILLING_PATTERN = os.environ.get("MOLECULE_BILLING_PATTERN", r".*_package_testing$")
-          MOLECULE_MAX_AGE = int(float(os.environ.get("MOLECULE_MAX_AGE_HOURS", "7")) * 3600)
-          try:
-              MOLECULE_RE = re.compile(MOLECULE_BILLING_PATTERN)
-          except re.error as e:
-              logger.error(f"Invalid MOLECULE_BILLING_PATTERN '{MOLECULE_BILLING_PATTERN}': {e}, molecule reaping disabled")
-              MOLECULE_RE = None
 
           logger.info(f"EKS_SKIP_PATTERN: {EKS_SKIP_PATTERN}")
           logger.info(f"DRY_RUN: {DRY_RUN}")
-          logger.info(f"MOLECULE: pattern={MOLECULE_BILLING_PATTERN} max_age={MOLECULE_MAX_AGE}s")
 
           eks_clusters_to_delete = {}
 
@@ -254,20 +229,9 @@ Resources:
 
           def should_terminate(instance):
               tags_dict = convert_tags_to_dict(instance.tags)
-              running = datetime.datetime.now(datetime.timezone.utc) - instance.launch_time
-              # Ephemeral package-testing molecule instances carry a non-numeric
-              # iit-billing-tag (e.g. ps_80_package_testing) that has_valid_billing_tag
-              # treats as a permanent category exemption. They leak when a build is
-              # aborted before "molecule destroy" runs, so age-bound them instead of
-              # exempting them forever.
-              bt = tags_dict.get("iit-billing-tag", "")
-              if bt and MOLECULE_RE and MOLECULE_RE.match(bt):
-                  if running.total_seconds() > MOLECULE_MAX_AGE:
-                      logger.info(f"Molecule leak: {instance.id} tag={bt} age={int(running.total_seconds())}s > {MOLECULE_MAX_AGE}s, terminate")
-                      return True
-                  return False
               if has_valid_billing_tag(tags_dict, instance.launch_time):
                   return False
+              running = datetime.datetime.now(datetime.timezone.utc) - instance.launch_time
               return running.total_seconds() > 600
 
 

--- a/IaC/LambdaEC2Cleanup.yml
+++ b/IaC/LambdaEC2Cleanup.yml
@@ -129,7 +129,11 @@ Resources:
           DRY_RUN = os.environ.get("DRY_RUN", "true").lower() == "true"
           MOLECULE_BILLING_PATTERN = os.environ.get("MOLECULE_BILLING_PATTERN", r".*_package_testing$")
           MOLECULE_MAX_AGE = int(float(os.environ.get("MOLECULE_MAX_AGE_HOURS", "7")) * 3600)
-          MOLECULE_RE = re.compile(MOLECULE_BILLING_PATTERN)
+          try:
+              MOLECULE_RE = re.compile(MOLECULE_BILLING_PATTERN)
+          except re.error as e:
+              logger.error(f"Invalid MOLECULE_BILLING_PATTERN '{MOLECULE_BILLING_PATTERN}': {e}, molecule reaping disabled")
+              MOLECULE_RE = None
 
           logger.info(f"EKS_SKIP_PATTERN: {EKS_SKIP_PATTERN}")
           logger.info(f"DRY_RUN: {DRY_RUN}")
@@ -257,7 +261,7 @@ Resources:
               # aborted before "molecule destroy" runs, so age-bound them instead of
               # exempting them forever.
               bt = tags_dict.get("iit-billing-tag", "")
-              if bt and MOLECULE_RE.match(bt):
+              if bt and MOLECULE_RE and MOLECULE_RE.match(bt):
                   if running.total_seconds() > MOLECULE_MAX_AGE:
                       logger.info(f"Molecule leak: {instance.id} tag={bt} age={int(running.total_seconds())}s > {MOLECULE_MAX_AGE}s, terminate")
                       return True

--- a/IaC/LambdaEC2Cleanup.yml
+++ b/IaC/LambdaEC2Cleanup.yml
@@ -25,6 +25,21 @@ Parameters:
     Type: Number
     Default: 14
     AllowedValues: [1, 3, 5, 7, 14, 30, 60, 90]
+  MoleculeBillingPattern:
+    Type: String
+    Default: ".*_package_testing$"
+    Description: >-
+      Regex on iit-billing-tag identifying ephemeral package-testing molecule
+      instances. Their tag is non-numeric, so has_valid_billing_tag would
+      otherwise exempt them forever; matches are age-reaped instead.
+  MoleculeMaxAgeHours:
+    Type: Number
+    Default: 7
+    Description: >-
+      Terminate MoleculeBillingPattern instances older than this many hours.
+      7h is derived from real build durations (worst genuine run 4.34h, p99
+      0.93h across 819 completed builds), so it clears live builds while
+      reclaiming aborted or leaked instances.
 
 Resources:
 
@@ -93,6 +108,8 @@ Resources:
         Variables:
           DRY_RUN: !Ref DryRunMode
           EKS_SKIP_PATTERN: !Ref EksSkipPattern
+          MOLECULE_BILLING_PATTERN: !Ref MoleculeBillingPattern
+          MOLECULE_MAX_AGE_HOURS: !Ref MoleculeMaxAgeHours
       Tags:
         - Key: iit-billing-tag
           Value: lambda-ec2-cleanup
@@ -110,9 +127,13 @@ Resources:
 
           EKS_SKIP_PATTERN = os.environ.get("EKS_SKIP_PATTERN", "pe-.*")
           DRY_RUN = os.environ.get("DRY_RUN", "true").lower() == "true"
+          MOLECULE_BILLING_PATTERN = os.environ.get("MOLECULE_BILLING_PATTERN", r".*_package_testing$")
+          MOLECULE_MAX_AGE = int(float(os.environ.get("MOLECULE_MAX_AGE_HOURS", "7")) * 3600)
+          MOLECULE_RE = re.compile(MOLECULE_BILLING_PATTERN)
 
           logger.info(f"EKS_SKIP_PATTERN: {EKS_SKIP_PATTERN}")
           logger.info(f"DRY_RUN: {DRY_RUN}")
+          logger.info(f"MOLECULE: pattern={MOLECULE_BILLING_PATTERN} max_age={MOLECULE_MAX_AGE}s")
 
           eks_clusters_to_delete = {}
 
@@ -229,9 +250,20 @@ Resources:
 
           def should_terminate(instance):
               tags_dict = convert_tags_to_dict(instance.tags)
+              running = datetime.datetime.now(datetime.timezone.utc) - instance.launch_time
+              # Ephemeral package-testing molecule instances carry a non-numeric
+              # iit-billing-tag (e.g. ps_80_package_testing) that has_valid_billing_tag
+              # treats as a permanent category exemption. They leak when a build is
+              # aborted before "molecule destroy" runs, so age-bound them instead of
+              # exempting them forever.
+              bt = tags_dict.get("iit-billing-tag", "")
+              if bt and MOLECULE_RE.match(bt):
+                  if running.total_seconds() > MOLECULE_MAX_AGE:
+                      logger.info(f"Molecule leak: {instance.id} tag={bt} age={int(running.total_seconds())}s > {MOLECULE_MAX_AGE}s, terminate")
+                      return True
+                  return False
               if has_valid_billing_tag(tags_dict, instance.launch_time):
                   return False
-              running = datetime.datetime.now(datetime.timezone.utc) - instance.launch_time
               return running.total_seconds() > 600
 
 

--- a/ps/jenkins/ps-package-testing-molecule.groovy
+++ b/ps/jenkins/ps-package-testing-molecule.groovy
@@ -473,6 +473,7 @@ pipeline {
     }
     options {
         withCredentials(moleculePdpsJenkinsCreds())
+        timeout(time: 6, unit: 'HOURS')
     }
         stages {
             stage('Set Build Name'){

--- a/ps/jenkins/ps80-binary-tarball.groovy
+++ b/ps/jenkins/ps80-binary-tarball.groovy
@@ -48,6 +48,7 @@ pipeline {
   options {
     withCredentials(moleculePdpsJenkinsCreds())
     disableConcurrentBuilds()
+    timeout(time: 6, unit: 'HOURS')
   }
   stages {
     stage('Set build name'){

--- a/pxb/jenkins/pxb-pt-testing-molecule.groovy
+++ b/pxb/jenkins/pxb-pt-testing-molecule.groovy
@@ -93,6 +93,7 @@
     }
     options {
         withCredentials(moleculepxbJenkinsCreds())
+        timeout(time: 6, unit: 'HOURS')
     }
 
         stages {

--- a/pxb/jenkins/pxb-tarball-molecule.groovy
+++ b/pxb/jenkins/pxb-tarball-molecule.groovy
@@ -142,6 +142,7 @@ pipeline {
     //withCredentials(moleculepxcJenkinsCreds())
     withCredentials(moleculepxbJenkinsCreds())
     disableConcurrentBuilds()
+    timeout(time: 6, unit: 'HOURS')
   }
 
   stages {

--- a/pxc/jenkins/pxc-package-testing.groovy
+++ b/pxc/jenkins/pxc-package-testing.groovy
@@ -919,6 +919,7 @@ pipeline {
 
     options {
         buildDiscarder(logRotator(numToKeepStr: '100'))
+        timeout(time: 6, unit: 'HOURS')
     }
 
     environment {


### PR DESCRIPTION
**Bug**
- Aborted package-testing molecule builds skip `molecule destroy`, leaking EC2 instances indefinitely; their category `iit-billing-tag` (`*_package_testing`) exempts them from the cleanup Lambda forever.

**Fix**
- `timeout(time: 6, unit: 'HOURS')` on the 4 molecule pipelines so an abort still reaches the `post { always }` destroy.
- The Lambda-side backstop (7h age-bound on `.*_package_testing$` billing tags) now lives in the Terraform reaper: [percona-cd-platform#123](https://github.com/percona/percona-cd-platform/pull/123). This PR is groovy-only and no longer touches `IaC/LambdaEC2Cleanup.yml` (deleted by [#4183](https://github.com/Percona-Lab/jenkins-pipelines/pull/4183)).

**Tickets**
- [PS-11257](https://perconadev.atlassian.net/browse/PS-11257)

[PS-11257]: https://perconadev.atlassian.net/browse/PS-11257?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ