### PR TITLE
PG-2353: Shrink OL10 package-test AMI root to 20 GiB

### DIFF
--- a/.github/workflows/ppg-oracle-ami-factory.yml
+++ b/.github/workflows/ppg-oracle-ami-factory.yml
@@ -76,6 +76,11 @@ jobs:
           ( cd smoke && packer init . && packer validate \
               -var candidate_ami=ami-00000000000000000 \
               -var os_major=9 -var arch=x86_64 . )
+          # drift guard (mirrors `just check`): justfile root_gib must equal var.volume_size,
+          # else a reimaged base would be the wrong root size for the refresh to launch.
+          rg=$(awk -F'"' '/^root_gib[[:space:]]*:=/{print $2; exit}' justfile)
+          vs=$(awk '/variable "volume_size"/{f=1} f&&/default/{gsub(/[^0-9]/,"");print;exit}' oracle-linux.pkr.hcl)
+          [[ -n "$rg" && "$rg" == "$vs" ]] || { echo "DRIFT: justfile root_gib=$rg != var.volume_size=$vs"; exit 1; }
           echo "check OK"
 
   bake:

--- a/ppg/packer/README.md
+++ b/ppg/packer/README.md
@@ -22,12 +22,13 @@ same Packer templates + scripts run whether driven locally (`justfile`) or by th
 GitHub Actions workflow. Builds connect over AWS Session Manager (no inbound SSH)
 and authenticate via GitHub OIDC (no static keys).
 
-## Two build paths
+## Three build paths
 
 | Path | Covers | Mechanism |
 |------|--------|-----------|
 | **Refresh** (`oracle-linux.pkr.hcl`) | OL8, OL9, OL10 (x86_64 + arm64) | `amazon-ebs`: launch the latest self-owned base of the same major+arch, `dnf update`, validate (fail-closed), snapshot. Each build's output is the next build's source. |
-| **Bootstrap** (`scripts/bootstrap-ol10.sh`) | OL10 lineage root, one-time per arch | Import Oracle's official OL10 cloud image (arm64 `*-kvm-cloud-*.qcow2`, x86_64 `*-aws-*.vmdk`) via `aws ec2 import-snapshot`, register the raw base, then `packer build bootstrap/finalize-ol10.pkr.hcl` (adds `ec2-user` + `amazon-ssm-agent` + `dnf update`). Needed because Oracle ships no OL10 AWS AMI. Idempotent: a re-run detects an already-promoted base and skips, and never re-downloads. |
+| **Bootstrap** (`scripts/bootstrap-ol10.sh`) | OL10 lineage root, one-time per arch | Import Oracle's official OL10 cloud image (arm64 `*-kvm-cloud-*.qcow2`, x86_64 `*-aws-*.vmdk`) via `aws ec2 import-snapshot`, register the raw base, then `packer build bootstrap/finalize-ol10.pkr.hcl` (adds `ec2-user` + `amazon-ssm-agent` + `dnf update`). Needed because Oracle ships no OL10 AWS AMI. Promotes to a `prebase` role: Oracle's full-size root cannot launch on `var.volume_size`, so `reimage-ol10` shrinks it before it becomes the consumed base. Idempotent. |
+| **Re-image** (`scripts/reimage-ol10.sh`) | OL10 root shrink, one-time per arch | Copy the current base's root onto a fresh `var.volume_size` GiB volume on a builder, snapshot + register, then `reimage-ol10-verify` boot-tests two sizes + smoke + size-gate + promote. Needed because EBS cannot restore a volume below its source snapshot and XFS cannot shrink in place. Full internals (`dd` /boot, LVM-to-plain, the gates): [docs/reimage.md](docs/reimage.md). |
 
 ## Usage
 
@@ -38,7 +39,9 @@ just bake 9 x86_64                      # build + smoke + promote one combo
 just all                                # build + promote every OL major x arch
 just bootstrap-ol10-prep                # one-time: import bucket + vmimport role + boot-test SG/key
 just bootstrap-ol10 x86_64              # one-time OL10 lineage root for an arch
-just bootstrap-ol10-verify <ami> x86_64 # boot-validate a candidate then promote it
+just bootstrap-ol10-verify <ami> x86_64 # boot-validate a candidate then promote it (prebase)
+just reimage-ol10 x86_64                # shrink the OL10 base root to var.volume_size (lineage shrink)
+just reimage-ol10-verify <ami> x86_64   # boot-test two sizes + smoke + size-gate + promote
 ```
 
 Each build registers `OL<major>-<arch>-<UTCstamp>` tagged `os=oraclelinux`,
@@ -113,8 +116,11 @@ a real boot/install failure (never on a transient promote-tag failure).
 
 OL10 is live: both lineage-root bases (x86_64 + arm64) are built and promoted
 `role=ppg-package-test`, and the refresh template's `os_major` validation
-includes `10`, so OL10 refreshes on the same schedule as OL8/OL9. The one-time
-bootstrap imported Oracle's official cloud images via `import-snapshot` (arm64 is
+includes `10`, so OL10 refreshes on the same schedule as OL8/OL9. The bases are
+re-imaged to `var.volume_size` so they launch on the same root size as OL8/OL9
+instead of Oracle's larger imported root ([docs/reimage.md](docs/reimage.md)); the
+refresh sustains that size. The one-time bootstrap imported Oracle's official cloud
+images via `import-snapshot` (arm64 is
 not eligible for `import-image`, so the VMDK is imported as a snapshot and
 registered with `--boot-mode uefi`; x86_64 uses Oracle's `-aws-` VMDK with
 `--boot-mode legacy-bios`). x86_64 OL10 requires the `x86-64-v3` microarch, which

--- a/ppg/packer/docs/reimage.md
+++ b/ppg/packer/docs/reimage.md
@@ -1,0 +1,157 @@
+# OL10 re-image (one-time root shrink)
+
+This page explains how the OL10 base root is shrunk to `var.volume_size`, and why
+each non-obvious step works the way it does. The Packer template
+(`reimage/reimage-ol10.pkr.hcl`) and its single provisioner
+(`scripts/reimage-surgery.sh`) keep only short pointers back to this page, so the
+full reasoning lives in one place.
+
+## Why this exists
+
+The OL10 lineage starts from Oracle's official cloud image, and that image ships a
+root larger than the `var.volume_size` (20 GiB) that OL8 and OL9 use. The ordinary
+[refresh](../README.md) path cannot shrink it on its own, because two limits get
+in the way:
+
+- EBS cannot restore a volume that is smaller than its source snapshot.
+- XFS cannot shrink in place.
+
+Reaching a smaller root therefore takes a one-time, file-level re-image: copy the
+root contents onto a fresh, smaller volume, snapshot that volume, and register it
+as a new base. OL8 and OL9 never need this step, because their bases already sit
+at `var.volume_size`.
+
+## Where it fits
+
+```mermaid
+flowchart TB
+  oracle["Oracle OL10 cloud image"]
+  candA["ppg-ol10-candidate<br/>full-size, LVM"]
+  prebase["ppg-ol10-prebase<br/>full-size, bootable"]
+  candB["ppg-reimage-candidate<br/>var.volume_size"]
+  consumed["ppg-package-test<br/>consumed base"]
+  oracle -->|"bootstrap-ol10: import-snapshot + finalize (amazon-ebs)"| candA
+  candA -->|"bootstrap-ol10-verify: BOOT (generates the new-kernel initramfs) then promote"| prebase
+  prebase -->|"reimage-ol10: amazon-ebssurrogate shrink"| candB
+  candB -->|"reimage-ol10-verify: two-size boot + smoke then promote"| consumed
+  consumed -->|"refresh (amazon-ebs): sustains the size, each build is the next source"| consumed
+```
+
+Both BOOT steps in that flow are essential, not just sanity checks. The
+`bootstrap-ol10-verify` boot of the full-size base is the moment the
+freshly-installed kernel's initramfs is generated and `/boot` settles, so the
+later shrink copies a `/boot` that is already complete and bootable.
+
+The re-image is **one-time per arch**. Once it has run, the refresh path sustains
+the smaller size on its own. You only need to run it again when one of these
+happens:
+
+- A fresh oversized source has been re-bootstrapped (a FORCE rebuild, or a new Oracle image).
+- `var.volume_size` is lowered further. The refresh can grow or hold a root, but it can never shrink below the current snapshot.
+
+## How it runs (amazon-ebssurrogate)
+
+`reimage/reimage-ol10.pkr.hcl` is a Packer `amazon-ebssurrogate` build. It
+launches a builder from the prebase (`source_ami_filter` with role
+`ppg-ol10-prebase`), attaches a blank `var.volume_size` surrogate volume
+(`launch_block_device_mappings`), and runs `scripts/reimage-surgery.sh` as a
+provisioner. It then snapshots that surrogate and registers the candidate AMI
+from it (`ami_root_device`). Packer owns the whole launch, attach, snapshot,
+register, and cleanup lifecycle, so none of that orchestration is hand-rolled.
+
+The single provisioner, `scripts/reimage-surgery.sh`, runs as root on that
+builder. Because the builder boots from the already-booted prebase that is being
+shrunk, the builder's live root and its complete `/boot` are themselves the
+source. The script finds the blank `ROOT_GIB` surrogate by its size (Packer
+attaches it, so there is no VolumeId to match against) and reproduces the root
+onto it at the smaller size. No `dnf` or kernel work happens during the surgery,
+so the prebase's already-generated initramfs is simply copied across. That is
+exactly why the shrink runs after the prebase boot-verify, rather than being
+folded into finalize.
+
+```mermaid
+flowchart LR
+  prebase["prebase AMI<br/>role=ppg-ol10-prebase"]
+  subgraph builder["Packer builder (amazon-ebssurrogate)"]
+    direction TB
+    root["booted prebase root<br/>+ complete /boot = SOURCE"]
+    surrogate["blank var.volume_size<br/>surrogate at /dev/sdf"]
+  end
+  ami["var.volume_size candidate AMI<br/>role=ppg-reimage-candidate"]
+  prebase -->|"launch FROM"| root
+  root -->|"reimage-surgery.sh: dd /boot, clone UUIDs, LVM to plain"| surrogate
+  surrogate -->|"Packer ami_root_device: snapshot + register"| ami
+```
+
+## Surgery internals
+
+### Partition layout
+
+Root is always the last partition so that it can grow, since cloud-init's
+`growpart` expands it on first boot. The offsets, in MiB, are:
+
+| | arm64 (UEFI) | x86_64 (BIOS) |
+|---|---|---|
+| p1 | ESP 1-201 | bios_grub 1-3 |
+| p2 | boot 201-1225 | boot 3-1027 |
+| p3 | swap 1225-5321 | swap 1027-5123 |
+| p4 | root 5321-100% | root 5123-100% |
+
+`reimage-ol10-verify` derives its post-`growpart` floor from the non-root overhead
+(the ESP or bios partition, plus boot, plus swap), so that check stays correct
+even if this table changes.
+
+### `/boot` is `dd`'d verbatim, not `mkfs` + copy
+
+A fresh `mkfs.xfs` on EL10 produces an XFS on-disk format (`nrext64`) that GRUB
+cannot read, which would leave the firmware unable to find `/boot`. Copying the
+partition with `dd` preserves both the original format and its UUID. The kernel
+itself can read any XFS, so only `/boot` (and the ESP) have to stay
+GRUB-readable. The root filesystem can be a fresh `mkfs`.
+
+### Cloned UUIDs
+
+Every filesystem UUID is cloned onto the target (`mkfs.xfs -m uuid=...`,
+`mkswap -U`, `mkfs.fat -i`), so `/etc/fstab` and the GRUB cmdline still resolve
+without any change. The target is mounted with `-o nouuid` because the source
+filesystem, which carries the same UUID, is still mounted on the builder.
+
+### LVM source -> plain-partition root (x86_64)
+
+The x86_64 base is LVM-rooted, and a second volume group of the same name cannot
+coexist on the builder, so the root is converted to a plain partition. The surgery
+rewrites the GRUB cmdline and the future-kernel seed `/etc/kernel/cmdline`,
+turning `root=/dev/mapper/...` and `rd.lvm.lv=...` into `root=UUID=...`. The fstab
+is already written by UUID. `os-prober` is disabled so that `grub2-mkconfig` does
+not graft the builder's own root into the generated config.
+
+### Device naming
+
+The target is a Nitro device (`/dev/nvme*`), so its partitions take a `p` suffix,
+as in `nvme1n1p2`. The script derives that suffix by appending `p` only when the
+device name ends in a digit, so a non-NVMe name such as `/dev/sdf` (which gives
+`sdf2`) would still work.
+
+## Fail-closed gates
+
+Each of these gates refuses to produce an image that might be unbootable or the
+wrong size:
+
+- **/boot size guard** (`surgery`): never `dd` a source `/boot` larger than the target partition (silent truncation -> unbootable).
+- **fstab-root invariant** (`surgery`): the target `/etc/fstab` root must be `UUID=<cloned>` or absent (root via cmdline). A `/dev/mapper` or bare-device pin would not resolve on the plain-partition target.
+- **surviving-LVM grep** (`surgery`, x86_64): abort if any `vg_main` / `rd.lvm.lv` / `root=/dev/(mapper|dm-)` reference survives in any cmdline source, including the future-kernel seeds `/etc/kernel/cmdline` and `grubenv` (a clean immediate boot can still regress on the next kernel install otherwise).
+- **root=UUID positive gate** (`surgery`, x86_64): abort unless the effective cmdline pins root by the cloned filesystem UUID.
+- **size gate** (`verify`): never promote a base whose root snapshot exceeds `var.volume_size`, or the refresh could not launch it.
+- **cross-env gate** (`verify`): never promote a candidate whose `factory_env` tag does not match the requested env (a test candidate can never reach the prod role by an omitted or wrong arg).
+- **two-size boot + smoke** (`verify`): boot at `var.volume_size` and 30 GiB, assert `growpart` grew root, then run a fresh-boot smoke install before promotion.
+
+## Cleanup and recovery
+
+Packer owns the lifecycle of the build's instance, surrogate volume, snapshot, and
+AMI, including cleanup when a build fails. On top of that, `reimage-surgery.sh`
+traps `EXIT` so it can thaw `/boot` if it is still frozen and unmount
+`/mnt/target` from the deepest mount upward. That way, even a failure partway
+through the surgery leaves the builder clean for Packer to detach.
+
+If a `verify` fails and leaves an orphaned candidate behind (role
+`ppg-reimage-candidate`, never consumed), `just prune-stale` reaps it.

--- a/ppg/packer/justfile
+++ b/ppg/packer/justfile
@@ -25,6 +25,7 @@ os_name         := "oraclelinux"
 billing_tag     := "ppg-ami-factory"            # iit-billing-tag value (cost attribution + IAM fence)
 role_prod       := "ppg-package-test"           # promoted role the pg.cd consumer selects
 role_test       := "ppg-test-package-test"      # isolated promoted role for env=test bakes
+role_prebase    := "ppg-ol10-prebase"           # greenfield bootstrap output; reimage shrinks it before promotion
 subnet          := "subnet-068170595951ab3a9"   # eu-central-1 default-VPC public subnet
 bucket_prefix   := "ppg-ami-factory-import"     # import bucket = "{{bucket_prefix}}-<account-id>"
 import_role     := "ppg-ol10-vmimport"          # vmimport role for the OL10 import-snapshot
@@ -35,6 +36,7 @@ boottest_sg     := "ppg-ol10-boottest-sg"       # OL10 boot-test SSH security gr
 # --- build matrix dimensions ---
 os_majors       := "8 9 10"
 arches          := "x86_64 arm64"
+root_gib        := "20"                          # reimage target root GiB; MUST match var.volume_size in oracle-linux.pkr.hcl
 
 # common create-tags / role-tags set (billing only), reused everywhere
 common_tags     := "Key=iit-billing-tag,Value=" + billing_tag
@@ -94,7 +96,7 @@ _prune-by-filter apply +filters:
     [ -z "$ids" ] && { echo "  (nothing matches)"; exit 0; }
     for ami in $ids; do
       role=$(aws ec2 describe-images --profile {{profile}} --region {{region}} --image-ids "$ami" \
-        --query 'Images[0].Tags[?Key==`role`]|[0].Value' --output text)
+        --query "Images[0].Tags[?Key=='role']|[0].Value" --output text)
       # fail-closed: never delete the prod base, nor anything we cannot positively
       # classify (missing/None role) -- "don't delete what you can't identify".
       if [ "$role" = "{{role_prod}}" ] || [ -z "$role" ] || [ "$role" = None ]; then echo "  SKIP $ami (protected: role=${role:-<none>})"; continue; fi
@@ -111,10 +113,12 @@ _prune-by-filter apply +filters:
 init:
     packer init .
 
-# format the HCL (main + smoke templates)
+# format the HCL (main + smoke + reimage + bootstrap templates)
 fmt:
     packer fmt .
     packer fmt smoke
+    packer fmt reimage
+    packer fmt bootstrap
 
 # validate one combo  (maj=8|9|10  arch=x86_64|arm64)
 validate maj="9" arch="x86_64":
@@ -129,14 +133,27 @@ validate-all:
       echo "validate OL$m $a"; packer validate -var os_major=$m -var arch=$a .
     done; done
     ( cd smoke && packer init . >/dev/null && packer validate -var candidate_ami=ami-00000000000000000 -var os_major=9 -var arch=x86_64 . )
+    ( cd reimage && packer init . >/dev/null && packer validate -var arch=x86_64 . )
+    ( cd bootstrap && packer init . >/dev/null && packer validate -var raw_ami=ami-00000000000000000 -var arch=x86_64 . )
 
 # fmt-check + validate everything + actionlint the GHA workflow (CI gate, no AWS)
 check:
     #!/usr/bin/env bash
     set -euo pipefail
-    packer fmt -check -diff . && packer fmt -check -diff smoke
+    packer fmt -check -diff . && packer fmt -check -diff smoke && packer fmt -check -diff reimage && packer fmt -check -diff bootstrap
     just validate-all
     command -v actionlint >/dev/null && actionlint ../../.github/workflows/ppg-oracle-ami-factory.yml || echo "actionlint not installed; skipping workflow lint"
+    # drift guard: {{root_gib}} must equal var.volume_size in BOTH the refresh + reimage templates
+    # (reimage-surgery partitions root to {{root_gib}}; a mismatch sizes the AMI wrong for the refresh).
+    vs=$(awk '/variable "volume_size"/{f=1} f&&/default/{gsub(/[^0-9]/,"");print;exit}' oracle-linux.pkr.hcl)
+    rvs=$(awk '/variable "volume_size"/{f=1} f&&/default/{gsub(/[^0-9]/,"");print;exit}' reimage/reimage-ol10.pkr.hcl)
+    { [ "$vs" = "{{root_gib}}" ] && [ "$rvs" = "{{root_gib}}" ]; } || { echo "DRIFT: root_gib={{root_gib}} != refresh=$vs / reimage=$rvs"; exit 1; }
+    # plugin-pin parity: the amazon plugin must be pinned to ONE version across every template, so a
+    # supply-chain bump is all-or-nothing instead of drifting silently per-file.
+    amazon_pin() { awk '/hashicorp\/amazon/{f=1} f&&/version =/{gsub(/[^0-9.]/,"");print;exit}' "$1"; }
+    pins=$(for f in oracle-linux.pkr.hcl smoke/smoke.pkr.hcl reimage/reimage-ol10.pkr.hcl bootstrap/finalize-ol10.pkr.hcl; do amazon_pin "$f"; done)
+    n=$(printf '%s\n' "$pins" | grep -c .); u=$(printf '%s\n' "$pins" | sort -u | grep -c .)
+    { [ "$n" -eq 4 ] && [ "$u" -eq 1 ]; } || { echo "DRIFT: amazon plugin pin not uniform across the 4 templates:"; printf '%s\n' "$pins"; exit 1; }
     echo "check OK"
 
 # trigger the GHA factory workflow for the full matrix (drive CI from just). Targets the
@@ -211,7 +228,7 @@ all env="prod":
 list env="prod":
     aws ec2 describe-images --profile {{profile}} --region {{region}} --owners self \
       --filters Name=tag:factory_env,Values={{env}} \
-      --query 'reverse(sort_by(Images,&CreationDate))[].{Name:Name,AMI:ImageId,role:Tags[?Key==`role`]|[0].Value,arch:Architecture,created:CreationDate}' \
+      --query "reverse(sort_by(Images,&CreationDate))[].{Name:Name,AMI:ImageId,role:Tags[?Key=='role']|[0].Value,arch:Architecture,created:CreationDate}" \
       --output table
 
 # resolve the newest promoted AMI for a combo (exactly what moleculeEnvPPG does)
@@ -245,9 +262,9 @@ prune-stale apply="0":
       # two scalar command-subs (not a process-sub `read`): a describe failure propagates
       # under set -e instead of being silently swallowed, and no IFS field-shift on tag values.
       role=$(aws ec2 describe-images --profile {{profile}} --region {{region}} --image-ids "$ami" \
-        --query 'Images[0].Tags[?Key==`role`]|[0].Value' --output text)
+        --query "Images[0].Tags[?Key=='role']|[0].Value" --output text)
       env=$(aws ec2 describe-images --profile {{profile}} --region {{region}} --image-ids "$ami" \
-        --query 'Images[0].Tags[?Key==`factory_env`]|[0].Value' --output text)
+        --query "Images[0].Tags[?Key=='factory_env']|[0].Value" --output text)
       # fail-closed: never delete the prod base, nor anything we cannot positively classify.
       if [ "$role" = "{{role_prod}}" ] || [ -z "$role" ] || [ "$role" = None ]; then echo "  SKIP $ami (protected: role=${role:-<none>})"; continue; fi
       if [ "$env" = "test" ]; then echo "  SKIP $ami (test AMI -> use prune-test)"; continue; fi
@@ -270,7 +287,7 @@ prune-superseded apply="0":
     echo "prune-superseded (apply={{apply}}; lists unless apply=1):"
     aws ec2 describe-images --profile {{profile}} --region {{region}} --owners self \
       --filters Name=tag:role,Values={{role_prod}} Name=tag:os,Values={{os_name}} Name=state,Values=available \
-      --query 'reverse(sort_by(Images,&CreationDate))[].[ImageId, Tags[?Key==`os_major`]|[0].Value, Tags[?Key==`arch`]|[0].Value]' --output text \
+      --query "reverse(sort_by(Images,&CreationDate))[].[ImageId, Tags[?Key=='os_major']|[0].Value, Tags[?Key=='arch']|[0].Value]" --output text \
       | { declare -A keep; while read -r id maj arch; do
             [ -z "$id" ] && continue
             { [ "$maj" = None ] || [ "$arch" = None ]; } && { echo "  SKIP $id (untagged maj/arch)"; continue; }
@@ -365,17 +382,19 @@ bootstrap-ol10-prep:
 # one-time bootstrap of the OL10 candidate base for an arch (import Oracle's official
 # image -> register raw -> Packer finalize). Both arches have built-in source URLs.
 # Idempotent: re-running detects an already-promoted base and exits without re-downloading.
-[doc("one-time per arch: import + finalize an OL10 candidate base (idempotent; no 37GB re-download)")]
+[doc("one-time per arch: import + finalize an OL10 candidate base (idempotent; no image re-download)")]
 bootstrap-ol10 arch="arm64":
     #!/usr/bin/env bash
     set -euo pipefail
     eval "$(aws configure export-credentials --profile {{profile}} --format env)"; unset AWS_PROFILE
     aws iam get-role --role-name {{import_role}} >/dev/null 2>&1 || { echo "run 'just bootstrap-ol10-prep' first"; exit 1; }
     ARCH={{arch}} REGION={{region}} BUCKET=$(just _bucket) VMIMPORT_ROLE={{import_role}} \
-      BILLING_TAG={{billing_tag}} OS_NAME={{os_name}} ROLE_PROMOTED={{role_prod}} \
+      BILLING_TAG={{billing_tag}} OS_NAME={{os_name}} ROLE_PROMOTED={{role_prod}} ROLE_PREBASE={{role_prebase}} \
       bash scripts/bootstrap-ol10.sh
 
-# boot-validate a candidate OL10 base then promote it to role={{role_prod}} (the refresh lineage root)
+# boot-validate a greenfield OL10 candidate then promote it to a PREBASE role (role={{role_prebase}}).
+# Bootstrap yields Oracle's full-size base, which the refresh (var.volume_size) cannot launch, so it
+# is NOT promoted straight to the consumed role; reimage-ol10 shrinks it and promotes to {{role_prod}}.
 bootstrap-ol10-verify ami arch="arm64":
     #!/usr/bin/env bash
     set -euo pipefail
@@ -392,6 +411,79 @@ bootstrap-ol10-verify ami arch="arm64":
     so="-o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o ConnectTimeout=25"
     ssh -i ol10-import/{{boottest_key}}.pem $so ec2-user@"$ip" 'echo "ssm: $(systemctl is-active amazon-ssm-agent)"; id -un'
     ssh -i ol10-import/{{boottest_key}}.pem $so ec2-user@"$ip" "sudo OS_MAJOR=10 UNAME_ARCH=$uarch bash -s" < scripts/validate.sh
-    echo "promote {{ami}} -> role={{role_prod}}"
-    just _promote {{ami}} {{role_prod}}
-    echo "OL10 {{arch}} base {{ami}} verified + promoted (role={{role_prod}})"
+    echo "promote {{ami}} -> role={{role_prebase}} (greenfield prebase; reimage-ol10 shrinks + promotes to {{role_prod}})"
+    just _promote {{ami}} {{role_prebase}}
+    echo "OL10 {{arch}} base {{ami}} verified + promoted (role={{role_prebase}}); NEXT: just reimage-ol10 {{arch}}"
+
+# ---------------------------------------------------------------------------
+# OL10 re-image (one-time lineage shrink, amazon-ebssurrogate): shrink the booted prebase onto a
+# {{root_gib}} GiB surrogate. AWS cannot restore a volume below its source snapshot and XFS cannot
+# shrink in place, so the refresh template alone cannot; the refresh then sustains the smaller size.
+# Packer owns the launch/attach/snapshot/register/cleanup lifecycle (reimage/reimage-ol10.pkr.hcl);
+# the prebase already booted (bootstrap-ol10-verify), so its /boot is complete and no dnf runs here.
+# Flow:  just reimage-ol10 <arch> [env]  ->  just reimage-ol10-verify <ami> <arch> [env]
+# ---------------------------------------------------------------------------
+
+# shrink the prebase root to {{root_gib}} GiB via ebssurrogate (registers a candidate; does not promote).
+[doc("one-time per arch: shrink the prebase root to {{root_gib}} GiB via ebssurrogate (env=test isolates the candidate)")]
+reimage-ol10 arch="arm64" env="prod":
+    #!/usr/bin/env bash
+    set -euo pipefail
+    eval "$(aws configure export-credentials --profile {{profile}} --format env)"; unset AWS_PROFILE
+    rm -f reimage/manifest.json
+    ( cd reimage && packer init . >/dev/null && AWS_REGION={{region}} packer build -color=false \
+        -var arch={{arch}} -var env={{env}} -var region={{region}} . )
+    ami=$(python3 -c "import json;print(json.load(open('reimage/manifest.json'))['builds'][-1]['artifact_id'].split(':')[-1])")
+    echo "REIMAGED: $ami (role=ppg-reimage-candidate); NEXT: just reimage-ol10-verify $ami {{arch}} {{env}}"
+
+# boot-validate a re-imaged candidate on TWO root sizes ({{root_gib}} + 30) + smoke, then promote.
+# Fail-closed SIZE GATE: never promote a base whose root snapshot exceeds {{root_gib}}
+# (= var.volume_size), or the refresh could not launch it (EBS won't restore below the snapshot).
+reimage-ol10-verify ami arch="arm64" env="prod":
+    #!/usr/bin/env bash
+    set -euo pipefail
+    eval "$(aws configure export-credentials --profile {{profile}} --format env)"; unset AWS_PROFILE
+    gib=$(aws ec2 describe-images --region {{region}} --image-ids {{ami}} \
+      --query 'Images[0].BlockDeviceMappings[0].Ebs.VolumeSize' --output text)
+    [ "$gib" -le "{{root_gib}}" ] || { echo "REFUSE promote: {{ami}} root is ${gib} GiB > {{root_gib}} GiB target"; exit 1; }
+    # cross-env guard: never promote a candidate whose factory_env tag does not match {{env}}, so a
+    # test candidate can never be promoted to the production role by an omitted/wrong env arg.
+    fenv=$(aws ec2 describe-images --region {{region}} --image-ids {{ami}} --query "Images[0].Tags[?Key=='factory_env']|[0].Value" --output text)
+    [ "$fenv" = "{{env}}" ] || { echo "REFUSE promote: {{ami}} factory_env=$fenv != env={{env}} (cross-env promotion blocked)"; exit 1; }
+    read -r uarch inst < <(just _arch-meta {{arch}})
+    sg=$(aws ec2 describe-security-groups --region {{region}} --filters Name=group-name,Values={{boottest_sg}} --query 'SecurityGroups[0].GroupId' --output text)
+    iids=""; so="-o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o ConnectTimeout=25"
+    runtag=ppg-reimage-verify-run; runval="{{ami}}-$$"   # unique-per-run recovery tag (value carries the run id)
+    # cleanup also recovers an instance created even if the CLI died before run-instances returned its
+    # id (the orphan still carries $runtag), not just the ids captured in $iids.
+    cleanup() {
+      set +e
+      local rec
+      rec=$(aws ec2 describe-instances --region {{region}} \
+        --filters "Name=tag:$runtag,Values=$runval" "Name=instance-state-name,Values=pending,running,stopping,stopped" \
+        --query 'Reservations[].Instances[].InstanceId' --output text 2>/dev/null)
+      for i in $iids $rec; do aws ec2 terminate-instances --region {{region}} --instance-ids "$i" >/dev/null 2>&1; done
+    }
+    trap cleanup EXIT
+    # growpart floor: derive the non-root overhead (ESP/bios + boot + swap) from the surgery partition
+    # table so this never drifts if that layout changes. Largest root-partition start across arches,
+    # rounded up to whole GiB = the space unavailable to the root fs.
+    ovh_mib=$(grep -oE 'mkpart root xfs +[0-9]+MiB' scripts/reimage-surgery.sh | grep -oE '[0-9]+' | sort -rn | head -1)
+    [[ "$ovh_mib" =~ ^[0-9]+$ ]] || { echo "FATAL: could not derive the root-partition offset from reimage-surgery.sh; the growpart floor would be wrong"; exit 1; }
+    ovh_gib=$(( (ovh_mib + 1023) / 1024 ))
+    for sz in {{root_gib}} 30; do
+      iid=$(aws ec2 run-instances --region {{region}} --image-id {{ami}} --instance-type "$inst" \
+        --key-name {{boottest_key}} --security-group-ids "$sg" --subnet-id {{subnet}} --associate-public-ip-address \
+        --block-device-mappings "DeviceName=/dev/sda1,Ebs={VolumeSize=$sz,VolumeType=gp3,DeleteOnTermination=true}" \
+        --tag-specifications "ResourceType=instance,Tags=[{Key=Name,Value=ol10-reimage-verify},{Key=$runtag,Value=$runval},{Key=iit-billing-tag,Value={{billing_tag}}}]" \
+        --query 'Instances[0].InstanceId' --output text)
+      iids="$iids $iid"
+      echo "launched $iid (root=${sz}GiB); waiting 2/2..."; aws ec2 wait instance-status-ok --region {{region}} --instance-ids "$iid"
+      ip=$(aws ec2 describe-instances --region {{region}} --instance-ids "$iid" --query 'Reservations[0].Instances[0].PublicIpAddress' --output text)
+      min=$(( sz - ovh_gib ))   # after growpart the root fs >= launch size minus the derived overhead
+      ssh -i ol10-import/{{boottest_key}}.pem $so ec2-user@"$ip" "rg=\$(findmnt -bno SIZE /); rg=\$((rg/1073741824)); echo root=\${rg}G; [ \$rg -ge $min ] || { echo \"FAIL growpart: root \${rg}G < ${min}G on a ${sz}G launch\"; exit 1; }; sudo OS_MAJOR=10 UNAME_ARCH=$uarch bash -s" < scripts/validate.sh
+    done
+    pr={{role_prod}}; [ "{{env}}" = "test" ] && pr={{role_test}}
+    echo "smoke (boot+install) {{ami}} -> promote role=$pr"
+    just smoke {{ami}} 10 {{arch}} $pr
+    echo "OL10 {{arch}} re-imaged base {{ami}} verified (${gib} GiB; {{root_gib}}+30 boot + smoke) + promoted (role=$pr)"

--- a/ppg/packer/oracle-linux.pkr.hcl
+++ b/ppg/packer/oracle-linux.pkr.hcl
@@ -89,13 +89,10 @@ variable "env" {
 }
 
 locals {
-  instance_type = var.arch == "arm64" ? "t4g.large" : "t3.large"
-  uname_arch    = var.arch == "arm64" ? "aarch64" : "x86_64"
-  ssm_arch      = var.arch == "arm64" ? "arm64" : "amd64"
-  # OL10's lineage base comes from Oracle's official cloud image with a 37GB root,
-  # so the build volume must be >= that, with headroom; OL8/9 self-built bases stay
-  # at var.volume_size (20). 60 leaves ~23GB free above the 37GB base.
-  root_volume_size = var.os_major == "10" ? 60 : var.volume_size
+  instance_type    = var.arch == "arm64" ? "t4g.large" : "t3.large"
+  uname_arch       = var.arch == "arm64" ? "aarch64" : "x86_64"
+  ssm_arch         = var.arch == "arm64" ? "arm64" : "amd64"
+  root_volume_size = var.volume_size
   ts               = formatdate("YYYYMMDD-hhmmss", timestamp())
   # Test bakes carry isolated tags so the production pg.cd consumer (which selects
   # role=ppg-package-test, source=factory) never picks them up.

--- a/ppg/packer/reimage/reimage-ol10.pkr.hcl
+++ b/ppg/packer/reimage/reimage-ol10.pkr.hcl
@@ -1,0 +1,161 @@
+# OL10 re-image (amazon-ebssurrogate): shrink the booted prebase onto a var.volume_size surrogate and
+# register the AMI from it (EBS can't restore below a snapshot, XFS can't shrink in place). Sourced from
+# role=ppg-ol10-prebase, which bootstrap-ol10-verify already booted, so /boot is complete. docs/reimage.md.
+#
+#   packer init . && packer build -var arch=x86_64 .   # or arm64; -var env=test for an isolated candidate
+
+packer {
+  required_plugins {
+    amazon = {
+      source  = "github.com/hashicorp/amazon"
+      version = "1.8.1" # pinned exact (supply-chain); parity across all templates enforced by `just check`
+    }
+  }
+}
+
+variable "arch" { type = string } # x86_64 | arm64
+variable "os_major" {
+  type    = string
+  default = "10"
+}
+variable "region" {
+  type    = string
+  default = "eu-central-1"
+}
+variable "subnet_id" {
+  type    = string
+  default = "subnet-068170595951ab3a9"
+}
+variable "builder_instance_profile" {
+  type    = string
+  default = "ppg-ami-builder-ssm"
+}
+variable "builder_security_group_name" {
+  type    = string
+  default = "ppg-ami-factory-builder"
+}
+variable "env" {
+  type    = string
+  default = "prod"
+}
+variable "volume_size" {
+  type    = number
+  default = 20 # surrogate (AMI) root GiB; MUST equal the refresh template's var.volume_size (drift-guarded in `just check`)
+}
+
+locals {
+  instance_type  = var.arch == "arm64" ? "t4g.large" : "t3.large"
+  boot_mode      = var.arch == "arm64" ? "uefi" : "legacy-bios"
+  ts             = formatdate("YYYYMMDD-hhmmss", timestamp())
+  candidate_role = var.env == "test" ? "ppg-reimage-test-candidate" : "ppg-reimage-candidate"
+  src_tag        = var.env == "test" ? "factory-test" : "factory"
+  name           = "${var.env == "test" ? "TEST-OL" : "OL"}${var.os_major}-${var.arch}-reimage-${local.ts}"
+}
+
+source "amazon-ebssurrogate" "reimage" {
+  region                      = var.region
+  instance_type               = local.instance_type
+  ami_name                    = local.name
+  ami_architecture            = var.arch
+  ami_virtualization_type     = "hvm"
+  boot_mode                   = local.boot_mode
+  ena_support                 = true
+  communicator                = "ssh"
+  ssh_username                = "ec2-user" # the prebase is finalized (ec2-user + amazon-ssm-agent baked)
+  ssh_interface               = "session_manager"
+  ssh_timeout                 = "12m"
+  ssh_clear_authorized_keys   = true
+  iam_instance_profile        = var.builder_instance_profile
+  skip_profile_validation     = true
+  subnet_id                   = var.subnet_id
+  associate_public_ip_address = true
+  deprecate_at                = timeadd(timestamp(), "168h") # a candidate; verify promotes it within hours
+
+  # Source = the booted, verified full-size prebase (role=ppg-ol10-prebase) for THIS arch.
+  source_ami_filter {
+    filters = {
+      "tag:os"            = "oraclelinux"
+      "tag:os_major"      = var.os_major
+      "tag:arch"          = var.arch
+      "tag:role"          = "ppg-ol10-prebase"
+      architecture        = var.arch
+      root-device-type    = "ebs"
+      virtualization-type = "hvm"
+      state               = "available"
+    }
+    owners      = ["self"]
+    most_recent = true
+  }
+
+  security_group_filter {
+    filters = {
+      "group-name" = var.builder_security_group_name
+    }
+  }
+
+  # Blank surrogate volume: reimage-surgery.sh partitions + copies the prebase root onto it at
+  # var.volume_size, then Packer snapshots IT (not the builder's larger root) and registers the AMI.
+  launch_block_device_mappings {
+    device_name           = "/dev/sdf"
+    volume_size           = var.volume_size
+    volume_type           = "gp3"
+    delete_on_termination = true
+  }
+
+  ami_root_device {
+    source_device_name    = "/dev/sdf"
+    device_name           = "/dev/sda1"
+    volume_size           = var.volume_size
+    volume_type           = "gp3"
+    delete_on_termination = true
+  }
+
+  run_tags = {
+    Name            = "packer-ppg-ol10-reimage"
+    iit-billing-tag = "ppg-ami-factory"
+  }
+  run_volume_tags = {
+    iit-billing-tag = "ppg-ami-factory"
+  }
+
+  # Packer owns the tags: a non-consumed candidate role until `just reimage-ol10-verify` promotes.
+  tags = {
+    Name            = local.name
+    os              = "oraclelinux"
+    os_major        = var.os_major
+    arch            = var.arch
+    role            = local.candidate_role
+    source          = local.src_tag
+    factory_env     = var.env
+    factory_run     = local.ts
+    iit-billing-tag = "ppg-ami-factory"
+    base            = "ppg-ol10-prebase"
+  }
+  snapshot_tags = {
+    Name            = local.name
+    role            = local.candidate_role
+    os_major        = var.os_major
+    arch            = var.arch
+    factory_env     = var.env
+    iit-billing-tag = "ppg-ami-factory"
+  }
+}
+
+build {
+  name    = "ppg-ol10-reimage"
+  sources = ["source.amazon-ebssurrogate.reimage"]
+
+  provisioner "shell" {
+    script = "${path.root}/../scripts/reimage-surgery.sh"
+    environment_vars = [
+      "ARCH=${var.arch}",
+      "ROOT_GIB=${var.volume_size}",
+    ]
+    execute_command = "sudo env {{ .Vars }} bash '{{ .Path }}'"
+  }
+
+  post-processor "manifest" {
+    output     = "${path.root}/manifest.json"
+    strip_path = true
+  }
+}

--- a/ppg/packer/scripts/bootstrap-ol10.sh
+++ b/ppg/packer/scripts/bootstrap-ol10.sh
@@ -21,7 +21,7 @@
 #
 # Idempotent + resumable: a re-run detects an already-promoted base (or a reusable raw/
 # candidate AMI, or the in-S3 source / a completed import) and skips the finished steps; it
-# will NOT re-download the 37GB image. FORCE=1 rebuilds the AMI lineage from the existing S3
+# will NOT re-download the image. FORCE=1 rebuilds the AMI lineage from the existing S3
 # source (still no re-download; delete the S3 object first to refresh the Oracle source).
 set -euo pipefail
 
@@ -49,13 +49,16 @@ esac
 SRC="$(basename "$SRC_URL")"; VMDK="ol10-${ARCH}.vmdk"
 
 FORCE="${FORCE:-0}"   # FORCE=1 rebuilds the AMI lineage (raw -> candidate) from the EXISTING
-                      # S3 source + snapshot; it never re-downloads the 37GB image. To refresh
-                      # the Oracle source, delete s3://$BUCKET/$VMDK (and bump bNNN) first.
+                      # S3 source + snapshot; it never re-downloads the image. To refresh the
+                      # Oracle source, delete s3://$BUCKET/$VMDK (and bump bNNN) first. The
+                      # result is Oracle's full-size base (x86_64 is LVM); shrink it with
+                      # reimage-ol10 before promotion. The refresh launches the newest promoted
+                      # base on var.volume_size and a base larger than that cannot launch.
 
 # Idempotency helpers: newest self-owned, available OL10 image for THIS arch.
 # Return an ImageId or empty string. A describe FAILURE (throttle, expired creds) is
-# NOT silently treated as "absent" -- that would bypass the guards below and re-trigger
-# the 37GB download/import. It retries, then returns non-zero so the callers' `|| exit 1`
+# NOT silently treated as "absent", which would bypass the guards below and re-trigger
+# the image download/import. It retries, then returns non-zero so the callers' `|| exit 1`
 # aborts (fail-closed). An empty result means the image is genuinely absent.
 _describe_newest() {  # $@ = --filters ...
   local out a
@@ -76,14 +79,15 @@ img_by_name() { _describe_newest --filters Name=name,Values="$1" Name=architectu
 RAW=""; BASE=""
 
 # 0. Strongest guard: a promoted prod base already exists -> nothing to do. This protects a
-#    small-disk host from a re-run that would otherwise attempt the 37GB download below.
+#    small-disk host from a re-run that would otherwise attempt the image download below.
 PROMOTED=$(img_by_tag "$ROLE_PROMOTED") || exit 1
-if [ -n "$PROMOTED" ] && [ "$FORCE" != 1 ]; then
+PREBASE=$(img_by_tag "${ROLE_PREBASE:-ppg-ol10-prebase}") || exit 1
+if { [ -n "$PROMOTED" ] || [ -n "$PREBASE" ]; } && [ "$FORCE" != 1 ]; then
   cat <<EOF
 
-OL10 $ARCH base already built + promoted: $PROMOTED (role=$ROLE_PROMOTED). Nothing to do.
-The refresh path (oracle-linux.pkr.hcl, os_major already includes 10) takes over from here.
-Re-run with FORCE=1 to rebuild the AMIs from the existing S3 source (no 37GB re-download).
+OL10 $ARCH base already built (${PROMOTED:+promoted $PROMOTED}${PREBASE:+ prebase $PREBASE}). Nothing to do.
+The reimage + refresh paths take over from here.
+Re-run with FORCE=1 to rebuild the AMIs from the existing S3 source (no re-download).
 EOF
   exit 0
 fi
@@ -99,7 +103,7 @@ else
   if [ -n "$RAW" ] && [ "$FORCE" != 1 ]; then
     log_step "reuse existing raw base $RAW (skip download/convert/upload/import/register)"
   else
-    # 2a. Ensure the streamOptimized VMDK is in S3 (NEVER re-download 37GB if it already is).
+    # 2a. Ensure the streamOptimized VMDK is in S3 (NEVER re-download the image if it already is).
     if aws s3 ls "s3://$BUCKET/$VMDK" --region "$REGION" >/dev/null 2>&1; then
       log_step "S3 source present: s3://$BUCKET/$VMDK (skip download/convert/upload)"
     else
@@ -157,6 +161,6 @@ cat <<EOF
 BOOTSTRAP-OL10 ($ARCH) COMPLETE.
   raw base (intermediate): ${RAW:-<reused candidate; no new raw>}
   candidate base:          ${BASE:-<see packer output above>}  (role=$ROLE_CANDIDATE, Packer-tagged)
-NEXT: just bootstrap-ol10-verify ${BASE:-<candidate-ami>} $ARCH   # boot-validate + promote to role=$ROLE_PROMOTED
-Then OL10 refreshes here like OL8/9 (oracle-linux.pkr.hcl os_major already includes 10).
+NEXT: just bootstrap-ol10-verify ${BASE:-<candidate-ami>} $ARCH   # boot-validate + promote to the prebase role
+Then: just reimage-ol10 $ARCH                                     # shrink to var.volume_size + promote to the consumed role
 EOF

--- a/ppg/packer/scripts/reimage-surgery.sh
+++ b/ppg/packer/scripts/reimage-surgery.sh
@@ -1,0 +1,255 @@
+#!/usr/bin/env bash
+# Shrink the booted prebase root onto Packer's blank ROOT_GIB surrogate (amazon-ebssurrogate
+# provisioner, reimage-ol10.pkr.hcl). Runs as root on the builder. Rationale: docs/reimage.md.
+set -euo pipefail
+
+# Trace every command (line-prefixed) so an unattended Packer-builder failure is debuggable from the
+# build log; no secrets pass through this script. QUIET=1 silences it.
+if [[ "${QUIET:-0}" != 1 ]]; then
+  export PS4='+ [reimage-surgery:${LINENO}] '
+  set -x
+fi
+
+ARCH="${ARCH:?set ARCH}"
+ROOT_GIB="${ROOT_GIB:?set ROOT_GIB (= var.volume_size)}"
+
+command -v parted >/dev/null || dnf -y install parted
+command -v rsync >/dev/null || dnf -y install rsync
+
+if [[ "${ARCH}" = arm64 ]]; then
+  command -v mkfs.fat >/dev/null || dnf -y install dosfstools
+fi
+
+for tool in mkfs.xfs mkswap partprobe xfs_freeze blkid findmnt; do
+  command -v "${tool}" >/dev/null || { echo "MISSING required tool: ${tool}" >&2; exit 1; }
+done
+
+# find the blank ROOT_GIB surrogate Packer attached (by size; no VolumeId to match). Collect ALL
+# blank disks of exactly ROOT_GIB and abort on more than one: silently reimaging onto a stray
+# same-size blank volume would corrupt the wrong disk, so fail closed instead.
+want_bytes=$((ROOT_GIB * 1024 * 1024 * 1024))
+TGT=""
+
+for _ in $(seq 1 30); do
+  candidates=()
+
+  while read -r name size type; do
+    [[ "${type}" = disk && "${size}" = "${want_bytes}" ]] || continue
+    (( $(lsblk -rno NAME "/dev/${name}" | wc -l) == 1 )) || continue   # blank = no partitions
+    candidates+=("/dev/${name}")
+  done < <(lsblk -bdno NAME,SIZE,TYPE)
+
+  case "${#candidates[@]}" in
+    0)
+      sleep 3
+      ;;
+    1)
+      TGT="${candidates[0]}"
+      break
+      ;;
+    *)
+      echo "FATAL: ${#candidates[@]} blank ${ROOT_GIB}GiB disks (${candidates[*]}); cannot disambiguate the surrogate" >&2
+      exit 1
+      ;;
+  esac
+done
+
+[[ -n "${TGT}" ]] || { echo "FATAL: no blank ${ROOT_GIB}GiB surrogate disk found" >&2; exit 1; }
+echo "surrogate target: ${TGT}"
+
+# fail-safe: thaw /boot + unmount the target on any exit
+cleanup_surgery() {
+  xfs_freeze -u /boot 2>/dev/null || true
+
+  for mount_point in $(mount | awk '{print $3}' | grep '^/mnt/target' | sort -r); do
+    umount "${mount_point}" 2>/dev/null || umount -l "${mount_point}" 2>/dev/null || true
+  done
+}
+trap cleanup_surgery EXIT
+
+# introspect the source (the running root)
+SRC_ROOT_DEV=$(findmnt -no SOURCE /)
+SRC_ROOT_UUID=$(blkid -s UUID -o value "${SRC_ROOT_DEV}")
+SRC_BOOT_DEV=$(findmnt -no SOURCE /boot)
+SRC_SWAP_DEV=$(swapon --show=NAME --noheadings | head -1 || true)
+SRC_SWAP_UUID=$([[ -n "${SRC_SWAP_DEV}" ]] && blkid -s UUID -o value "${SRC_SWAP_DEV}" || true)
+IS_LVM=$([[ "${SRC_ROOT_DEV#/dev/mapper/}" != "${SRC_ROOT_DEV}" ]] && echo 1 || echo 0)
+
+if [[ "${ARCH}" = arm64 ]]; then
+  SRC_ESP_DEV=$(findmnt -no SOURCE /boot/efi)
+  FATID=$(blkid -s UUID -o value "${SRC_ESP_DEV}" | tr -d -)
+fi
+
+echo "source: root=${SRC_ROOT_DEV} (${SRC_ROOT_UUID}) boot=${SRC_BOOT_DEV} swap=${SRC_SWAP_UUID:-none} lvm=${IS_LVM}"
+
+# partition the surrogate (offsets in docs/reimage.md; root is the last, growable partition)
+case "${TGT}" in
+  *[0-9]) PART="${TGT}p" ;;   # nvme needs a 'p' suffix, sd* does not
+  *)      PART="${TGT}" ;;
+esac
+
+wipefs -a "${TGT}" || true
+parted -s "${TGT}" mklabel gpt
+
+if [[ "${ARCH}" = arm64 ]]; then
+  parted -s "${TGT}" mkpart EFI  fat32      1MiB    201MiB
+  parted -s "${TGT}" set 1 esp on
+  parted -s "${TGT}" mkpart boot xfs        201MiB  1225MiB
+  parted -s "${TGT}" mkpart swap linux-swap 1225MiB 5321MiB
+  parted -s "${TGT}" mkpart root xfs        5321MiB 100%
+  ESP_P="${PART}1"
+else
+  parted -s "${TGT}" mkpart bios_grub 1MiB 3MiB
+  parted -s "${TGT}" set 1 bios_grub on
+  parted -s "${TGT}" mkpart boot xfs        3MiB    1027MiB
+  parted -s "${TGT}" mkpart swap linux-swap 1027MiB 5123MiB
+  parted -s "${TGT}" mkpart root xfs        5123MiB 100%
+fi
+
+BOOT_P="${PART}2"
+SWAP_P="${PART}3"
+ROOT_P="${PART}4"
+
+partprobe "${TGT}"
+udevadm settle
+
+# wait for the kernel to materialize the partition nodes (busy Nitro re-read can lag a fixed sleep).
+want_partitions=("${BOOT_P}" "${SWAP_P}" "${ROOT_P}")
+[[ "${ARCH}" = arm64 ]] && want_partitions+=("${ESP_P}")
+
+for _ in $(seq 1 30); do
+  missing=0
+
+  for part in "${want_partitions[@]}"; do
+    [[ -b "${part}" ]] || missing=1
+  done
+
+  (( missing == 0 )) && break
+
+  partprobe "${TGT}" 2>/dev/null || true
+  udevadm settle
+  sleep 1
+done
+
+for part in "${want_partitions[@]}"; do
+  [[ -b "${part}" ]] || { echo "FATAL: partition ${part} never appeared after partprobe" >&2; exit 1; }
+done
+
+# /boot: dd verbatim (GRUB can't read EL10 nrext64 xfs); root/swap: fresh fs, cloned UUIDs
+src_boot_sz=$(blockdev --getsize64 "${SRC_BOOT_DEV}")
+tgt_boot_sz=$(blockdev --getsize64 "${BOOT_P}")
+(( src_boot_sz <= tgt_boot_sz )) || { echo "FATAL: source /boot ${src_boot_sz}B > target ${tgt_boot_sz}B" >&2; exit 1; }
+
+xfs_freeze -f /boot
+dd if="${SRC_BOOT_DEV}" of="${BOOT_P}" bs=4M conv=fsync
+xfs_freeze -u /boot
+
+if [[ -n "${SRC_SWAP_UUID}" ]]; then
+  mkswap -U "${SRC_SWAP_UUID}" -L swap "${SWAP_P}"
+else
+  mkswap -L swap "${SWAP_P}"
+fi
+
+mkfs.xfs -f -m uuid="${SRC_ROOT_UUID}" "${ROOT_P}"
+[[ "${ARCH}" = arm64 ]] && mkfs.fat -F32 -n EFI -i "${FATID}" "${ESP_P}"
+
+partprobe "${TGT}"
+udevadm settle
+
+# mount surrogate (-o nouuid: same-UUID source still mounted) + copy root
+mkdir -p /mnt/target
+mount -o nouuid "${ROOT_P}" /mnt/target
+mkdir -p /mnt/target/boot
+mount -o nouuid "${BOOT_P}" /mnt/target/boot
+
+if [[ "${ARCH}" = arm64 ]]; then
+  mkdir -p /mnt/target/boot/efi
+  mount "${ESP_P}" /mnt/target/boot/efi
+fi
+
+# -x keeps rsync on one filesystem, so /proc /sys /dev /run (separate mounts) are skipped without
+# excludes; only same-fs scratch needs excluding. Keep -x if you touch these excludes.
+rsync -aHAXx --numeric-ids --exclude='/tmp/*' --exclude='/var/tmp/*' --exclude='/mnt/*' / /mnt/target/
+[[ "${ARCH}" = arm64 ]] && rsync -rt --no-perms --no-owner --no-group /boot/efi/ /mnt/target/boot/efi/
+
+# LVM source -> plain root: rewrite the GRUB cmdline + /etc/kernel/cmdline (future kernels); fstab is by UUID
+if [[ "${IS_LVM}" = 1 ]]; then
+  for cfg in /mnt/target/boot/loader/entries/*.conf /mnt/target/etc/kernel/cmdline; do
+    [[ -e "${cfg}" ]] || continue
+    sed -i -e "s#root=${SRC_ROOT_DEV}#root=UUID=${SRC_ROOT_UUID}#g" \
+           -e "s#root=/dev/dm-[0-9]*#root=UUID=${SRC_ROOT_UUID}#g" \
+           -e 's#rd\.lvm\.lv=[^ ]*##g' "${cfg}"
+  done
+
+  sed -i 's#rd\.lvm\.lv=[^ ]*##g' /mnt/target/etc/default/grub
+fi
+
+# gate: fstab root must be UUID=<cloned> or absent (docs/reimage.md)
+[[ -f /mnt/target/etc/fstab ]] || { echo "FATAL: /mnt/target/etc/fstab missing after rsync" >&2; exit 1; }
+root_spec=$(awk '$1 !~ /^#/ && $2 == "/" {print $1; exit}' /mnt/target/etc/fstab || true)
+
+case "${root_spec:-}" in
+  ""|"UUID=${SRC_ROOT_UUID}")
+    :
+    ;;
+  *)
+    echo "FATAL: target fstab pins / to '${root_spec}' (expected UUID=${SRC_ROOT_UUID} or none)" >&2
+    exit 1
+    ;;
+esac
+
+# gate: fstab /boot, /boot/efi, swap must be UUID=/LABEL= or absent (PARTUUID/device won't resolve on the fresh GPT)
+while read -r spec where; do
+  case "${spec}" in
+    UUID=*|LABEL=*)
+      ;;
+    *)
+      echo "FATAL: target fstab pins ${where} by '${spec}' (expected UUID= or LABEL=)" >&2
+      exit 1
+      ;;
+  esac
+done < <(awk '$1 !~ /^#/ && ($2=="/boot"||$2=="/boot/efi"||$3=="swap"){print $1, ($3=="swap"?"swap":$2)}' /mnt/target/etc/fstab)
+
+# bootloader: arm64 uses the verbatim ESP; x86_64 reinstalls grub2 (os-prober off)
+if [[ "${ARCH}" = x86_64 ]]; then
+  for pseudo_fs in proc sys dev dev/pts run; do
+    mountpoint -q "/mnt/target/${pseudo_fs}" || mount --bind "/${pseudo_fs}" "/mnt/target/${pseudo_fs}"
+  done
+
+  if grep -q '^GRUB_DISABLE_OS_PROBER=' /mnt/target/etc/default/grub; then
+    sed -i 's/^GRUB_DISABLE_OS_PROBER=.*/GRUB_DISABLE_OS_PROBER=true/' /mnt/target/etc/default/grub
+  else
+    echo 'GRUB_DISABLE_OS_PROBER=true' >> /mnt/target/etc/default/grub
+  fi
+
+  chroot /mnt/target /bin/bash -c "grub2-install --target=i386-pc --recheck ${TGT} && grub2-mkconfig -o /boot/grub2/grub.cfg" >/dev/null
+
+  # gate: no LVM ref may survive in any cmdline source (incl /etc/kernel/cmdline + grubenv); -a for binary grubenv
+  if grep -aREl 'vg_main|rd\.lvm\.lv|root=/dev/(mapper|dm-)' \
+       /mnt/target/boot/loader/entries/ /mnt/target/boot/grub2/grub.cfg \
+       /mnt/target/boot/grub2/grubenv /mnt/target/etc/default/grub \
+       /mnt/target/etc/kernel/cmdline 2>/dev/null; then
+    echo "FATAL: LVM references survive in the x86_64 boot config" >&2
+    exit 1
+  fi
+
+  # gate: the cmdline must pin root by the cloned UUID
+  if ! grep -aqrs "root=UUID=${SRC_ROOT_UUID}" /mnt/target/boot/loader/entries/ /mnt/target/etc/kernel/cmdline; then
+    echo "FATAL: no root=UUID=${SRC_ROOT_UUID} in the x86_64 boot cmdline" >&2
+    exit 1
+  fi
+fi
+
+# de-instance for a clean AMI (cloud-init + machine-id + host/build keys)
+rm -rf /mnt/target/var/lib/cloud/instances/* /mnt/target/var/lib/cloud/instance /mnt/target/var/lib/cloud/sem 2>/dev/null || true
+: > /mnt/target/etc/machine-id
+rm -f /mnt/target/etc/ssh/ssh_host_*_key /mnt/target/etc/ssh/ssh_host_*_key.pub /mnt/target/var/lib/systemd/random-seed 2>/dev/null || true
+rm -f /mnt/target/home/ec2-user/.ssh/authorized_keys /mnt/target/root/.ssh/authorized_keys 2>/dev/null || true
+touch /mnt/target/.autorelabel
+
+# unmount deepest-first
+sync
+for mount_point in $(mount | awk '{print $3}' | grep '^/mnt/target' | sort -r); do
+  umount "${mount_point}" 2>/dev/null || umount -l "${mount_point}"
+done
+echo "REIMAGE_SURGERY_OK root_uuid=${SRC_ROOT_UUID} lvm_converted=${IS_LVM}"


### PR DESCRIPTION
**Bug**
- OL10 package-test AMIs shipped a 60 GiB root, which fails to launch on the PPG Molecule 30 GiB standard because EBS cannot restore a volume below its source snapshot (`InvalidBlockDeviceMapping`), blocking OL10 PPG jobs. OL8/OL9 are 20 GiB.

**Fix**
- Drop the OL10 `root_volume_size` special-case so OL10 refreshes at `var.volume_size` (20 GiB) like OL8/OL9.
- Add `reimage-ol10` + `reimage-ol10-verify`: a Packer `amazon-ebssurrogate` build (`reimage/reimage-ol10.pkr.hcl` + `scripts/reimage-surgery.sh`) copies the booted prebase root onto a smaller surrogate and registers the AMI from it, since EBS cannot restore below a snapshot and XFS cannot shrink in place. Fail-closed size gate, two-size boot + PPG smoke before promotion.
- Greenfield bootstrap promotes to a `prebase` role, and re-image shrinks it to the consumed role.

**Tickets**
- [PG-2353](https://perconadev.atlassian.net/browse/PG-2353) (this)

[PG-2353]: https://perconadev.atlassian.net/browse/PG-2353?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
