### PR TITLE
PKG-1340: Grant pg.cd worker role ec2:DescribeImages for AMI lookup

### DIFF
--- a/IaC/pg.cd/JenkinsStack.yml
+++ b/IaC/pg.cd/JenkinsStack.yml
@@ -334,6 +334,7 @@ Resources:
             - ec2:CreateTags
             - ec2:DeleteTags
             - ec2:DescribeInstances
+            - ec2:DescribeImages
             - ec2:DescribeSpotInstanceRequests
           - Effect: Allow
             Action:


### PR DESCRIPTION
**Bug**
- `ppg-multiOS-parallel` aborts intermittently at the Oracle Linux AMI lookup with `UnauthorizedOperation` on `ec2:DescribeImages`. The `moleculeEnvPPG` resolver runs on the molecule worker, whose `jenkins-pg-worker` role lacks that action. Only runs that land on the controller (which has it) pass, so it looks intermittent.

**Fix**
- Add `ec2:DescribeImages` to the `JWorkerRole` policy in `IaC/pg.cd/JenkinsStack.yml`.
- The live role was already granted the action to stop the failures. This aligns the template so the next stack update keeps it.

**Tickets**
- [PKG-1340](https://perconadev.atlassian.net/browse/PKG-1340) (this), [PG-2353](https://perconadev.atlassian.net/browse/PG-2353) (origin of the dynamic AMI lookup)


[PKG-1340]: https://perconadev.atlassian.net/browse/PKG-1340?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[PG-2353]: https://perconadev.atlassian.net/browse/PG-2353?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ