### PR TITLE
PS-11260: Modernize Jenkins master spot-fleet instance types

### DIFF
--- a/IaC/cloud.cd/JenkinsStack.yml
+++ b/IaC/cloud.cd/JenkinsStack.yml
@@ -484,13 +484,13 @@ Resources:
             LaunchTemplateId: !Ref JMasterTemplate
             Version: !Ref MasterLtVersion
           Overrides:
-          - InstanceType: c5a.xlarge
+          - InstanceType: c7a.xlarge
             AvailabilityZone:
               Fn::Select: [ 1, !GetAZs '' ]
-          - InstanceType: c5d.xlarge
+          - InstanceType: c7i.xlarge
             AvailabilityZone:
               Fn::Select: [ 1, !GetAZs '' ]
-          - InstanceType: c6in.xlarge
+          - InstanceType: c8i.xlarge
             AvailabilityZone:
               Fn::Select: [ 1, !GetAZs '' ]
           - InstanceType: c7i-flex.xlarge

--- a/IaC/pg.cd/JenkinsStack.yml
+++ b/IaC/pg.cd/JenkinsStack.yml
@@ -515,16 +515,16 @@ Resources:
             LaunchTemplateId: !Ref JMasterTemplate
             Version: !Ref MasterLtVersion
           Overrides:
-          - InstanceType: i3en.large
+          - InstanceType: i7i.large
             AvailabilityZone:
               Fn::Select: [ 1, !GetAZs '' ]
           - InstanceType: i4i.large
             AvailabilityZone:
               Fn::Select: [ 1, !GetAZs '' ]
-          - InstanceType: r5a.large
+          - InstanceType: r7a.large
             AvailabilityZone:
               Fn::Select: [ 1, !GetAZs '' ]
-          - InstanceType: r5dn.large
+          - InstanceType: r7i.large
             AvailabilityZone:
               Fn::Select: [ 1, !GetAZs '' ]
 

--- a/IaC/pmm.cd/JenkinsStack.yml
+++ b/IaC/pmm.cd/JenkinsStack.yml
@@ -534,7 +534,7 @@ Resources:
               LaunchTemplateId: !Ref JMasterTemplate
               Version: !Ref MasterLtVersion
             Overrides:
-              - InstanceType: g4ad.xlarge
+              - InstanceType: m7i.xlarge
                 AvailabilityZone:
                   Fn::Select: [1, !GetAZs ""]
               - InstanceType: m7a.xlarge

--- a/IaC/psmdb.cd/JenkinsStack.yml
+++ b/IaC/psmdb.cd/JenkinsStack.yml
@@ -409,7 +409,7 @@ Resources:
             LaunchTemplateId: !Ref JMasterTemplate
             Version: !Ref MasterLtVersion
           Overrides:
-          - InstanceType: c5d.2xlarge
+          - InstanceType: c7a.2xlarge
             AvailabilityZone:
               Fn::Select: [ 1, !GetAZs '' ]
           - InstanceType: c7i-flex.2xlarge

--- a/IaC/rel.cd/JenkinsStack.yml
+++ b/IaC/rel.cd/JenkinsStack.yml
@@ -463,13 +463,13 @@ Resources:
             LaunchTemplateId: !Ref JMasterTemplate
             Version: !Ref MasterLtVersion
           Overrides:
-          - InstanceType: c5a.xlarge
+          - InstanceType: c7a.xlarge
             AvailabilityZone:
               Fn::Select: [ 1, !GetAZs '' ]
-          - InstanceType: c5d.xlarge
+          - InstanceType: c7i.xlarge
             AvailabilityZone:
               Fn::Select: [ 1, !GetAZs '' ]
-          - InstanceType: c6in.xlarge
+          - InstanceType: c8i.xlarge
             AvailabilityZone:
               Fn::Select: [ 1, !GetAZs '' ]
           - InstanceType: c7i-flex.xlarge


### PR DESCRIPTION
**Summary**
- Modernize the spot-fleet instance pools of the 5 CloudFormation masters still on spot (cloud, pg, pmm, psmdb, rel) to current-generation x86 types, and drop the idle GPU type from pmm.

**Why**
- pmm restarted 8 times in the last 7 days. 7 of 10 controller launches were the `g4ad` GPU type, reclaimed roughly daily, because GPU spot capacity is volatile. Replacing it with `m7i.xlarge` removes that exposure and keeps the pool diverse.
- The same root cause (aging or volatile spot types) applies to the other masters' gen-5 pools, where current generations give better price, performance, and capacity stability.
- Each swap preserves family, vCPU, RAM, and the per-master processor mix. Local-NVMe variants dropped only where unused, and new types verified per region and under each `SpotPrice` cap.

**Tickets**
- [PS-11260](https://perconadev.atlassian.net/browse/PS-11260)

[PS-11260]: https://perconadev.atlassian.net/browse/PS-11260?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ