### PR TITLE
PMM-14154 Update references from v3 to main

### DIFF
--- a/pmm/README.md
+++ b/pmm/README.md
@@ -8,7 +8,7 @@
 
 ## Agents
 
-We build the custom image for agents and you can find Packer and Ansible files in [pmm](https://github.com/percona/pmm/tree/v3/build/packer) repo.
+We build the custom image for agents and you can find Packer and Ansible files in [pmm](https://github.com/percona/pmm/tree/main/build/packer) repo.
 
 Use the following tags for agents:
 

--- a/pmm/infrastructure/rpm-build.groovy
+++ b/pmm/infrastructure/rpm-build.groovy
@@ -4,7 +4,7 @@ pipeline {
     }
     parameters {
         string(
-            defaultValue: 'v3',
+            defaultValue: 'main',
             description: 'Tag/Branch for pmm repository',
             name: 'PMM_GIT_BRANCH')
     }


### PR DESCRIPTION
This pull request updates documentation and pipeline configuration to reference the correct default branch, switching from `v3` to `main` for the PMM repository. This ensures consistency across the codebase and documentation.

Repository branch updates:

* Updated the documentation in `pmm/README.md` to point to the `main` branch instead of `v3` for the location of Packer and Ansible files.
* Changed the default value of the `PMM_GIT_BRANCH` parameter in `pmm/infrastructure/rpm-build.groovy` from `v3` to `main`.