### PR TITLE
PS-11265: Fix NPE on cause-less runs of pxc80 parallel-mtr

### DIFF
--- a/pxc/jenkins/pxc80-pipeline-parallel-mtr.groovy
+++ b/pxc/jenkins/pxc80-pipeline-parallel-mtr.groovy
@@ -640,10 +640,10 @@ pipeline {
                 git branch: JENKINS_SCRIPTS_BRANCH, url: JENKINS_SCRIPTS_REPO
 
                 script {
-                    BUILD_TRIGGER_BY = " (${currentBuild.getBuildCauses()[0].userId})"
-                    if (BUILD_TRIGGER_BY == " (null)") {
-                        BUILD_TRIGGER_BY = " "
-                    }
+                    // A build can have no cause at all (Replay, or the EC2 Fleet
+                    // plugin's task resubmit); indexing [0] then throws an NPE.
+                    def userCause = currentBuild.getBuildCauses('hudson.model.Cause$UserIdCause')
+                    BUILD_TRIGGER_BY = userCause ? " (${userCause[0].userId})" : " "
                     currentBuild.displayName = "${BUILD_NUMBER} ${CMAKE_BUILD_TYPE}/${DOCKER_OS}${BUILD_TRIGGER_BY} ${CUSTOM_BUILD_NAME}"
                 }
 


### PR DESCRIPTION
**Bug**
- A cause-less run of `pxc80-pipeline-parallel-mtr` (Replay, or the EC2 Fleet plugin's task resubmit) crashes in seconds with an NPE at `getBuildCauses()[0].userId` before any work starts. Same crash class as ps80 builds 487-489 of the PS twin

**Fix**
- Replace the `[0]` indexing with a typed `UserIdCause` lookup with a blank fallback

**Tickets**
- [PS-11265](https://perconadev.atlassian.net/browse/PS-11265), sibling: [ps-build PR 523](https://github.com/Percona-Lab/ps-build/pull/523)

[PS-11265]: https://perconadev.atlassian.net/browse/PS-11265?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ