### PR TITLE
Fix Docker CVE report styling and links

### DIFF
--- a/ppg/docker-cve-scan.groovy
+++ b/ppg/docker-cve-scan.groovy
@@ -140,7 +140,7 @@ for scan in scans:
     status_cls = "status-clean" if clean else "status-vuln"
 
     summary_rows.append(
-        f\'<tr><td>{escape(image)}</td><td>{escape(platform)}</td>\'
+        f\'<tr><td>{escape(image)}</td><td class="cnt">{escape(platform)}</td>\'
         f\'<td class="cnt sev-critical">{counts["CRITICAL"]}</td>\'
         f\'<td class="cnt sev-high">{counts["HIGH"]}</td>\'
         f\'<td class="cnt {status_cls}">{"CLEAN" if clean else "VULNERABLE"}</td></tr>\'
@@ -202,7 +202,7 @@ html = (
     f\'<h1>CVE Scan Report: {escape(group_name)}</h1>\'
     f\'<p class="meta">Generated: {datetime.utcnow().strftime("%Y-%m-%d %H:%M UTC")}</p>\'
     f\'<h2>Summary</h2>\'
-    f\'<table><thead><tr><th>Image</th><th>Platform</th><th>CRITICAL</th><th>HIGH</th><th>Status</th></tr></thead>\'
+    f\'<table><thead><tr><th>Image</th><th class="cnt">Platform</th><th class="cnt">CRITICAL</th><th class="cnt">HIGH</th><th class="cnt">Status</th></tr></thead>\'
     f\'<tbody>{"".join(summary_rows)}</tbody></table>\'
     f\'{"".join(sections)}</body></html>\'
 )

--- a/ppg/docker-cve-scan.groovy
+++ b/ppg/docker-cve-scan.groovy
@@ -120,7 +120,7 @@ scans = []
 for entry in manifest:
     scans.append({"image": entry["image"], "platform": entry["platform"], "data": json.load(open(entry["file"]))})
 
-SEV_COLOR = {"CRITICAL": "#d73a49", "HIGH": "#e36209"}
+SEV_CLASS = {"CRITICAL": "sev-critical", "HIGH": "sev-high"}
 
 def count_cves(data):
     c = {"CRITICAL": 0, "HIGH": 0}
@@ -137,13 +137,13 @@ for scan in scans:
     image, platform, data = scan["image"], scan["platform"], scan["data"]
     counts = count_cves(data)
     clean = counts["CRITICAL"] == 0 and counts["HIGH"] == 0
-    status_color = "#28a745" if clean else "#d73a49"
+    status_cls = "status-clean" if clean else "status-vuln"
 
     summary_rows.append(
         f\'<tr><td>{escape(image)}</td><td>{escape(platform)}</td>\'
-        f\'<td style="color:{SEV_COLOR["CRITICAL"]};font-weight:bold">{counts["CRITICAL"]}</td>\'
-        f\'<td style="color:{SEV_COLOR["HIGH"]};font-weight:bold">{counts["HIGH"]}</td>\'
-        f\'<td style="color:{status_color};font-weight:bold">{"CLEAN" if clean else "VULNERABLE"}</td></tr>\'
+        f\'<td class="cnt sev-critical">{counts["CRITICAL"]}</td>\'
+        f\'<td class="cnt sev-high">{counts["HIGH"]}</td>\'
+        f\'<td class="cnt {status_cls}">{"CLEAN" if clean else "VULNERABLE"}</td></tr>\'
     )
 
     rows = []
@@ -151,12 +151,12 @@ for scan in scans:
         for v in sorted(result.get("Vulnerabilities") or [],
                         key=lambda x: (0 if x.get("Severity") == "CRITICAL" else 1, x.get("PkgName", ""))):
             sev = v.get("Severity", "")
+            sev_cls = SEV_CLASS.get(sev, "")
             cve_id = escape(v.get("VulnerabilityID", ""))
-            url = v.get("PrimaryURL", "")
-            link = f\'<a href="{escape(url)}" target="_blank">{cve_id}</a>\' if url else cve_id
+            link = f\'<a href="https://nvd.nist.gov/vuln/detail/{cve_id}" target="_blank">{cve_id}</a>\' if cve_id else cve_id
             rows.append(
                 f\'<tr><td>{link}</td>\'
-                f\'<td style="color:{SEV_COLOR.get(sev, "#000")};font-weight:bold">{escape(sev)}</td>\'
+                f\'<td class="{sev_cls}">{escape(sev)}</td>\'
                 f\'<td>{escape(v.get("PkgName", ""))}</td>\'
                 f\'<td>{escape(v.get("InstalledVersion", ""))}</td>\'
                 f\'<td>{escape(v.get("FixedVersion") or "n/a")}</td>\'
@@ -168,7 +168,7 @@ for scan in scans:
         \'<table><thead><tr><th>CVE ID</th><th>Severity</th><th>Package</th>\'
         \'<th>Installed</th><th>Fixed</th><th>Target</th><th>Title</th></tr></thead>\'
         f\'<tbody>{"".join(rows)}</tbody></table>\'
-    ) if rows else \'<p style="color:#28a745">&#x2713; No HIGH/CRITICAL vulnerabilities found.</p>\'
+    ) if rows else \'<p class="status-clean">&#x2713; No HIGH/CRITICAL vulnerabilities found.</p>\'
 
     anchor = escape(f"{image}-{platform}").replace("/", "-").replace(":", "-")
     sections.append(
@@ -189,6 +189,11 @@ tr:hover td{background:#f1f8ff}
 a{color:#0366d6;text-decoration:none}
 a:hover{text-decoration:underline}
 .meta{color:#586069;font-size:.85em;margin-bottom:20px}
+.sev-critical{color:#d73a49;font-weight:bold}
+.sev-high{color:#e36209;font-weight:bold}
+.status-clean{color:#28a745;font-weight:bold}
+.status-vuln{color:#d73a49;font-weight:bold}
+.cnt{text-align:center}
 """
 
 html = (


### PR DESCRIPTION
Replace inline style attributes with CSS classes to fix rendering under Jenkins. Switch CVE links from unreliable AVD URLs to authoritative NIST NVD links built directly from the CVE ID.