### PR TITLE
PMM-15127: Resolve post-release test versions from Docker Hub

### DIFF
--- a/pmm/v3/pmm3-post-release-tests.groovy
+++ b/pmm/v3/pmm3-post-release-tests.groovy
@@ -8,10 +8,6 @@ library changelog: false, identifier: 'v3lib@master', retriever: modernSCM(
   libraryPath: 'pmm/v3/'
 )
 
-def versionsList = pmmVersion('v3')
-def latestVersion = versionsList.last()
-def prevVersion = versionsList[-2]
-
 pipeline {
     agent {
         label 'agent-amd64'
@@ -35,6 +31,16 @@ pipeline {
             steps {
                 script {
                     env.ADMIN_PASSWORD = params.ADMIN_PASSWORD
+                    def tags = sh(
+                        script: '''wget -q "https://registry.hub.docker.com/v2/repositories/percona/pmm-server/tags?page_size=100" -O - \
+                            | jq -r '.results[].name' | grep -E '^[0-9]+\\.[0-9]+\\.[0-9]+$' | sort -V''',
+                        returnStdout: true
+                    ).trim().split('\n').findAll { it }
+                    if (tags.size() < 2) {
+                        error('Need at least two released percona/pmm-server tags on Docker Hub')
+                    }
+                    def prevVersion = tags[-2]
+                    def latestVersion = tags[-1]
                     env.PMM_SERVER_LATEST = latestVersion
                     env.DOCKER_TAG = "percona/pmm-server:${prevVersion}"
                     env.DOCKER_TAG_UPGRADE = "percona/pmm-server:${latestVersion}"

--- a/pmm/v3/pmm3-post-release-tests.groovy
+++ b/pmm/v3/pmm3-post-release-tests.groovy
@@ -36,9 +36,6 @@ pipeline {
                             | jq -r '.results[].name' | grep -E '^[0-9]+\\.[0-9]+\\.[0-9]+$' | sort -V''',
                         returnStdout: true
                     ).trim().split('\n').findAll { it }
-                    if (tags.size() < 2) {
-                        error('Need at least two released percona/pmm-server tags on Docker Hub')
-                    }
                     def prevVersion = tags[-2]
                     def latestVersion = tags[-1]
                     env.PMM_SERVER_LATEST = latestVersion

--- a/pmm/v3/pmm3-post-release-tests.groovy
+++ b/pmm/v3/pmm3-post-release-tests.groovy
@@ -33,12 +33,13 @@ pipeline {
                     env.ADMIN_PASSWORD = params.ADMIN_PASSWORD
                     def tags = sh(
                         script: '''set -e
-curl -sf "https://registry.hub.docker.com/v2/repositories/percona/pmm-server/tags?page_size=5" \
-    | jq -r '.results[].name' | grep -E '^3\\.[0-9]+\\.[0-9]+$' | sort -V''',
+json=$(curl -sf "https://registry.hub.docker.com/v2/repositories/percona/pmm-server/tags?page_size=100")
+echo "$json" | jq -e '.results' >/dev/null
+echo "$json" | jq -r '.results[].name' | grep -E '^3\\.[0-9]+\\.[0-9]+$' | sort -V || true''',
                         returnStdout: true
                     ).trim().split('\n').findAll { it }
                     if (tags.size() < 2) {
-                        error('Need at least two released PMM 3.x percona/pmm-server tags on Docker Hub')
+                        error('Need at least two released PMM 3.x.y percona/pmm-server tags on Docker Hub after filtering semver tags')
                     }
                     def prevVersion = tags[-2]
                     def latestVersion = tags[-1]

--- a/pmm/v3/pmm3-post-release-tests.groovy
+++ b/pmm/v3/pmm3-post-release-tests.groovy
@@ -32,10 +32,14 @@ pipeline {
                 script {
                     env.ADMIN_PASSWORD = params.ADMIN_PASSWORD
                     def tags = sh(
-                        script: '''wget -q "https://registry.hub.docker.com/v2/repositories/percona/pmm-server/tags?page_size=100" -O - \
-                            | jq -r '.results[].name' | grep -E '^[0-9]+\\.[0-9]+\\.[0-9]+$' | sort -V''',
+                        script: '''set -e
+curl -sf "https://registry.hub.docker.com/v2/repositories/percona/pmm-server/tags?page_size=5" \
+    | jq -r '.results[].name' | grep -E '^3\\.[0-9]+\\.[0-9]+$' | sort -V''',
                         returnStdout: true
                     ).trim().split('\n').findAll { it }
+                    if (tags.size() < 2) {
+                        error('Need at least two released PMM 3.x percona/pmm-server tags on Docker Hub')
+                    }
                     def prevVersion = tags[-2]
                     def latestVersion = tags[-1]
                     env.PMM_SERVER_LATEST = latestVersion


### PR DESCRIPTION
## Summary
- Post-release pipeline resolves latest and previous PMM versions from released \percona/pmm-server\ tags on Docker Hub instead of the static \pmmVersion('v3')\ list.
- Avoids running against a version that was added to the map before GA (e.g. 3.8.1 in the list while Hub still has 3.8.0).

