### PR TITLE
feat(arm-fleet): Graviton EC2 Fleet clouds on the 5 CFN masters

### DIFF
--- a/IaC/cloud.cd/init.groovy.d/ec2FleetCloud.groovy
+++ b/IaC/cloud.cd/init.groovy.d/ec2FleetCloud.groovy
@@ -1,0 +1,76 @@
+// ec2FleetCloud.groovy  (PS-11179)
+//
+// Registers the diversified Graviton EC2 Fleet (ASG-backed via the ec2-fleet
+// plugin) as a Jenkins Cloud serving the `docker-32gb-aarch64` label on cloud.
+// Uniform multi-SKU fallback path with ps3/ps57/ps80/pxc.
+//
+// IAM: the `Ec2FleetPluginAutoScaling` policy is attached to the CFN-managed
+// jenkins-cloud-master role by the standalone TF block in
+// terraform/master-cloud.tf (jenkins-arm-fleet module) in percona-cd-platform.
+// The plugin uses the master IAM instance profile (`awsCredentialsId = ""`).
+//
+// SSH: the `percona-jenkins` private-key credential must be loaded into cloud;
+// it matches the AWS key pair on the Launch Template (`key_name = "percona-jenkins"`).
+// `privateIpUsed = true` because the master's egress does not reliably reach the
+// worker's public IP; master + worker share the same VPC (jenkins-cloud,
+// 10.177.0.0/22), so private IP routing works.
+//
+// Requires the ec2-fleet plugin to be installed + active first, or the
+// EC2FleetCloud import fails to resolve. Idempotent: re-applying via
+// `jenkins iac deploy` removes the prior cloud instance with the same name.
+
+import com.amazon.jenkins.ec2fleet.EC2FleetCloud
+import hudson.plugins.sshslaves.SSHConnector
+import hudson.plugins.sshslaves.verifiers.NonVerifyingKeyVerificationStrategy
+import jenkins.model.Jenkins
+import java.util.logging.Logger
+
+final Logger LOG = Logger.getLogger('ec2FleetCloud')
+final String CLOUD_NAME   = 'arm-graviton-fleet'
+final String REGION       = 'eu-west-1'
+final String ASG_NAME     = 'jenkins-cloud-arm-graviton'
+final String LABEL        = 'docker-32gb-aarch64'
+final String SSH_CRED_ID  = 'percona-jenkins'
+
+Jenkins.instance.clouds.findAll { it.name == CLOUD_NAME }.each {
+    Jenkins.instance.clouds.remove(it)
+}
+
+def sshConn = new SSHConnector(
+    22, SSH_CRED_ID,
+    '', '', '', '',
+    null, null, null,
+    new NonVerifyingKeyVerificationStrategy()
+)
+
+def fleet = new EC2FleetCloud(
+    CLOUD_NAME,
+    '',                          // awsCredentialsId (empty -> master IAM instance profile)
+    '',                          // credentialsId (legacy field, kept empty)
+    REGION,
+    '',                          // endpoint
+    ASG_NAME,
+    LABEL,
+    '/mnt/jenkins',              // fsRoot
+    sshConn,                     // computerConnector
+    true,                        // privateIpUsed -- master + worker share the master VPC
+    false,                       // alwaysReconnect
+    (Integer) 10,                // idleMinutes (NON-zero: 0 = never scale down)
+    0,                           // minSize
+    16,                          // maxSize (matches TF)
+    0,                           // minSpareSize
+    1,                           // numExecutors
+    true,                        // addNodeOnlyIfRunning
+    false,                       // restrictUsage
+    '-1',                        // maxTotalUses (-1 = unlimited)
+    false,                       // disableTaskResubmit
+    (Integer) 600,               // initOnlineTimeoutSec
+    (Integer) 15,                // initOnlineCheckIntervalSec
+    (Integer) 10,                // cloudStatusIntervalSec
+    false,                       // noDelayProvision
+    false,                       // scaleExecutorsByWeight
+    new EC2FleetCloud.NoScaler()
+)
+
+Jenkins.instance.clouds.add(fleet)
+LOG.info("ec2FleetCloud: registered cloud='${CLOUD_NAME}' label='${LABEL}' fleet='${ASG_NAME}' region='${REGION}'")

--- a/IaC/cloud.cd/init.groovy.d/ec2FleetCloud.groovy
+++ b/IaC/cloud.cd/init.groovy.d/ec2FleetCloud.groovy
@@ -63,7 +63,7 @@ def fleet = new EC2FleetCloud(
     true,                        // addNodeOnlyIfRunning
     false,                       // restrictUsage
     '-1',                        // maxTotalUses (-1 = unlimited)
-    false,                       // disableTaskResubmit
+    true,                        // disableTaskResubmit (PS-11265: resubmit aborts pipeline node bodies and re-schedules with wrong params and no cause)
     (Integer) 600,               // initOnlineTimeoutSec
     (Integer) 15,                // initOnlineCheckIntervalSec
     (Integer) 10,                // cloudStatusIntervalSec

--- a/IaC/pg.cd/init.groovy.d/ec2FleetCloud.groovy
+++ b/IaC/pg.cd/init.groovy.d/ec2FleetCloud.groovy
@@ -63,7 +63,7 @@ def fleet = new EC2FleetCloud(
     true,                        // addNodeOnlyIfRunning
     false,                       // restrictUsage
     '-1',                        // maxTotalUses (-1 = unlimited)
-    false,                       // disableTaskResubmit
+    true,                        // disableTaskResubmit (PS-11265: resubmit aborts pipeline node bodies and re-schedules with wrong params and no cause)
     (Integer) 600,               // initOnlineTimeoutSec
     (Integer) 15,                // initOnlineCheckIntervalSec
     (Integer) 10,                // cloudStatusIntervalSec

--- a/IaC/pg.cd/init.groovy.d/ec2FleetCloud.groovy
+++ b/IaC/pg.cd/init.groovy.d/ec2FleetCloud.groovy
@@ -1,0 +1,76 @@
+// ec2FleetCloud.groovy  (PS-11179)
+//
+// Registers the diversified Graviton EC2 Fleet (ASG-backed via the ec2-fleet
+// plugin) as a Jenkins Cloud serving the `docker-32gb-aarch64` label on pg.
+// Uniform multi-SKU fallback path with ps3/ps57/ps80/pxc.
+//
+// IAM: the `Ec2FleetPluginAutoScaling` policy is attached to the CFN-managed
+// jenkins-pg-master role by the standalone TF block in
+// terraform/master-pg.tf (jenkins-arm-fleet module) in percona-cd-platform.
+// The plugin uses the master IAM instance profile (`awsCredentialsId = ""`).
+//
+// SSH: the `percona-jenkins` private-key credential must be loaded into pg;
+// it matches the AWS key pair on the Launch Template (`key_name = "percona-jenkins"`).
+// `privateIpUsed = true` because the master's egress does not reliably reach the
+// worker's public IP; master + worker share the same VPC (jenkins-pg,
+// 10.144.0.0/22), so private IP routing works.
+//
+// Requires the ec2-fleet plugin to be installed + active first, or the
+// EC2FleetCloud import fails to resolve. Idempotent: re-applying via
+// `jenkins iac deploy` removes the prior cloud instance with the same name.
+
+import com.amazon.jenkins.ec2fleet.EC2FleetCloud
+import hudson.plugins.sshslaves.SSHConnector
+import hudson.plugins.sshslaves.verifiers.NonVerifyingKeyVerificationStrategy
+import jenkins.model.Jenkins
+import java.util.logging.Logger
+
+final Logger LOG = Logger.getLogger('ec2FleetCloud')
+final String CLOUD_NAME   = 'arm-graviton-fleet'
+final String REGION       = 'eu-central-1'
+final String ASG_NAME     = 'jenkins-pg-arm-graviton'
+final String LABEL        = 'docker-32gb-aarch64'
+final String SSH_CRED_ID  = 'percona-jenkins'
+
+Jenkins.instance.clouds.findAll { it.name == CLOUD_NAME }.each {
+    Jenkins.instance.clouds.remove(it)
+}
+
+def sshConn = new SSHConnector(
+    22, SSH_CRED_ID,
+    '', '', '', '',
+    null, null, null,
+    new NonVerifyingKeyVerificationStrategy()
+)
+
+def fleet = new EC2FleetCloud(
+    CLOUD_NAME,
+    '',                          // awsCredentialsId (empty -> master IAM instance profile)
+    '',                          // credentialsId (legacy field, kept empty)
+    REGION,
+    '',                          // endpoint
+    ASG_NAME,
+    LABEL,
+    '/mnt/jenkins',              // fsRoot
+    sshConn,                     // computerConnector
+    true,                        // privateIpUsed -- master + worker share the master VPC
+    false,                       // alwaysReconnect
+    (Integer) 10,                // idleMinutes (NON-zero: 0 = never scale down)
+    0,                           // minSize
+    16,                          // maxSize (matches TF)
+    0,                           // minSpareSize
+    1,                           // numExecutors
+    true,                        // addNodeOnlyIfRunning
+    false,                       // restrictUsage
+    '-1',                        // maxTotalUses (-1 = unlimited)
+    false,                       // disableTaskResubmit
+    (Integer) 600,               // initOnlineTimeoutSec
+    (Integer) 15,                // initOnlineCheckIntervalSec
+    (Integer) 10,                // cloudStatusIntervalSec
+    false,                       // noDelayProvision
+    false,                       // scaleExecutorsByWeight
+    new EC2FleetCloud.NoScaler()
+)
+
+Jenkins.instance.clouds.add(fleet)
+LOG.info("ec2FleetCloud: registered cloud='${CLOUD_NAME}' label='${LABEL}' fleet='${ASG_NAME}' region='${REGION}'")

--- a/IaC/pmm.cd/init.groovy.d/ec2FleetCloud.groovy
+++ b/IaC/pmm.cd/init.groovy.d/ec2FleetCloud.groovy
@@ -1,0 +1,76 @@
+// ec2FleetCloud.groovy  (PS-11179)
+//
+// Registers the diversified Graviton EC2 Fleet (ASG-backed via the ec2-fleet
+// plugin) as a Jenkins Cloud serving the `docker-32gb-aarch64` label on pmm.
+// Uniform multi-SKU fallback path with ps3/ps57/ps80/pxc.
+//
+// IAM: the `Ec2FleetPluginAutoScaling` policy is attached to the CFN-managed
+// jenkins-pmm-amzn2-master role by the standalone TF block in
+// terraform/master-pmm.tf (jenkins-arm-fleet module) in percona-cd-platform.
+// The plugin uses the master IAM instance profile (`awsCredentialsId = ""`).
+//
+// SSH: the `percona-jenkins` private-key credential must be loaded into pmm;
+// it matches the AWS key pair on the Launch Template (`key_name = "percona-jenkins"`).
+// `privateIpUsed = true` because the master's egress does not reliably reach the
+// worker's public IP; master + worker share the same VPC (jenkins-pmm-amzn2,
+// 10.166.0.0/22), so private IP routing works.
+//
+// Requires the ec2-fleet plugin to be installed + active first, or the
+// EC2FleetCloud import fails to resolve. Idempotent: re-applying via
+// `jenkins iac deploy` removes the prior cloud instance with the same name.
+
+import com.amazon.jenkins.ec2fleet.EC2FleetCloud
+import hudson.plugins.sshslaves.SSHConnector
+import hudson.plugins.sshslaves.verifiers.NonVerifyingKeyVerificationStrategy
+import jenkins.model.Jenkins
+import java.util.logging.Logger
+
+final Logger LOG = Logger.getLogger('ec2FleetCloud')
+final String CLOUD_NAME   = 'arm-graviton-fleet'
+final String REGION       = 'us-east-2'
+final String ASG_NAME     = 'jenkins-pmm-arm-graviton'
+final String LABEL        = 'docker-32gb-aarch64'
+final String SSH_CRED_ID  = 'percona-jenkins'
+
+Jenkins.instance.clouds.findAll { it.name == CLOUD_NAME }.each {
+    Jenkins.instance.clouds.remove(it)
+}
+
+def sshConn = new SSHConnector(
+    22, SSH_CRED_ID,
+    '', '', '', '',
+    null, null, null,
+    new NonVerifyingKeyVerificationStrategy()
+)
+
+def fleet = new EC2FleetCloud(
+    CLOUD_NAME,
+    '',                          // awsCredentialsId (empty -> master IAM instance profile)
+    '',                          // credentialsId (legacy field, kept empty)
+    REGION,
+    '',                          // endpoint
+    ASG_NAME,
+    LABEL,
+    '/mnt/jenkins',              // fsRoot
+    sshConn,                     // computerConnector
+    true,                        // privateIpUsed -- master + worker share the master VPC
+    false,                       // alwaysReconnect
+    (Integer) 10,                // idleMinutes (NON-zero: 0 = never scale down)
+    0,                           // minSize
+    16,                          // maxSize (matches TF)
+    0,                           // minSpareSize
+    1,                           // numExecutors
+    true,                        // addNodeOnlyIfRunning
+    false,                       // restrictUsage
+    '-1',                        // maxTotalUses (-1 = unlimited)
+    true,                        // disableTaskResubmit (PS-11265: resubmit aborts pipeline node bodies and re-schedules with wrong params and no cause)
+    (Integer) 600,               // initOnlineTimeoutSec
+    (Integer) 15,                // initOnlineCheckIntervalSec
+    (Integer) 10,                // cloudStatusIntervalSec
+    false,                       // noDelayProvision
+    false,                       // scaleExecutorsByWeight
+    new EC2FleetCloud.NoScaler()
+)
+
+Jenkins.instance.clouds.add(fleet)
+LOG.info("ec2FleetCloud: registered cloud='${CLOUD_NAME}' label='${LABEL}' fleet='${ASG_NAME}' region='${REGION}'")

--- a/IaC/psmdb.cd/init.groovy.d/ec2FleetCloud.groovy
+++ b/IaC/psmdb.cd/init.groovy.d/ec2FleetCloud.groovy
@@ -65,7 +65,7 @@ def fleet = new EC2FleetCloud(
     true,                        // addNodeOnlyIfRunning
     false,                       // restrictUsage
     '-1',                        // maxTotalUses (-1 = unlimited)
-    false,                       // disableTaskResubmit
+    true,                        // disableTaskResubmit (PS-11265: resubmit aborts pipeline node bodies and re-schedules with wrong params and no cause)
     (Integer) 600,               // initOnlineTimeoutSec
     (Integer) 15,                // initOnlineCheckIntervalSec
     (Integer) 10,                // cloudStatusIntervalSec

--- a/IaC/psmdb.cd/init.groovy.d/ec2FleetCloud.groovy
+++ b/IaC/psmdb.cd/init.groovy.d/ec2FleetCloud.groovy
@@ -1,0 +1,78 @@
+// ec2FleetCloud.groovy  (PS-11179)
+//
+// Registers the diversified Graviton EC2 Fleet (ASG-backed via the ec2-fleet
+// plugin) as a Jenkins Cloud serving the `docker-32gb-aarch64` label on psmdb.
+// Uniform multi-SKU fallback path with ps3/ps57/ps80/pxc. psmdb has real
+// aarch64 demand today (PSMDB / PBM / mlink), so this Fleet is its diversified
+// spot-capacity backstop alongside the classic EC2 + Hetzner CAX paths.
+//
+// IAM: the `Ec2FleetPluginAutoScaling` policy is attached to the CFN-managed
+// jenkins-psmdb-master role by the standalone TF block in
+// terraform/master-psmdb.tf (jenkins-arm-fleet module) in percona-cd-platform.
+// The plugin uses the master IAM instance profile (`awsCredentialsId = ""`).
+//
+// SSH: the `percona-jenkins` private-key credential must be loaded into psmdb;
+// it matches the AWS key pair on the Launch Template (`key_name = "percona-jenkins"`).
+// `privateIpUsed = true` because the master's egress does not reliably reach the
+// worker's public IP; master + worker share the same VPC (jenkins-psmdb,
+// 10.188.0.0/22), so private IP routing works.
+//
+// Requires the ec2-fleet plugin to be installed + active first, or the
+// EC2FleetCloud import fails to resolve. Idempotent: re-applying via
+// `jenkins iac deploy` removes the prior cloud instance with the same name.
+
+import com.amazon.jenkins.ec2fleet.EC2FleetCloud
+import hudson.plugins.sshslaves.SSHConnector
+import hudson.plugins.sshslaves.verifiers.NonVerifyingKeyVerificationStrategy
+import jenkins.model.Jenkins
+import java.util.logging.Logger
+
+final Logger LOG = Logger.getLogger('ec2FleetCloud')
+final String CLOUD_NAME   = 'arm-graviton-fleet'
+final String REGION       = 'us-west-2'
+final String ASG_NAME     = 'jenkins-psmdb-arm-graviton'
+final String LABEL        = 'docker-32gb-aarch64'
+final String SSH_CRED_ID  = 'percona-jenkins'
+
+Jenkins.instance.clouds.findAll { it.name == CLOUD_NAME }.each {
+    Jenkins.instance.clouds.remove(it)
+}
+
+def sshConn = new SSHConnector(
+    22, SSH_CRED_ID,
+    '', '', '', '',
+    null, null, null,
+    new NonVerifyingKeyVerificationStrategy()
+)
+
+def fleet = new EC2FleetCloud(
+    CLOUD_NAME,
+    '',                          // awsCredentialsId (empty -> master IAM instance profile)
+    '',                          // credentialsId (legacy field, kept empty)
+    REGION,
+    '',                          // endpoint
+    ASG_NAME,
+    LABEL,
+    '/mnt/jenkins',              // fsRoot
+    sshConn,                     // computerConnector
+    true,                        // privateIpUsed -- master + worker share the master VPC
+    false,                       // alwaysReconnect
+    (Integer) 10,                // idleMinutes (NON-zero: 0 = never scale down)
+    0,                           // minSize
+    16,                          // maxSize (matches TF)
+    0,                           // minSpareSize
+    1,                           // numExecutors
+    true,                        // addNodeOnlyIfRunning
+    false,                       // restrictUsage
+    '-1',                        // maxTotalUses (-1 = unlimited)
+    false,                       // disableTaskResubmit
+    (Integer) 600,               // initOnlineTimeoutSec
+    (Integer) 15,                // initOnlineCheckIntervalSec
+    (Integer) 10,                // cloudStatusIntervalSec
+    false,                       // noDelayProvision
+    false,                       // scaleExecutorsByWeight
+    new EC2FleetCloud.NoScaler()
+)
+
+Jenkins.instance.clouds.add(fleet)
+LOG.info("ec2FleetCloud: registered cloud='${CLOUD_NAME}' label='${LABEL}' fleet='${ASG_NAME}' region='${REGION}'")

--- a/IaC/rel.cd/init.groovy.d/ec2FleetCloud.groovy
+++ b/IaC/rel.cd/init.groovy.d/ec2FleetCloud.groovy
@@ -29,7 +29,10 @@ final Logger LOG = Logger.getLogger('ec2FleetCloud')
 final String CLOUD_NAME   = 'arm-graviton-fleet'
 final String REGION       = 'eu-west-1'
 final String ASG_NAME     = 'jenkins-rel-arm-graviton'
-final String LABEL        = 'docker-32gb-aarch64'
+// docker-aarch64 is deliberately included on rel ONLY: release builds queue on
+// that label and rel has had zero Hetzner aarch64 templates since the PS-11149
+// CAX mitigation; Graviton (8 vCPU / 32 GiB) is a superset of the cax41 it replaces.
+final String LABEL        = 'docker-32gb-aarch64 docker-aarch64'
 final String SSH_CRED_ID  = 'percona-jenkins'
 
 Jenkins.instance.clouds.findAll { it.name == CLOUD_NAME }.each {
@@ -63,7 +66,7 @@ def fleet = new EC2FleetCloud(
     true,                        // addNodeOnlyIfRunning
     false,                       // restrictUsage
     '-1',                        // maxTotalUses (-1 = unlimited)
-    false,                       // disableTaskResubmit
+    true,                        // disableTaskResubmit (PS-11265: resubmit aborts pipeline node bodies and re-schedules with wrong params and no cause)
     (Integer) 600,               // initOnlineTimeoutSec
     (Integer) 15,                // initOnlineCheckIntervalSec
     (Integer) 10,                // cloudStatusIntervalSec

--- a/IaC/rel.cd/init.groovy.d/ec2FleetCloud.groovy
+++ b/IaC/rel.cd/init.groovy.d/ec2FleetCloud.groovy
@@ -1,0 +1,76 @@
+// ec2FleetCloud.groovy  (PS-11179)
+//
+// Registers the diversified Graviton EC2 Fleet (ASG-backed via the ec2-fleet
+// plugin) as a Jenkins Cloud serving the `docker-32gb-aarch64` label on rel.
+// Uniform multi-SKU fallback path with ps3/ps57/ps80/pxc.
+//
+// IAM: the `Ec2FleetPluginAutoScaling` policy is attached to the CFN-managed
+// jenkins-rel-master role by the standalone TF block in
+// terraform/master-rel.tf (jenkins-arm-fleet module) in percona-cd-platform.
+// The plugin uses the master IAM instance profile (`awsCredentialsId = ""`).
+//
+// SSH: the `percona-jenkins` private-key credential must be loaded into rel;
+// it matches the AWS key pair on the Launch Template (`key_name = "percona-jenkins"`).
+// `privateIpUsed = true` because the master's egress does not reliably reach the
+// worker's public IP; master + worker share the same VPC (jenkins-rel,
+// 10.199.0.0/22), so private IP routing works.
+//
+// Requires the ec2-fleet plugin to be installed + active first, or the
+// EC2FleetCloud import fails to resolve. Idempotent: re-applying via
+// `jenkins iac deploy` removes the prior cloud instance with the same name.
+
+import com.amazon.jenkins.ec2fleet.EC2FleetCloud
+import hudson.plugins.sshslaves.SSHConnector
+import hudson.plugins.sshslaves.verifiers.NonVerifyingKeyVerificationStrategy
+import jenkins.model.Jenkins
+import java.util.logging.Logger
+
+final Logger LOG = Logger.getLogger('ec2FleetCloud')
+final String CLOUD_NAME   = 'arm-graviton-fleet'
+final String REGION       = 'eu-west-1'
+final String ASG_NAME     = 'jenkins-rel-arm-graviton'
+final String LABEL        = 'docker-32gb-aarch64'
+final String SSH_CRED_ID  = 'percona-jenkins'
+
+Jenkins.instance.clouds.findAll { it.name == CLOUD_NAME }.each {
+    Jenkins.instance.clouds.remove(it)
+}
+
+def sshConn = new SSHConnector(
+    22, SSH_CRED_ID,
+    '', '', '', '',
+    null, null, null,
+    new NonVerifyingKeyVerificationStrategy()
+)
+
+def fleet = new EC2FleetCloud(
+    CLOUD_NAME,
+    '',                          // awsCredentialsId (empty -> master IAM instance profile)
+    '',                          // credentialsId (legacy field, kept empty)
+    REGION,
+    '',                          // endpoint
+    ASG_NAME,
+    LABEL,
+    '/mnt/jenkins',              // fsRoot
+    sshConn,                     // computerConnector
+    true,                        // privateIpUsed -- master + worker share the master VPC
+    false,                       // alwaysReconnect
+    (Integer) 10,                // idleMinutes (NON-zero: 0 = never scale down)
+    0,                           // minSize
+    16,                          // maxSize (matches TF)
+    0,                           // minSpareSize
+    1,                           // numExecutors
+    true,                        // addNodeOnlyIfRunning
+    false,                       // restrictUsage
+    '-1',                        // maxTotalUses (-1 = unlimited)
+    false,                       // disableTaskResubmit
+    (Integer) 600,               // initOnlineTimeoutSec
+    (Integer) 15,                // initOnlineCheckIntervalSec
+    (Integer) 10,                // cloudStatusIntervalSec
+    false,                       // noDelayProvision
+    false,                       // scaleExecutorsByWeight
+    new EC2FleetCloud.NoScaler()
+)
+
+Jenkins.instance.clouds.add(fleet)
+LOG.info("ec2FleetCloud: registered cloud='${CLOUD_NAME}' label='${LABEL}' fleet='${ASG_NAME}' region='${REGION}'")


### PR DESCRIPTION
**Feature**
- Register the `arm-graviton-fleet` cloud (ec2-fleet plugin, ASG-backed) on the five CFN masters: psmdb, pg, rel, cloud, pmm. The ASGs, IAM, and widened 8-type spot pools are already live from percona-cd-platform
- rel additionally carries the `docker-aarch64` label, restoring aarch64 capacity for release builds queued since the CAX mitigation removed the Hetzner templates

**Why**
- Completes the PS-11179 Graviton fallback path on the CFN half of the fleet
- `disableTaskResubmit=true` from day one: the plugin's resubmit aborts pipeline node bodies and mints cause-less ghost builds ([PS-11265](https://perconadev.atlassian.net/browse/PS-11265))

**Rollout**
- Deployed live from this branch and checklist-verified on all five masters (prereq plugins + the `percona-jenkins` SSH credential loaded everywhere; rel drained the queued aarch64 release builds within minutes). Merge makes these files canonical

**Tickets**
- [PS-11179](https://perconadev.atlassian.net/browse/PS-11179), related: [PS-11265](https://perconadev.atlassian.net/browse/PS-11265), substrate: [cd-platform 109](https://github.com/Percona/percona-cd-platform/pull/109) + [132](https://github.com/Percona/percona-cd-platform/pull/132) + [133](https://github.com/Percona/percona-cd-platform/pull/133)


[PS-11265]: https://perconadev.atlassian.net/browse/PS-11265?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[PS-11179]: https://perconadev.atlassian.net/browse/PS-11179?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[PS-11265]: https://perconadev.atlassian.net/browse/PS-11265?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ