### PR TITLE
PG-2353: Auto-prune superseded OL AMIs safely after each promote

### DIFF
--- a/.github/workflows/ppg-oracle-ami-factory.yml
+++ b/.github/workflows/ppg-oracle-ami-factory.yml
@@ -41,6 +41,7 @@ concurrency:
 env:
   AWS_REGION: eu-central-1
   FACTORY_ENV: ${{ github.event.inputs.env || 'prod' }}
+  KEEP_GENERATIONS: '2' # per (os_major, arch) prod/test bases the post-promote prune keeps
 
 jobs:
   # No-AWS gate: a malformed template or bad combo fails HERE, before bake spins
@@ -109,10 +110,18 @@ jobs:
           aws-region: ${{ env.AWS_REGION }}
 
       - name: Install Session Manager plugin
+        env:
+          # Pinned to an immutable versioned URL + verified SHA256 (supply-chain): never
+          # `latest`. The plugin is installed in a job holding AWS OIDC creds, so the bytes
+          # are integrity-checked. Bump deliberately and re-record the digest of the new
+          # version's .deb (curl the versioned URL, sha256sum it).
+          SMP_VERSION: 1.2.835.0
+          SMP_SHA256: 7c6dcad12518571cc7959a713e6a8ae1bdf6ed66fd9bee37dc189e39ca58ae03
         run: |
           set -euo pipefail
           if ! command -v session-manager-plugin >/dev/null; then
-            curl -fsSL "https://s3.amazonaws.com/session-manager-downloads/plugin/latest/ubuntu_64bit/session-manager-plugin.deb" -o /tmp/smp.deb
+            curl -fsSL "https://s3.amazonaws.com/session-manager-downloads/plugin/${SMP_VERSION}/ubuntu_64bit/session-manager-plugin.deb" -o /tmp/smp.deb
+            echo "${SMP_SHA256}  /tmp/smp.deb" | sha256sum -c -
             sudo dpkg -i /tmp/smp.deb
           fi
           session-manager-plugin --version
@@ -162,8 +171,10 @@ jobs:
         run: |
           set -euo pipefail
           echo "smoke candidate: $AMI"
-          # Deregister ONLY on a real boot/install failure (never on a later promote-tag failure).
-          ( cd smoke && packer init . && packer build -color=false \
+          # `packer init` is CI infra (plugin download); a transient init failure must NOT
+          # deregister a good candidate. Only a real boot/install (build) failure does.
+          ( cd smoke && packer init . ) || { echo "smoke packer init failed (CI infra, not a candidate defect); keeping $AMI"; echo "- smoke: init failed (kept $AMI)" >> "$GITHUB_STEP_SUMMARY"; exit 1; }
+          ( cd smoke && packer build -color=false \
               -var "candidate_ami=$AMI" -var "os_major=${OS_MAJOR}" \
               -var "arch=${ARCH}" -var "region=${AWS_REGION}" . ) \
           || { echo "smoke (boot+install) failed; deregistering $AMI + its snapshots"; aws ec2 deregister-image --delete-associated-snapshots --region "$AWS_REGION" --image-id "$AMI"; echo "- smoke: FAIL (deregistered $AMI)" >> "$GITHUB_STEP_SUMMARY"; exit 1; }
@@ -183,6 +194,26 @@ jobs:
             echo "promote attempt $a failed; retry in $((a * 5))s"; sleep $((a * 5))
           done
           echo "- promote: $pr" >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Prune superseded (keep last ${{ env.KEEP_GENERATIONS }})
+        working-directory: ppg/packer
+        # Housekeeping must never fail an already-promoted bake, but it is not
+        # silent either: the script appends counts to $GITHUB_STEP_SUMMARY and
+        # emits ::warning:: annotations on any skipped deregister, failed
+        # snapshot cleanup, or combo left over the keep count.
+        continue-on-error: true
+        env:
+          OS_MAJOR: ${{ matrix.os_major }}
+          ARCH: ${{ matrix.arch }}
+          AMI: ${{ steps.build.outputs.ami }}
+        run: |
+          set -euo pipefail
+          # Deregister this combo's older promoted bases, keeping the newest KEEP_GENERATIONS.
+          # deprecate_at only marks, it never deletes, so without this the inventory grows.
+          role=ppg-package-test; [ "$FACTORY_ENV" = "test" ] && role=ppg-test-package-test
+          # PROMOTED_AMI guards the prune against EC2 eventual consistency: the script
+          # refuses to act unless the just-promoted AMI is the newest visible match.
+          PROMOTED_AMI="$AMI" bash scripts/prune-superseded.sh "$role" "$OS_MAJOR" "$ARCH" "${KEEP_GENERATIONS:-2}" 1 "$AWS_REGION"
 
   notify:
     needs: bake

--- a/ppg/packer/README.md
+++ b/ppg/packer/README.md
@@ -57,9 +57,18 @@ is the newest `role=ppg-package-test` AMI by `CreationDate` (no SSM parameter).
 
 ## Housekeeping (all via `just`, fail-safe)
 
-Cleanup is recipes too. Every prune recipe **lists by default** and deregisters
-only on an explicit `1`; the guard **never deletes a promoted prod base** and
-fail-closes on an AMI it cannot positively classify.
+Superseded prod bases are pruned **automatically**: after each successful promote the
+workflow runs `scripts/prune-superseded.sh` for that combo, keeping the last
+`KEEP_GENERATIONS` (default 2, newest + one rollback). `deprecate_at` only marks an AMI
+deprecated, it never deletes, so without this the inventory grows ~6 AMIs/bake. The `just`
+recipes below remain for ad-hoc / backfill cleanup and share that same script.
+
+Every prune recipe **lists by default** and deregisters only on an explicit `1`; the guard
+**never deletes the newest-per-combo base** and fail-closes on an AMI it cannot classify.
+Demoted rollback AMIs (`role=*-superseded*`) are never touched by any recipe. The
+post-promote prune additionally refuses to act while the just-promoted AMI is not yet
+visible as the newest of its combo, and reports every skipped deregister, failed
+snapshot cleanup, or over-keep residue as a workflow warning + step-summary line.
 
 ```bash
 just list                # current factory AMIs (prod|test)

--- a/ppg/packer/justfile
+++ b/ppg/packer/justfile
@@ -63,27 +63,35 @@ _arch-meta arch:
 _promote ami role:
     #!/usr/bin/env bash
     set -euo pipefail
-    for a in 1 2 3 4 5; do
+    # native retries absorb throttles; the loop below exists for the non-retryable
+    # eventual-consistency window right after CreateImage (InvalidAMIID.NotFound).
+    export AWS_RETRY_MODE="${AWS_RETRY_MODE:-standard}" AWS_MAX_ATTEMPTS="${AWS_MAX_ATTEMPTS:-8}"
+    for attempt in 1 2 3 4 5; do
       aws ec2 create-tags --profile {{profile}} --region {{region}} --resources {{ami}} \
         --tags Key=role,Value={{role}} Key=smoke,Value=passed && { echo "promoted {{ami}} -> {{role}}"; exit 0; }
-      echo "promote attempt $a failed; retry in $((a * 5))s"; sleep $((a * 5))
+      echo "promote attempt ${attempt} failed; retry in $((attempt * 5))s"; sleep $((attempt * 5))
     done
     echo "FATAL: promote {{ami}} -> {{role}} failed after retries (AMI left intact for manual promote)" >&2; exit 1
 
-# deregister an AMI + delete its backing snapshots. Idempotent (an already-gone AMI
-# is a no-op) but NOT error-masking: a genuine API failure aborts rather than silently
-# leaking a snapshot. describe-images --image-ids errors InvalidAMIID.NotFound when gone.
+# deregister an AMI + its backing snapshots in ONE native call
+# (--delete-associated-snapshots). Idempotent (an already-gone AMI is a no-op)
+# but NOT error-masking: a genuine API failure aborts, and any non-success
+# snapshot result is surfaced instead of silently leaking.
 _deregister ami:
     #!/usr/bin/env bash
     set -euo pipefail
-    err=$(mktemp)
-    snaps=$(aws ec2 describe-images --profile {{profile}} --region {{region}} --image-ids "{{ami}}" \
-      --query 'Images[0].BlockDeviceMappings[].Ebs.SnapshotId' --output text 2>"$err") || {
-        if grep -qiE "InvalidAMIID.NotFound|does not exist" "$err"; then echo "  {{ami}} already gone"; rm -f "$err"; exit 0; fi
-        echo "  ERROR describing {{ami}}:" >&2; cat "$err" >&2; rm -f "$err"; exit 1; }
-    rm -f "$err"
-    aws ec2 deregister-image --profile {{profile}} --region {{region}} --image-id "{{ami}}"
-    for s in $snaps; do [ "$s" = None ] && continue; aws ec2 delete-snapshot --profile {{profile}} --region {{region}} --snapshot-id "$s"; done
+    export AWS_RETRY_MODE="${AWS_RETRY_MODE:-standard}" AWS_MAX_ATTEMPTS="${AWS_MAX_ATTEMPTS:-8}"
+    error_file=$(mktemp)
+    snapshot_failures=$(aws ec2 deregister-image --profile {{profile}} --region {{region}} \
+      --image-id "{{ami}}" --delete-associated-snapshots --output text \
+      --query "DeleteSnapshotResults[?ReturnCode != 'success'].[SnapshotId, ReturnCode]" 2>"$error_file") || {
+        if grep -qiE "InvalidAMIID.NotFound|InvalidAMIID.Unavailable|does not exist" "$error_file"; then echo "  {{ami}} already gone"; rm -f "$error_file"; exit 0; fi
+        echo "  ERROR deregistering {{ami}}:" >&2; cat "$error_file" >&2; rm -f "$error_file"; exit 1; }
+    rm -f "$error_file"
+    while IFS= read -r snapshot_result; do
+      [ -z "$snapshot_result" ] && continue
+      echo "  WARN snapshot cleanup for {{ami}}: $snapshot_result" >&2
+    done <<< "$snapshot_failures"
 
 # deregister every self-owned AMI matching a tag filter (+ snapshots), with a HARD guard
 # that NEVER touches a promoted prod base (role={{role_prod}}) or an AMI it cannot classify.
@@ -91,19 +99,20 @@ _deregister ami:
 _prune-by-filter apply +filters:
     #!/usr/bin/env bash
     set -euo pipefail
-    ids=$(aws ec2 describe-images --profile {{profile}} --region {{region}} --owners self \
-      {{filters}} --query 'Images[].ImageId' --output text)
-    [ -z "$ids" ] && { echo "  (nothing matches)"; exit 0; }
-    for ami in $ids; do
-      role=$(aws ec2 describe-images --profile {{profile}} --region {{region}} --image-ids "$ami" \
-        --query "Images[0].Tags[?Key=='role']|[0].Value" --output text)
+    # one describe returns id + role together (no per-AMI re-describe); tag
+    # values are single tokens, so the tab-split read cannot field-shift.
+    candidates=$(aws ec2 describe-images --profile {{profile}} --region {{region}} --owners self \
+      {{filters}} --query "Images[].[ImageId, Tags[?Key=='role']|[0].Value]" --output text)
+    [ -z "$candidates" ] && { echo "  (nothing matches)"; exit 0; }
+    while IFS=$'\t' read -r ami role; do
+      [ -z "$ami" ] && continue
       # fail-closed: never delete the prod base, nor anything we cannot positively
       # classify (missing/None role) -- "don't delete what you can't identify".
       if [ "$role" = "{{role_prod}}" ] || [ -z "$role" ] || [ "$role" = None ]; then echo "  SKIP $ami (protected: role=${role:-<none>})"; continue; fi
       # fail-safe: deregister ONLY on an exact apply=1; any other value (incl a malformed
       # `apply=1` arg, which just passes as the literal "apply=1") lists without deleting.
       if [ "{{apply}}" = "1" ]; then echo "  deregister $ami (role=$role)"; just _deregister "$ami"; else echo "  would deregister $ami (role=$role)"; fi
-    done
+    done <<< "$candidates"
 
 # ===========================================================================
 # packer build / validate (OL8/9 refresh + OL10 once bootstrapped)
@@ -129,8 +138,8 @@ validate-all:
     #!/usr/bin/env bash
     set -euo pipefail
     packer init . >/dev/null
-    for m in {{os_majors}}; do for a in {{arches}}; do
-      echo "validate OL$m $a"; packer validate -var os_major=$m -var arch=$a .
+    for os_major in {{os_majors}}; do for arch in {{arches}}; do
+      echo "validate OL${os_major} ${arch}"; packer validate -var os_major=${os_major} -var arch=${arch} .
     done; done
     ( cd smoke && packer init . >/dev/null && packer validate -var candidate_ami=ami-00000000000000000 -var os_major=9 -var arch=x86_64 . )
     ( cd reimage && packer init . >/dev/null && packer validate -var arch=x86_64 . )
@@ -151,9 +160,9 @@ check:
     # plugin-pin parity: the amazon plugin must be pinned to ONE version across every template, so a
     # supply-chain bump is all-or-nothing instead of drifting silently per-file.
     amazon_pin() { awk '/hashicorp\/amazon/{f=1} f&&/version =/{gsub(/[^0-9.]/,"");print;exit}' "$1"; }
-    pins=$(for f in oracle-linux.pkr.hcl smoke/smoke.pkr.hcl reimage/reimage-ol10.pkr.hcl bootstrap/finalize-ol10.pkr.hcl; do amazon_pin "$f"; done)
-    n=$(printf '%s\n' "$pins" | grep -c .); u=$(printf '%s\n' "$pins" | sort -u | grep -c .)
-    { [ "$n" -eq 4 ] && [ "$u" -eq 1 ]; } || { echo "DRIFT: amazon plugin pin not uniform across the 4 templates:"; printf '%s\n' "$pins"; exit 1; }
+    pins=$(for template_file in oracle-linux.pkr.hcl smoke/smoke.pkr.hcl reimage/reimage-ol10.pkr.hcl bootstrap/finalize-ol10.pkr.hcl; do amazon_pin "$template_file"; done)
+    pin_count=$(printf '%s\n' "$pins" | grep -c .); unique_pins=$(printf '%s\n' "$pins" | sort -u | grep -c .)
+    { [ "$pin_count" -eq 4 ] && [ "$unique_pins" -eq 1 ]; } || { echo "DRIFT: amazon plugin pin not uniform across the 4 templates:"; printf '%s\n' "$pins"; exit 1; }
     echo "check OK"
 
 # trigger the GHA factory workflow for the full matrix (drive CI from just). Targets the
@@ -215,9 +224,9 @@ all env="prod":
     #!/usr/bin/env bash
     set -uo pipefail
     ok=""; fail=""
-    for m in {{os_majors}}; do for a in {{arches}}; do
-      echo "=========== bake OL$m $a (env={{env}}) ==========="
-      if just bake $m $a {{env}}; then ok="$ok OL$m-$a"; else fail="$fail OL$m-$a"; fi
+    for os_major in {{os_majors}}; do for arch in {{arches}}; do
+      echo "=========== bake OL${os_major} ${arch} (env={{env}}) ==========="
+      if just bake ${os_major} ${arch} {{env}}; then ok="$ok OL${os_major}-${arch}"; else fail="$fail OL${os_major}-${arch}"; fi
     done; done
     echo "=========== summary (env={{env}}) ==========="
     echo "  ok:    ${ok:- none}"
@@ -254,47 +263,41 @@ prune-stale apply="0":
     #!/usr/bin/env bash
     set -euo pipefail
     echo "prune-stale (apply={{apply}}; lists unless apply=1):"
-    ids=$(aws ec2 describe-images --profile {{profile}} --region {{region}} --owners self \
+    # one describe returns id + role + factory_env together (no per-AMI
+    # re-describes); the command-sub still propagates a describe failure under
+    # set -e, and these tag values are single tokens so tab-split cannot shift.
+    candidates=$(aws ec2 describe-images --profile {{profile}} --region {{region}} --owners self \
       --filters Name=tag:iit-billing-tag,Values={{billing_tag}} Name=tag:os,Values={{os_name}} \
-      --query 'Images[].ImageId' --output text)
-    [ -z "$ids" ] && { echo "  (no factory AMIs)"; exit 0; }
-    for ami in $ids; do
-      # two scalar command-subs (not a process-sub `read`): a describe failure propagates
-      # under set -e instead of being silently swallowed, and no IFS field-shift on tag values.
-      role=$(aws ec2 describe-images --profile {{profile}} --region {{region}} --image-ids "$ami" \
-        --query "Images[0].Tags[?Key=='role']|[0].Value" --output text)
-      env=$(aws ec2 describe-images --profile {{profile}} --region {{region}} --image-ids "$ami" \
-        --query "Images[0].Tags[?Key=='factory_env']|[0].Value" --output text)
+      --query "Images[].[ImageId, Tags[?Key=='role']|[0].Value, Tags[?Key=='factory_env']|[0].Value]" --output text)
+    [ -z "$candidates" ] && { echo "  (no factory AMIs)"; exit 0; }
+    while IFS=$'\t' read -r ami role env; do
+      [ -z "$ami" ] && continue
       # fail-closed: never delete the prod base, nor anything we cannot positively classify.
       if [ "$role" = "{{role_prod}}" ] || [ -z "$role" ] || [ "$role" = None ]; then echo "  SKIP $ami (protected: role=${role:-<none>})"; continue; fi
+      # demoted rollback AMIs (e.g. role=ppg-ol10-oversized-superseded) are deliberate keeps,
+      # not stale intermediates; only an explicit human decision removes them.
+      case "$role" in *superseded*) echo "  SKIP $ami (protected demotion: role=$role)"; continue;; esac
       if [ "$env" = "test" ]; then echo "  SKIP $ami (test AMI -> use prune-test)"; continue; fi
       if [ "{{apply}}" = "1" ]; then echo "  deregister $ami (role=$role env=$env)"; just _deregister "$ami"; else echo "  would deregister $ami (role=$role env=$env)"; fi
-    done
+    done <<< "$candidates"
 
 # list ALL factory housekeeping AMIs (test + stale intermediates); never prod. Pass `1` to delete.
 prune-all apply="0":
     @just prune-test "{{apply}}"
     @just prune-stale "{{apply}}"
 
-# deregister SUPERSEDED prod bases: per (os_major, arch) KEEP the newest role={{role_prod}}
-# AMI (the one the consumer selects) and remove older duplicates left by refreshes
-# (deprecate_at only marks, never deletes -> inventory grows). Lists by default; pass `1`
-# to deregister. NEVER deletes the newest-per-combo, and skips any AMI missing maj/arch.
+# deregister SUPERSEDED prod bases: per (os_major, arch) KEEP the newest `keep` role={{role_prod}}
+# AMIs (the consumer + refresh select the newest) and remove older duplicates left by refreshes
+# (deprecate_at only marks, never deletes -> inventory grows). Shares scripts/prune-superseded.sh
+# with the GHA workflow, which auto-prunes keep=2 after each promote. Lists by default; pass `1`.
 [doc("deregister superseded prod bases, keeping newest per combo; lists unless apply=1")]
-prune-superseded apply="0":
+prune-superseded apply="0" keep="2":
     #!/usr/bin/env bash
     set -euo pipefail
-    echo "prune-superseded (apply={{apply}}; lists unless apply=1):"
-    aws ec2 describe-images --profile {{profile}} --region {{region}} --owners self \
-      --filters Name=tag:role,Values={{role_prod}} Name=tag:os,Values={{os_name}} Name=state,Values=available \
-      --query "reverse(sort_by(Images,&CreationDate))[].[ImageId, Tags[?Key=='os_major']|[0].Value, Tags[?Key=='arch']|[0].Value]" --output text \
-      | { declare -A keep; while read -r id maj arch; do
-            [ -z "$id" ] && continue
-            { [ "$maj" = None ] || [ "$arch" = None ]; } && { echo "  SKIP $id (untagged maj/arch)"; continue; }
-            k="$maj/$arch"
-            if [ -z "${keep[$k]:-}" ]; then keep[$k]=$id; echo "  KEEP $id (OL$maj $arch, newest)"; continue; fi
-            if [ "{{apply}}" = "1" ]; then echo "  deregister $id (OL$maj $arch, superseded)"; just _deregister "$id"; else echo "  would deregister $id (OL$maj $arch, superseded)"; fi
-          done; }
+    echo "prune-superseded (apply={{apply}}, keep={{keep}}; lists unless apply=1):"
+    for os_major in {{os_majors}}; do for arch in {{arches}}; do
+      OS_NAME={{os_name}} bash scripts/prune-superseded.sh {{role_prod}} "${os_major}" "${arch}" {{keep}} "{{apply}}" {{region}} {{profile}}
+    done; done
 
 # create the SSM builder instance profile locally (one-time, for local builds).
 # PRODUCTION is terraform-managed: percona-cd-platform terraform/ppg-ami-factory.tf.
@@ -325,9 +328,9 @@ teardown-temp apply="0":
     act(){ if [ "{{apply}}" = "1" ]; then echo "  + $*"; "$@"; else echo "  [list] $*"; fi; }
     # present <get-cmd...>: 0 = exists, 1 = genuinely absent (NoSuchEntity); ABORTS on any
     # other error so a throttle / expired creds / AccessDenied is never misread as 'absent'.
-    present(){ local e; e=$(mktemp); if "$@" >/dev/null 2>"$e"; then rm -f "$e"; return 0; fi
-      grep -qiE "NoSuchEntity|InvalidGroup.NotFound|does not exist|cannot be found" "$e" && { rm -f "$e"; return 1; }
-      echo "  ERROR probing: $*" >&2; cat "$e" >&2; rm -f "$e"; exit 1; }
+    present(){ local error_file; error_file=$(mktemp); if "$@" >/dev/null 2>"$error_file"; then rm -f "$error_file"; return 0; fi
+      grep -qiE "NoSuchEntity|InvalidGroup.NotFound|does not exist|cannot be found" "$error_file" && { rm -f "$error_file"; return 1; }
+      echo "  ERROR probing: $*" >&2; cat "$error_file" >&2; rm -f "$error_file"; exit 1; }
     if present aws iam get-instance-profile $P --instance-profile-name {{builder_profile}}; then
       act aws iam remove-role-from-instance-profile $P --instance-profile-name {{builder_profile}} --role-name {{builder_profile}}
       act aws iam delete-instance-profile $P --instance-profile-name {{builder_profile}}
@@ -462,7 +465,7 @@ reimage-ol10-verify ami arch="arm64" env="prod":
       rec=$(aws ec2 describe-instances --region {{region}} \
         --filters "Name=tag:$runtag,Values=$runval" "Name=instance-state-name,Values=pending,running,stopping,stopped" \
         --query 'Reservations[].Instances[].InstanceId' --output text 2>/dev/null)
-      for i in $iids $rec; do aws ec2 terminate-instances --region {{region}} --instance-ids "$i" >/dev/null 2>&1; done
+      for instance_id in $iids $rec; do aws ec2 terminate-instances --region {{region}} --instance-ids "$instance_id" >/dev/null 2>&1; done
     }
     trap cleanup EXIT
     # growpart floor: derive the non-root overhead (ESP/bios + boot + swap) from the surgery partition

--- a/ppg/packer/oracle-linux.pkr.hcl
+++ b/ppg/packer/oracle-linux.pkr.hcl
@@ -133,8 +133,10 @@ source "amazon-ebs" "ol" {
   skip_profile_validation = true
   user_data               = local.ssm_bootstrap
 
-  # Native retention: the baked AMI auto-deprecates ~5 weeks out, so superseded
-  # weekly images age out without a custom deregister-old sweep.
+  # Mark the AMI deprecated ~5 weeks out (deprioritizes it in default describe-images
+  # results). Deprecation only MARKS, it never deletes the AMI or its snapshot; superseded
+  # bases are removed by the post-promote prune (scripts/prune-superseded.sh, keep last
+  # KEEP_GENERATIONS) in the workflow, or by `just prune-superseded`.
   deprecate_at = timeadd(timestamp(), "840h")
 
   # Latest self-owned base of the same major+arch, selected by FACTORY TAGS

--- a/ppg/packer/scripts/prune-superseded.sh
+++ b/ppg/packer/scripts/prune-superseded.sh
@@ -1,0 +1,159 @@
+#!/usr/bin/env bash
+# Post-promote AMI prune - keep the newest KEEP_N promoted bases per
+# (os_major, arch) combo, deregister the rest with their snapshots.
+# Shared by the GHA workflow (auto-prune after each promote) and the
+# justfile `prune-superseded` recipe. deprecate_at only MARKS an AMI,
+# it never deletes, so without this the inventory grows every bake.
+#
+#   Usage: prune-superseded.sh ROLE OS_MAJOR ARCH KEEP_N APPLY REGION [PROFILE]
+#     APPLY=1 deregisters. Anything else lists only (dry run).
+#   Env:   OS_NAME (default oraclelinux)
+#          PROMOTED_AMI - refuse to prune unless it is the newest match
+#
+# Fail-safe: only exact role-tag matches with the right NATIVE architecture
+# are candidates (demoted `*-superseded` roles and mistagged AMIs are never
+# seen), the newest KEEP_N always survive, and a describe failure aborts
+# rather than treating images as absent. Sorting and selection are native
+# (CLI v2 aggregates pagination before applying --query); the only loops are
+# per-AMI mutations, which have no bulk API.
+set -euo pipefail
+
+# Native throttle handling on every call; warn-and-continue below is the
+# after-retries fallback, not the first line of defense.
+export AWS_RETRY_MODE="${AWS_RETRY_MODE:-standard}"
+export AWS_MAX_ATTEMPTS="${AWS_MAX_ATTEMPTS:-8}"
+
+err() {
+  echo "$*" >&2
+}
+
+# Report lines go to stdout AND the workflow step summary when present.
+summary() {
+  echo "$*"
+
+  if [[ -n "${GITHUB_STEP_SUMMARY:-}" ]]; then
+    echo "$*" >> "${GITHUB_STEP_SUMMARY}"
+  fi
+}
+
+# Arguments + preflight: refuse to run half-armed.
+ROLE="${1:?ROLE}"
+OS_MAJOR="${2:?OS_MAJOR}"
+ARCH="${3:?ARCH}"
+KEEP_N="${4:?KEEP_N}"
+APPLY="${5:?APPLY (1=delete, else list)}"
+REGION="${6:?REGION}"
+OS_NAME="${OS_NAME:-oraclelinux}"
+
+PROFILE_ARGS=()
+[[ -n "${7:-}" ]] && PROFILE_ARGS=(--profile "$7")
+
+command -v aws >/dev/null || { err "missing required tool: aws"; exit 1; }
+
+# KEEP_N=0 would deregister the live base the consumer resolves to. The
+# integer check also makes KEEP_N safe to interpolate into --query below.
+if ! [[ "${KEEP_N}" =~ ^[0-9]+$ ]] || (( KEEP_N < 1 )); then
+  err "KEEP_N must be a positive integer, got '${KEEP_N}'"
+  exit 1
+fi
+
+# The EC2 native Architecture token is arm64; accept the aarch64 vocabulary too.
+NATIVE_ARCH="${ARCH/aarch64/arm64}"
+
+# Candidate listing: one call, filtered server-side (role, os, os_major, arch
+# tag AND native architecture, so a mistagged AMI is structurally excluded),
+# sorted newest-first natively. --include-deprecated keeps AMIs past
+# deprecate_at visible so they are pruned too.
+ids_text=$(aws ec2 describe-images "${PROFILE_ARGS[@]}" --region "${REGION}" \
+  --owners self --include-deprecated --output text \
+  --filters Name=tag:role,Values="${ROLE}" Name=tag:os,Values="${OS_NAME}" \
+            Name=tag:os_major,Values="${OS_MAJOR}" Name=tag:arch,Values="${ARCH}" \
+            Name=architecture,Values="${NATIVE_ARCH}" Name=state,Values=available \
+  --query 'reverse(sort_by(Images,&CreationDate))[].ImageId') \
+  || { err "FATAL: describe-images failed for OL${OS_MAJOR} ${ARCH} (refusing to prune blind)"; exit 1; }
+
+mapfile -t ami_ids < <(tr '\t' '\n' <<< "${ids_text}" | grep -vE '^(None)?$' || true)
+
+# A tag:arch match whose native architecture differs is excluded above;
+# surface the count so a mistagging cannot rot silently.
+mismatched_arch=$(aws ec2 describe-images "${PROFILE_ARGS[@]}" --region "${REGION}" \
+  --owners self --include-deprecated --output text \
+  --filters Name=tag:role,Values="${ROLE}" Name=tag:os,Values="${OS_NAME}" \
+            Name=tag:os_major,Values="${OS_MAJOR}" Name=tag:arch,Values="${ARCH}" \
+            Name=state,Values=available \
+  --query "length(Images[?Architecture != '${NATIVE_ARCH}'])")
+
+if (( mismatched_arch > 0 )); then
+  summary "::warning::OL${OS_MAJOR} ${ARCH}: ${mismatched_arch} AMI(s) tagged arch=${ARCH} but native Architecture differs, excluded from pruning"
+fi
+
+# Guards: empty estate is reportable but not fatal, and pruning is refused
+# while the just-promoted AMI is not yet the newest visible match (EC2
+# describe is eventually consistent right after a promote).
+if [[ "${#ami_ids[@]}" -eq 0 ]]; then
+  summary "OL${OS_MAJOR} ${ARCH}: no ${ROLE} AMIs found (unexpected after a promote)"
+  exit 0
+fi
+
+if [[ -n "${PROMOTED_AMI:-}" ]] && [[ "${ami_ids[0]}" != "${PROMOTED_AMI}" ]]; then
+  err "FATAL: newest visible AMI ${ami_ids[0]} != just-promoted ${PROMOTED_AMI} (eventual consistency?), refusing to prune"
+  exit 1
+fi
+
+if [[ "${#ami_ids[@]}" -le "${KEEP_N}" ]]; then
+  summary "OL${OS_MAJOR} ${ARCH}: ${#ami_ids[@]} AMI(s) <= keep ${KEEP_N}, nothing to prune"
+  exit 0
+fi
+
+summary "OL${OS_MAJOR} ${ARCH}: ${#ami_ids[@]} ${ROLE} AMIs, keep newest ${KEEP_N}"
+
+# Keep/prune split by array slice; the newest KEEP_N are untouchable.
+keep_ids=("${ami_ids[@]:0:${KEEP_N}}")
+prune_ids=("${ami_ids[@]:${KEEP_N}}")
+
+for ami in "${keep_ids[@]}"; do
+  echo "    KEEP ${ami}"
+done
+
+# Prune loop: warn-and-continue. One failed call (after native retries) must
+# not abort the remaining AMIs (or, via the caller loop, the remaining
+# combos). Snapshot cleanup is native (--delete-associated-snapshots). Any
+# non-success snapshot result is surfaced instead of silently orphaning.
+prune_failures=0
+pruned_count=0
+
+for ami in "${prune_ids[@]}"; do
+  if [[ "${APPLY}" != 1 ]]; then
+    echo "    would deregister ${ami} (superseded)"
+    continue
+  fi
+
+  if ! snapshot_failures=$(aws ec2 deregister-image "${PROFILE_ARGS[@]}" --region "${REGION}" \
+      --image-id "${ami}" --delete-associated-snapshots --output text \
+      --query "DeleteSnapshotResults[?ReturnCode != 'success'].[SnapshotId, ReturnCode]"); then
+    summary "::warning::OL${OS_MAJOR} ${ARCH}: deregister ${ami} failed, continuing"
+    prune_failures=$((prune_failures + 1))
+    continue
+  fi
+
+  echo "    deregistered ${ami} (superseded)"
+  pruned_count=$((pruned_count + 1))
+
+  while IFS= read -r snapshot_result; do
+    [[ -z "${snapshot_result}" ]] && continue
+    summary "::warning::OL${OS_MAJOR} ${ARCH}: snapshot cleanup for ${ami}: ${snapshot_result}"
+    prune_failures=$((prune_failures + 1))
+  done <<< "${snapshot_failures}"
+done
+
+# Report: counts always, a loud warning when the combo is still over keep
+# (the signal that the filter drifted or failures piled up).
+residual=$(( ${#ami_ids[@]} - pruned_count ))
+
+if [[ "${APPLY}" == 1 ]]; then
+  summary "OL${OS_MAJOR} ${ARCH}: pruned ${pruned_count}, failures ${prune_failures}, remaining ${residual} (keep ${KEEP_N})"
+
+  if (( residual > KEEP_N )); then
+    summary "::warning::OL${OS_MAJOR} ${ARCH}: still ${residual} AMIs after pruning (over keep ${KEEP_N})"
+  fi
+fi

--- a/ppg/packer/smoke/smoke.pkr.hcl
+++ b/ppg/packer/smoke/smoke.pkr.hcl
@@ -21,8 +21,20 @@ packer {
 }
 
 variable "candidate_ami" { type = string }
-variable "os_major" { type = string }
-variable "arch" { type = string } # x86_64 | arm64
+variable "os_major" {
+  type = string
+  validation {
+    condition     = contains(["8", "9", "10"], var.os_major)
+    error_message = "Value of os_major must be 8, 9, or 10."
+  }
+}
+variable "arch" {
+  type = string # x86_64 | arm64
+  validation {
+    condition     = contains(["x86_64", "arm64"], var.arch)
+    error_message = "Value of arch must be x86_64 or arm64."
+  }
+}
 variable "region" {
   type    = string
   default = "eu-central-1"


### PR DESCRIPTION
**Feature**
- After each promote the factory keeps the newest `KEEP_GENERATIONS` (2) AMIs per (os_major, arch) and deregisters older ones together with their snapshots

**Why**
- `deprecate_at` only marks an AMI deprecated, it never deletes, so the inventory grows ~6 AMIs per weekly bake
- Deletion automation next to production consumers must fail safe: native newest-first selection with server-side architecture filters, warn-and-continue on throttling, `role=*superseded*` demotions and mistagged AMIs never match, and a promoted-AMI guard refuses to prune during the EC2 eventual-consistency window
- The justfile helpers go native too: `--delete-associated-snapshots` replaces the hand-rolled snapshot loops (fixing an unreachable already-gone path) and the per-AMI re-describes collapse into single calls

**Tickets**
- [PG-2353](https://perconadev.atlassian.net/browse/PG-2353) (this), supersedes [#4213](https://github.com/Percona-Lab/jenkins-pipelines/pull/4213) with its review addressed

[PG-2353]: https://perconadev.atlassian.net/browse/PG-2353?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ