### PR TITLE
PMM-14154 Update v3 branch references to main in pipelines

### DIFF
--- a/pmm/v3/pmm3-ami.groovy
+++ b/pmm/v3/pmm3-ami.groovy
@@ -4,7 +4,7 @@ pipeline {
     }
     parameters {
         string(
-            defaultValue: 'v3',
+            defaultValue: 'main',
             description: 'Tag/Branch for pmm repository',
             name: 'PMM_BRANCH')
         string(

--- a/pmm/v3/pmm3-api-tests.groovy
+++ b/pmm/v3/pmm3-api-tests.groovy
@@ -14,7 +14,7 @@ pipeline {
             name: 'GIT_URL'
         )
         string(
-            defaultValue: 'v3',
+            defaultValue: 'main',
             description: 'Tag/Branch for pmm repository',
             name: 'GIT_BRANCH'
         )

--- a/pmm/v3/pmm3-migration-tests.groovy
+++ b/pmm/v3/pmm3-migration-tests.groovy
@@ -272,7 +272,7 @@ pipeline {
                         echo "Percona repository is: \$PERCONA_REPOSITORY"
                         echo "Docker tag is: \$DOCKER_TAG"
 
-                        wget https://raw.githubusercontent.com/percona/pmm/refs/heads/v3/get-pmm.sh
+                        wget https://raw.githubusercontent.com/percona/pmm/refs/heads/main/get-pmm.sh
                         chmod +x get-pmm.sh
                         ./get-pmm.sh -n pmm-server -b --network-name pmm-qa --tag "\$DOCKER_TAG" --repo "\$DOCKER_REPO"
 

--- a/pmm/v3/pmm3-ovf.groovy
+++ b/pmm/v3/pmm3-ovf.groovy
@@ -4,7 +4,7 @@ pipeline {
     }
     parameters {
         string(
-            defaultValue: 'v3',
+            defaultValue: 'main',
             description: 'Tag/Branch for pmm repository',
             name: 'PMM_BRANCH')
         string(
@@ -38,7 +38,7 @@ pipeline {
                     if (params.RELEASE_CANDIDATE == 'yes') {
                         // release branch should be in the format: pmm-3.x.y
                         env.PMM_VERSION = PMM_BRANCH.split('-')[1]
-                    } else if (params.PMM_BRANCH != 'v3') {
+                    } else if (params.PMM_BRANCH != 'main') {
                         env.PMM_VERSION = '3-dev-' + PMM_BRANCH
                     }
                 }

--- a/pmm/v3/pmm3-release.groovy
+++ b/pmm/v3/pmm3-release.groovy
@@ -512,14 +512,14 @@ ENDSSH
                                 -H "Accept: application/vnd.github.v3+json" \
                                 -H "Authorization: token ${GITHUB_API_TOKEN}" \
                                 "https://api.github.com/repos/percona/pmm-qa/actions/workflows/package-test-single.yml/dispatches" \
-                                -d '{"ref":"v3","inputs":{"playbook": "pmm3-client", "package": "pmm3-client", "repository": "release", "metrics_mode": "auto"}}'
+                                -d '{"ref":"main","inputs":{"playbook": "pmm3-client", "package": "pmm3-client", "repository": "release", "metrics_mode": "auto"}}'
                         '''
                         sh '''
                             curl -v -X POST \
                                 -H "Accept: application/vnd.github.v3+json" \
                                 -H "Authorization: token ${GITHUB_API_TOKEN}" \
                                 "https://api.github.com/repos/percona/pmm-qa/actions/workflows/e2e-upgrade-tests-matrix-full.yml/dispatches" \
-                                -d '{"ref":"v3","inputs":{"pmm_ui_tests_branch": "v3", "pmm_qa_branch": "v3", "repository": "release", "versions_range": 1}}'
+                                -d '{"ref":"main","inputs":{"pmm_ui_tests_branch": "main", "pmm_qa_branch": "main", "repository": "release", "versions_range": 1}}'
                         '''
                     }
                 }

--- a/pmm/v3/pmm3-server-autobuild.groovy
+++ b/pmm/v3/pmm3-server-autobuild.groovy
@@ -166,12 +166,12 @@ pipeline {
             steps {
                 withCredentials([string(credentialsId: 'GITHUB_API_TOKEN', variable: 'GITHUB_API_TOKEN')]) {
                     sh '''
-                        # 'ref' is a required parameter, it should always equal 'v3' (or 'main' for v2)
+                        # 'ref' is a required parameter, it should always equal 'main' (the default branch of percona/pmm)
                         curl -L -X POST \
                             -H "Accept: application/vnd.github+json" \
                             -H "Authorization: token ${GITHUB_API_TOKEN}" \
                             "https://api.github.com/repos/percona/pmm/actions/workflows/devcontainer.yml/dispatches" \
-                            -d '{"ref":"v3"}'
+                            -d '{"ref":"main"}'
                     '''
                 }
             }

--- a/pmm/v3/pmm3-testsuite.groovy
+++ b/pmm/v3/pmm3-testsuite.groovy
@@ -131,7 +131,7 @@ pipeline {
             description: 'PMM Client Docker tag',
             name: 'CLIENT_DOCKER_VERSION')
         string(
-            defaultValue: 'v3',
+            defaultValue: 'main',
             description: 'Tag/Branch for pmm-qa repository',
             name: 'PMM_QA_GIT_BRANCH')
         string(


### PR DESCRIPTION
@ademidoff

**Explicitly NOT changing (pmm-submodules — per your instruction):**

  - pmm3-client-autobuild-amd.groovy:17, pmm3-client-autobuild-arm.groovy:17, pmm3-client-autobuild.groovy:7, pmm3-watchtower-autobuild.groovy:12, pmm3-server-autobuild.groovy:12 —
  GIT_BRANCH for pmm-submodules
  - pmm3-server-autobuild.groovy:164 — params.GIT_BRANCH == "v3" (GIT_BRANCH is pmm-submodules)
  - pmm3-release-candidate.groovy:120 — DEFAULT_BRANCH = 'v3' (SUBMODULES_GIT_BRANCH)
  - pmm3-submodules-rewind.groovy:22-23 — clones pmm-submodules
  - pmm3-upgrade-tests-matrix.groovy:29, pmm3-upgrade-ami-test-runner.groovy:16, pmm3-upgrade-test-runner.groovy:16 — curl/wget pmm-submodules VERSION

**Not branch references (LEAVE)**

  - 'v3lib@master', libraryPath: 'pmm/v3/' — Jenkins library identifier/path
  - public.ecr.aws/e7j3v3n0/... — ECR URL (incidental v3)
  - application/vnd.github.v3+json — GitHub API media type
  - pmmVersion('v3'), pmmVersion('v3-ami'), pmmVersion('v3-old') — function arg (version key, not branch)
  - pmmha-v3 — helm chart branch (unrelated)
  - pmm3-submodules.groovy:82 "v3 build started", pmm3-server-autobuild.groovy:190 "RC Build v3" — product version labels