### PR TITLE
PMM-15146 Export `PMM_PERCONA_PLATFORM_ADDRESS` on RC builds

### DIFF
--- a/pmm/v3/pmm3-package-testing-amd64.groovy
+++ b/pmm/v3/pmm3-package-testing-amd64.groovy
@@ -7,7 +7,7 @@ void runStaging(String DOCKER_VERSION, ADMIN_PASSWORD, CLIENTS) {
     stagingJob = build job: 'pmm3-aws-staging-start', parameters: [
         string(name: 'DOCKER_VERSION', value: DOCKER_VERSION),
         string(name: 'CLIENT_VERSION', value: '3-dev-latest'),
-        string(name: 'DOCKER_ENV_VARIABLE', value: '-e PMM_ENABLE_TELEMETRY=false -e PMM_DATA_RETENTION=48h -e PMM_PERCONA_PLATFORM_ADDRESS=https://check-dev.percona.com:443 -e PMM_DEV_PERCONA_PLATFORM_PUBLIC_KEY=RWTg+ZmCCjt7O8eWeAmTLAqW+1ozUbpRSKSwNTmO+exlS5KEIPYWuYdX -e PMM_ENABLE_NOMAD=1'),
+        string(name: 'DOCKER_ENV_VARIABLE', value: '-e PMM_ENABLE_TELEMETRY=0 -e PMM_DATA_RETENTION=48h -e PMM_PERCONA_PLATFORM_ADDRESS=https://check-dev.percona.com:443 -e PMM_ENABLE_NOMAD=1'),
         string(name: 'CLIENTS', value: CLIENTS),
         string(name: 'ADMIN_PASSWORD', value: ADMIN_PASSWORD),
         string(name: 'NOTIFY', value: 'false'),

--- a/pmm/v3/pmm3-package-testing-amd64.groovy
+++ b/pmm/v3/pmm3-package-testing-amd64.groovy
@@ -7,7 +7,7 @@ void runStaging(String DOCKER_VERSION, ADMIN_PASSWORD, CLIENTS) {
     stagingJob = build job: 'pmm3-aws-staging-start', parameters: [
         string(name: 'DOCKER_VERSION', value: DOCKER_VERSION),
         string(name: 'CLIENT_VERSION', value: '3-dev-latest'),
-        string(name: 'DOCKER_ENV_VARIABLE', value: '-e PMM_ENABLE_TELEMETRY=false -e PMM_DATA_RETENTION=48h -e PMM_DEV_PERCONA_PLATFORM_ADDRESS=https://check-dev.percona.com:443 -e PMM_DEV_PERCONA_PLATFORM_PUBLIC_KEY=RWTg+ZmCCjt7O8eWeAmTLAqW+1ozUbpRSKSwNTmO+exlS5KEIPYWuYdX -e PMM_ENABLE_NOMAD=1'),
+        string(name: 'DOCKER_ENV_VARIABLE', value: '-e PMM_ENABLE_TELEMETRY=false -e PMM_DATA_RETENTION=48h -e PMM_PERCONA_PLATFORM_ADDRESS=https://check-dev.percona.com:443 -e PMM_DEV_PERCONA_PLATFORM_PUBLIC_KEY=RWTg+ZmCCjt7O8eWeAmTLAqW+1ozUbpRSKSwNTmO+exlS5KEIPYWuYdX -e PMM_ENABLE_NOMAD=1'),
         string(name: 'CLIENTS', value: CLIENTS),
         string(name: 'ADMIN_PASSWORD', value: ADMIN_PASSWORD),
         string(name: 'NOTIFY', value: 'false'),

--- a/pmm/v3/pmm3-package-testing-arm64.groovy
+++ b/pmm/v3/pmm3-package-testing-arm64.groovy
@@ -7,7 +7,7 @@ void runStaging(String DOCKER_VERSION, ADMIN_PASSWORD, CLIENTS) {
     stagingJob = build job: 'pmm3-aws-staging-start', parameters: [
         string(name: 'DOCKER_VERSION', value: DOCKER_VERSION),
         string(name: 'CLIENT_VERSION', value: '3-dev-latest'),
-        string(name: 'DOCKER_ENV_VARIABLE', value: '-e PMM_ENABLE_TELEMETRY=0 -e PMM_DATA_RETENTION=48h -e PMM_DEV_PERCONA_PLATFORM_ADDRESS=https://check-dev.percona.com:443 -e PMM_ENABLE_NOMAD=1'),
+        string(name: 'DOCKER_ENV_VARIABLE', value: '-e PMM_ENABLE_TELEMETRY=0 -e PMM_DATA_RETENTION=48h -e PMM_PERCONA_PLATFORM_ADDRESS=https://check-dev.percona.com:443 -e PMM_ENABLE_NOMAD=1'),
         string(name: 'CLIENTS', value: CLIENTS),
         string(name: 'ADMIN_PASSWORD', value: ADMIN_PASSWORD),
         string(name: 'NOTIFY', value: 'false'),

--- a/pmm/v3/pmm3-server-autobuild.groovy
+++ b/pmm/v3/pmm3-server-autobuild.groovy
@@ -128,7 +128,7 @@ pipeline {
                     export DOCKER_TAG=perconalab/pmm-server:$(date -u '+%Y%m%d%H%M')
                     export DOCKERFILE=Dockerfile.el9
                     if [ -n "${DOCKER_RC_TAG}" ]; then
-                        export PMM_DEV_PERCONA_PLATFORM_ADDRESS=https://check.percona.com
+                        export PMM_PERCONA_PLATFORM_ADDRESS=https://check.percona.com
                     fi
 
                     ${PATH_TO_SCRIPTS}/build-server-docker

--- a/pmm/v3/pmm3-server-autobuild.groovy
+++ b/pmm/v3/pmm3-server-autobuild.groovy
@@ -127,6 +127,9 @@ pipeline {
 
                     export DOCKER_TAG=perconalab/pmm-server:$(date -u '+%Y%m%d%H%M')
                     export DOCKERFILE=Dockerfile.el9
+                    if [ -n "${DOCKER_RC_TAG}" ]; then
+                        export PMM_DEV_PERCONA_PLATFORM_ADDRESS=https://check.percona.com
+                    fi
 
                     ${PATH_TO_SCRIPTS}/build-server-docker
 

--- a/pmm/v3/pmm3-upgrade-ami-test-runner.groovy
+++ b/pmm/v3/pmm3-upgrade-ami-test-runner.groovy
@@ -51,7 +51,7 @@ void runAMIStagingStart(String AMI_ID, PMM_QA_GIT_BRANCH, SSH_KEY) {
             echo \\"PMM_DEBUG=1\\" >> /home/admin/.config/systemd/user/pmm-server.env
             echo \\"PMM_ENABLE_TELEMETRY=0\\" >> /home/admin/.config/systemd/user/pmm-server.env
             echo \\"PMM_DEV_PERCONA_PLATFORM_PUBLIC_KEY=RWTg+ZmCCjt7O8eWeAmTLAqW+1ozUbpRSKSwNTmO+exlS5KEIPYWuYdX\\" >> /home/admin/.config/systemd/user/pmm-server.env
-            echo \\"PMM_DEV_PERCONA_PLATFORM_ADDRESS=https://check-dev.percona.com\\" >> /home/admin/.config/systemd/user/pmm-server.env
+            echo \\"PMM_PERCONA_PLATFORM_ADDRESS=https://check-dev.percona.com\\" >> /home/admin/.config/systemd/user/pmm-server.env
             echo \\"PERCONA_TEST_PLATFORM_ADDRESS=https://check-dev.percona.com:443\\" >> /home/admin/.config/systemd/user/pmm-server.env
             echo \\"PMM_DEV_UPDATE_DOCKER_IMAGE=$DOCKER_TAG_UPGRADE\\" >> /home/admin/.config/systemd/user/pmm-server.env
             cat /home/admin/.config/systemd/user/pmm-server.env

--- a/pmm/v3/pmm3-upgrade-test-runner.groovy
+++ b/pmm/v3/pmm3-upgrade-test-runner.groovy
@@ -209,7 +209,7 @@ pipeline {
                             -e PMM_DEBUG=1 \
                             -e PMM_WATCHTOWER_HOST=http://watchtower:8080 \
                             -e PMM_WATCHTOWER_TOKEN=testUpgradeToken \
-                            -e PMM_DEV_PERCONA_PLATFORM_ADDRESS=https://check-dev.percona.com:443 \
+                            -e PMM_PERCONA_PLATFORM_ADDRESS=https://check-dev.percona.com:443 \
                             -e PERCONA_TEST_PLATFORM_ADDRESS=https://check-dev.percona.com:443 \
                             -e PMM_DEV_PORTAL_URL=https://portal-dev.percona.com \
                             -e PMM_DEV_PERCONA_PLATFORM_PUBLIC_KEY=RWTkF7Snv08FCboTne4djQfN5qbrLfAjb8SY3/wwEP+X5nUrkxCEvUDJ \
@@ -225,7 +225,7 @@ pipeline {
                             -e PMM_DEBUG=1 \
                             -e PMM_WATCHTOWER_HOST=http://watchtower:8080 \
                             -e PMM_WATCHTOWER_TOKEN=testUpgradeToken \
-                            -e PMM_DEV_PERCONA_PLATFORM_ADDRESS=https://check-dev.percona.com:443 \
+                            -e PMM_PERCONA_PLATFORM_ADDRESS=https://check-dev.percona.com:443 \
                             -e PERCONA_TEST_PLATFORM_ADDRESS=https://check-dev.percona.com:443 \
                             -e PMM_DEV_PORTAL_URL=https://portal-dev.percona.com \
                             -e PMM_DEV_PERCONA_PLATFORM_PUBLIC_KEY=RWTkF7Snv08FCboTne4djQfN5qbrLfAjb8SY3/wwEP+X5nUrkxCEvUDJ \
@@ -387,10 +387,10 @@ pipeline {
                                         docker run --detach --restart always \
                                             --network="pmm-qa" \
                                             -e PMM_DEBUG=1 \
-                                            -e PMM_DEV_PERCONA_PLATFORM_ADDRESS=https://check-dev.percona.com:443 \
+                                            -e PMM_PERCONA_PLATFORM_ADDRESS=https://check-dev.percona.com:443 \
                                             -e PERCONA_TEST_PLATFORM_ADDRESS=https://check-dev.percona.com:443 \
                                             -e PMM_DEV_PORTAL_URL=https://portal-dev.percona.com \
-                                            -e PMM_DEV_PERCONA_PLATFORM_PUBLIC_KEY=RWTkF7Snv08FCboTne4djQfN5qbrLfAjb8SY3/wwEP+X5nUrkxCEvUDJ \
+                                            -e PMM_PERCONA_PLATFORM_PUBLIC_KEY=RWTkF7Snv08FCboTne4djQfN5qbrLfAjb8SY3/wwEP+X5nUrkxCEvUDJ \
                                             -e PMM_ENABLE_UPDATES=1 \
                                             -e PMM_ENABLE_INTERNAL_PG_QAN=1 \
                                             --publish 80:8080 --publish 443:8443 \


### PR DESCRIPTION
[PMM-15146](https://perconadev.atlassian.net/browse/PMM-15146)

We now set production platform address explicitly in build step when building RC images.

See related PR that adjusts dockerfile and build script to accept build arg: https://github.com/percona/pmm/pull/5505

[PMM-15146]: https://perconadev.atlassian.net/browse/PMM-15146?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ