### PR TITLE
PMM-7 Bump timeout to 100s

### DIFF
--- a/pmm/v3/pmm3-aws-staging-start.groovy
+++ b/pmm/v3/pmm3-aws-staging-start.groovy
@@ -250,7 +250,7 @@ pipeline {
                                         ${DOCKER_ENV_VARIABLE} \
                                         ${DOCKER_VERSION}
 
-                                    if ! timeout 60 bash -c 'until [ "$(curl -ks -o /dev/null -w "%{http_code}" https://127.0.0.1/v1/server/readyz)" = "200" ]; do sleep 5; done'; then
+                                    if ! timeout 100 bash -c 'until [ "$(curl -ks -o /dev/null -w "%{http_code}" https://127.0.0.1/v1/server/readyz)" = "200" ]; do sleep 5; done'; then
                                         echo "PMM Server did not become ready within the timeout, dumping logs" >&2
                                         docker logs pmm-server || true
                                         mkdir -p "${WORKSPACE}/logs"


### PR DESCRIPTION
Grafana needs more time to startup since it currently exceeds the 60s timeout causing the job to fail.