### PR TITLE
PKG-1339: Increase pg.cd Jenkins data volume to 500 GiB

### DIFF
--- a/IaC/pg.cd/JenkinsStack.yml
+++ b/IaC/pg.cd/JenkinsStack.yml
@@ -490,7 +490,7 @@ Resources:
       AvailabilityZone:
         Fn::Select: [ 1, !GetAZs '' ]
       Encrypted: false
-      Size: 100
+      Size: 500
       Tags:
       - Key: iit-billing-tag
         Value: !Ref JShortName


### PR DESCRIPTION
**Feature**
- Increase the `pg.cd` Jenkins data volume from 100 to 500 GiB.

**Why**
- Artifact-uploading jobs (2 to 15 GiB per run, ~10 retained runs across many pipelines) outgrew the 100 GiB volume, which filled and caused a worker-provisioning outage ([PKG-1337](https://perconadev.atlassian.net/browse/PKG-1337)).
- The volume was bumped to 200 GiB manually for immediate relief and is being grown to 500 GiB. This codifies the target size so a stack rebuild keeps it and reconciles CloudFormation drift.

**Tickets**
- [PKG-1339](https://perconadev.atlassian.net/browse/PKG-1339) (this), [PKG-1337](https://perconadev.atlassian.net/browse/PKG-1337) (incident)


[PKG-1337]: https://perconadev.atlassian.net/browse/PKG-1337?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[PKG-1339]: https://perconadev.atlassian.net/browse/PKG-1339?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[PKG-1337]: https://perconadev.atlassian.net/browse/PKG-1337?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ