### PR TITLE
PMM-7 Save PMM logs on start timeout

### DIFF
--- a/pmm/v3/pmm3-aws-staging-start.groovy
+++ b/pmm/v3/pmm3-aws-staging-start.groovy
@@ -216,6 +216,7 @@ pipeline {
                     withEnv(['JENKINS_NODE_COOKIE=dontKillMe']) {
                         node(env.VM_NAME){
                             withCredentials([aws(accessKeyVariable: 'AWS_ACCESS_KEY_ID', credentialsId: 'AMI/OVF', secretKeyVariable: 'AWS_SECRET_ACCESS_KEY')]) {
+                              try {
                                 sh '''
                                     set -o errexit
                                     set -o xtrace
@@ -252,6 +253,8 @@ pipeline {
                                     if ! timeout 60 bash -c 'until [ "$(curl -ks -o /dev/null -w "%{http_code}" https://127.0.0.1/v1/server/readyz)" = "200" ]; do sleep 5; done'; then
                                         echo "PMM Server did not become ready within the timeout, dumping logs" >&2
                                         docker logs pmm-server || true
+                                        mkdir -p "${WORKSPACE}/logs"
+                                        docker cp pmm-server:/srv/logs/. "${WORKSPACE}/logs/" || true
                                         exit 1
                                     fi
                                     pmm_tag="${DOCKER_VERSION##*:}"
@@ -262,6 +265,11 @@ pipeline {
                                     fi
                                     docker logs pmm-server
                                 '''
+                              } finally {
+                                  if (fileExists('logs')) {
+                                      archiveArtifacts artifacts: 'logs/**', allowEmptyArchive: true
+                                  }
+                              }
                             }
                         }
                     }


### PR DESCRIPTION
This pull request improves the Jenkins pipeline in `pmm3-aws-staging-start.groovy` by enhancing error handling and log management during the PMM Server startup process.

**Error handling and log archiving improvements:**

* Wrapped the shell execution block in a `try...finally` to guarantee that log archiving runs regardless of success or failure.
* On PMM Server startup failure, the pipeline now creates a `logs` directory and copies logs from the `pmm-server` Docker container for later inspection.
* After execution, if the `logs` directory exists, its contents are archived as build artifacts, even if empty.