### PR TITLE
PMM-7 Print the logs on start timeout

### DIFF
--- a/pmm/v3/pmm3-aws-staging-start.groovy
+++ b/pmm/v3/pmm3-aws-staging-start.groovy
@@ -249,7 +249,11 @@ pipeline {
                                         ${DOCKER_ENV_VARIABLE} \
                                         ${DOCKER_VERSION}
 
-                                    timeout 60 bash -c 'until [ "$(curl -ks -o /dev/null -w "%{http_code}" https://127.0.0.1/v1/server/readyz)" = "200" ]; do sleep 5; done'
+                                    if ! timeout 60 bash -c 'until [ "$(curl -ks -o /dev/null -w "%{http_code}" https://127.0.0.1/v1/server/readyz)" = "200" ]; do sleep 5; done'; then
+                                        echo "PMM Server did not become ready within the timeout, dumping logs" >&2
+                                        docker logs pmm-server || true
+                                        exit 1
+                                    fi
                                     pmm_tag="${DOCKER_VERSION##*:}"
                                     minor_version=${pmm_tag#3.}
                                     minor_version=${minor_version%%.*}


### PR DESCRIPTION
This pull request improves the reliability and debuggability of the PMM server startup process in the `pmm3-aws-staging-start.groovy` pipeline script. 

* Enhanced the PMM server readiness check: if the server does not become ready within 60 seconds, the script now prints an error message, dumps the PMM server logs using `docker logs pmm-server`, and exits with an error code. This makes failures easier to diagnose in CI/CD runs.