### PR TITLE
PS-11278: spot-price-auto-updater fails on on-demand EC2 templates

### DIFF
--- a/IaC/spot-price-auto-updater.yml
+++ b/IaC/spot-price-auto-updater.yml
@@ -202,9 +202,9 @@
             // Get all templates for the current cloud
             def templates = cloud.getTemplates()
 
-            // Iterate through each template
+            // Iterate through each template (skip on-demand templates, they have no spotConfig)
             templates.each { template ->
-                if (template instanceof SlaveTemplate) {
+                if (template instanceof SlaveTemplate && template.spotConfig instanceof SpotConfiguration) {
                     def instanceType = template.type.toString()
                     def amiId = template.ami
                     def maxBidPrice = template.spotConfig.getSpotMaxBidPrice()


### PR DESCRIPTION
**Bug**
- `spot-price-auto-updater` aborts with `NullPointerException: Cannot invoke method getSpotMaxBidPrice() on null object` on any master with on-demand EC2 templates. pmm has three, so its bid ceilings have not updated since the templates were added.
- The collection pass guards with `instanceof SpotConfiguration`; the update pass dereferences `template.spotConfig` unguarded.

**Fix**
- Apply the same guard in the update pass, skipping on-demand templates.

**Tickets**
- [PS-11278](https://perconadev.atlassian.net/browse/PS-11278) (this)


[PS-11278]: https://perconadev.atlassian.net/browse/PS-11278?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ