### PR TITLE
PKG-1427: Reuse a named buildx builder in hetzner-branch pipelines

### DIFF
--- a/cloud/jenkins/pgo_operator_aks_latest.groovy
+++ b/cloud/jenkins/pgo_operator_aks_latest.groovy
@@ -79,7 +79,7 @@ void dockerBuildPush() {
             else
                 cd source
                 sg docker -c "
-                    docker buildx create --use
+                    docker buildx use multiarch 2>/dev/null || docker buildx create --name multiarch --use
                     docker login -u '$USER' -p '$PASS'
                     export IMAGE=perconalab/percona-postgresql-operator:$GIT_BRANCH
                     make build-docker-image

--- a/cloud/jenkins/pgo_operator_aks_version.groovy
+++ b/cloud/jenkins/pgo_operator_aks_version.groovy
@@ -79,7 +79,7 @@ void dockerBuildPush() {
             else
                 cd source
                 sg docker -c "
-                    docker buildx create --use
+                    docker buildx use multiarch 2>/dev/null || docker buildx create --name multiarch --use
                     docker login -u '$USER' -p '$PASS'
                     export IMAGE=perconalab/percona-postgresql-operator:$GIT_BRANCH
                     make build-docker-image

--- a/cloud/jenkins/pgo_operator_aws_openshift-4.groovy
+++ b/cloud/jenkins/pgo_operator_aws_openshift-4.groovy
@@ -88,7 +88,7 @@ void dockerBuildPush() {
             else
                 cd source
                 sg docker -c "
-                    docker buildx create --use
+                    docker buildx use multiarch 2>/dev/null || docker buildx create --name multiarch --use
                     docker login -u '$USER' -p '$PASS'
                     export IMAGE=perconalab/percona-postgresql-operator:$GIT_BRANCH
                     make build-docker-image

--- a/cloud/jenkins/pgo_operator_aws_openshift_latest.groovy
+++ b/cloud/jenkins/pgo_operator_aws_openshift_latest.groovy
@@ -88,7 +88,7 @@ void dockerBuildPush() {
             else
                 cd source
                 sg docker -c "
-                    docker buildx create --use
+                    docker buildx use multiarch 2>/dev/null || docker buildx create --name multiarch --use
                     docker login -u '$USER' -p '$PASS'
                     export IMAGE=perconalab/percona-postgresql-operator:$GIT_BRANCH
                     make build-docker-image

--- a/cloud/jenkins/pgo_operator_eks_latest.groovy
+++ b/cloud/jenkins/pgo_operator_eks_latest.groovy
@@ -67,7 +67,7 @@ void dockerBuildPush() {
             else
                 cd source
                 sg docker -c "
-                    docker buildx create --use
+                    docker buildx use multiarch 2>/dev/null || docker buildx create --name multiarch --use
                     docker login -u '$USER' -p '$PASS'
                     export IMAGE=perconalab/percona-postgresql-operator:$GIT_BRANCH
                     make build-docker-image

--- a/cloud/jenkins/pgo_operator_eks_version.groovy
+++ b/cloud/jenkins/pgo_operator_eks_version.groovy
@@ -67,7 +67,7 @@ void dockerBuildPush() {
             else
                 cd source
                 sg docker -c "
-                    docker buildx create --use
+                    docker buildx use multiarch 2>/dev/null || docker buildx create --name multiarch --use
                     docker login -u '$USER' -p '$PASS'
                     export IMAGE=perconalab/percona-postgresql-operator:$GIT_BRANCH
                     make build-docker-image

--- a/cloud/jenkins/pgo_operator_gke_latest.groovy
+++ b/cloud/jenkins/pgo_operator_gke_latest.groovy
@@ -82,7 +82,7 @@ void dockerBuildPush() {
             else
                 cd source
                 sg docker -c "
-                    docker buildx create --use
+                    docker buildx use multiarch 2>/dev/null || docker buildx create --name multiarch --use
                     docker login -u '$USER' -p '$PASS'
                     export IMAGE=perconalab/percona-postgresql-operator:$GIT_BRANCH
                     make build-docker-image

--- a/cloud/jenkins/pgo_operator_gke_version.groovy
+++ b/cloud/jenkins/pgo_operator_gke_version.groovy
@@ -82,7 +82,7 @@ void dockerBuildPush() {
             else
                 cd source
                 sg docker -c "
-                    docker buildx create --use
+                    docker buildx use multiarch 2>/dev/null || docker buildx create --name multiarch --use
                     docker login -u '$USER' -p '$PASS'
                     export IMAGE=perconalab/percona-postgresql-operator:$GIT_BRANCH
                     make build-docker-image

--- a/cloud/jenkins/pgo_operator_minikube.groovy
+++ b/cloud/jenkins/pgo_operator_minikube.groovy
@@ -32,7 +32,7 @@ void dockerBuildPush() {
             else
                 cd source
                 sg docker -c "
-                    docker buildx create --use
+                    docker buildx use multiarch 2>/dev/null || docker buildx create --name multiarch --use
                     docker login -u '$USER' -p '$PASS'
                     export IMAGE=perconalab/percona-postgresql-operator:$GIT_BRANCH
                     make build-docker-image

--- a/cloud/jenkins/pgov2_docker_build.groovy
+++ b/cloud/jenkins/pgov2_docker_build.groovy
@@ -78,7 +78,7 @@ pipeline {
                                     fi
 
                                     docker login -u '${USER}' -p '${PASS}'
-                                    docker buildx create --use
+                                    docker buildx use multiarch 2>/dev/null || docker buildx create --name multiarch --use
 
                                     DOCKER_DEFAULT_PLATFORM='linux/amd64,linux/arm64' make build-docker-image
 

--- a/cloud/jenkins/ps_operator_minikube.groovy
+++ b/cloud/jenkins/ps_operator_minikube.groovy
@@ -32,7 +32,7 @@ void dockerBuildPush() {
             else
                 cd source
                 sg docker -c "
-                    docker buildx create --use
+                    docker buildx use multiarch 2>/dev/null || docker buildx create --name multiarch --use
                     docker login -u '$USER' -p '$PASS'
                     export IMAGE=perconalab/percona-server-mysql-operator:$GIT_BRANCH
                     e2e-tests/build

--- a/cloud/jenkins/psmdb_docker_build.groovy
+++ b/cloud/jenkins/psmdb_docker_build.groovy
@@ -97,7 +97,7 @@ pipeline {
                         unstash "sourceFILES"
                         withCredentials([usernamePassword(credentialsId: 'hub.docker.com', passwordVariable: 'PASS', usernameVariable: 'USER')]) {
                             sh '''
-                                docker buildx create --use
+                                docker buildx use multiarch 2>/dev/null || docker buildx create --name multiarch --use
                                 cd ./source/
                                 sg docker -c "
                                     docker login -u '${USER}' -p '${PASS}'

--- a/cloud/jenkins/psmdb_operator_aks_latest.groovy
+++ b/cloud/jenkins/psmdb_operator_aks_latest.groovy
@@ -110,7 +110,7 @@ void dockerBuildPush() {
             else
                 cd source
                 sg docker -c "
-                    docker buildx create --use
+                    docker buildx use multiarch 2>/dev/null || docker buildx create --name multiarch --use
                     docker login -u '$USER' -p '$PASS'
                     export IMAGE=perconalab/percona-server-mongodb-operator:$GIT_BRANCH
                     e2e-tests/build

--- a/cloud/jenkins/psmdb_operator_aks_version.groovy
+++ b/cloud/jenkins/psmdb_operator_aks_version.groovy
@@ -110,7 +110,7 @@ void dockerBuildPush() {
             else
                 cd source
                 sg docker -c "
-                    docker buildx create --use
+                    docker buildx use multiarch 2>/dev/null || docker buildx create --name multiarch --use
                     docker login -u '$USER' -p '$PASS'
                     export IMAGE=perconalab/percona-server-mongodb-operator:$GIT_BRANCH
                     e2e-tests/build

--- a/cloud/jenkins/psmdb_operator_aws_openshift-4.groovy
+++ b/cloud/jenkins/psmdb_operator_aws_openshift-4.groovy
@@ -106,7 +106,7 @@ void dockerBuildPush() {
             else
                 cd source
                 sg docker -c "
-                    docker buildx create --use
+                    docker buildx use multiarch 2>/dev/null || docker buildx create --name multiarch --use
                     docker login -u '$USER' -p '$PASS'
                     export IMAGE=perconalab/percona-server-mongodb-operator:$GIT_BRANCH
                     e2e-tests/build

--- a/cloud/jenkins/psmdb_operator_aws_openshift_latest.groovy
+++ b/cloud/jenkins/psmdb_operator_aws_openshift_latest.groovy
@@ -106,7 +106,7 @@ void dockerBuildPush() {
             else
                 cd source
                 sg docker -c "
-                    docker buildx create --use
+                    docker buildx use multiarch 2>/dev/null || docker buildx create --name multiarch --use
                     docker login -u '$USER' -p '$PASS'
                     export IMAGE=perconalab/percona-server-mongodb-operator:$GIT_BRANCH
                     e2e-tests/build

--- a/cloud/jenkins/psmdb_operator_eks_latest.groovy
+++ b/cloud/jenkins/psmdb_operator_eks_latest.groovy
@@ -100,7 +100,7 @@ void dockerBuildPush() {
             else
                 cd source
                 sg docker -c "
-                    docker buildx create --use
+                    docker buildx use multiarch 2>/dev/null || docker buildx create --name multiarch --use
                     docker login -u '$USER' -p '$PASS'
                     export IMAGE=perconalab/percona-server-mongodb-operator:$GIT_BRANCH
                     e2e-tests/build

--- a/cloud/jenkins/psmdb_operator_eks_version.groovy
+++ b/cloud/jenkins/psmdb_operator_eks_version.groovy
@@ -100,7 +100,7 @@ void dockerBuildPush() {
             else
                 cd source
                 sg docker -c "
-                    docker buildx create --use
+                    docker buildx use multiarch 2>/dev/null || docker buildx create --name multiarch --use
                     docker login -u '$USER' -p '$PASS'
                     export IMAGE=perconalab/percona-server-mongodb-operator:$GIT_BRANCH
                     e2e-tests/build

--- a/cloud/jenkins/psmdb_operator_gke_latest.groovy
+++ b/cloud/jenkins/psmdb_operator_gke_latest.groovy
@@ -126,7 +126,7 @@ void dockerBuildPush() {
             else
                 cd source
                 sg docker -c "
-                    docker buildx create --use
+                    docker buildx use multiarch 2>/dev/null || docker buildx create --name multiarch --use
                     docker login -u '$USER' -p '$PASS'
                     export IMAGE=perconalab/percona-server-mongodb-operator:$GIT_BRANCH
                     e2e-tests/build

--- a/cloud/jenkins/psmdb_operator_gke_version.groovy
+++ b/cloud/jenkins/psmdb_operator_gke_version.groovy
@@ -126,7 +126,7 @@ void dockerBuildPush() {
             else
                 cd source
                 sg docker -c "
-                    docker buildx create --use
+                    docker buildx use multiarch 2>/dev/null || docker buildx create --name multiarch --use
                     docker login -u '$USER' -p '$PASS'
                     export IMAGE=perconalab/percona-server-mongodb-operator:$GIT_BRANCH
                     e2e-tests/build

--- a/cloud/jenkins/psmdb_operator_minikube.groovy
+++ b/cloud/jenkins/psmdb_operator_minikube.groovy
@@ -76,7 +76,7 @@ void dockerBuildPush() {
             else
                 cd source
                 sg docker -c "
-                    docker buildx create --use
+                    docker buildx use multiarch 2>/dev/null || docker buildx create --name multiarch --use
                     docker login -u '$USER' -p '$PASS'
                     export IMAGE=perconalab/percona-server-mongodb-operator:$GIT_BRANCH
                     e2e-tests/build

--- a/cloud/jenkins/psmo_docker_build.groovy
+++ b/cloud/jenkins/psmo_docker_build.groovy
@@ -47,7 +47,7 @@ pipeline {
                         withCredentials([usernamePassword(credentialsId: 'hub.docker.com', passwordVariable: 'PASS', usernameVariable: 'USER')]) {
                             sh """
                                 docker login -u '${USER}' -p '${PASS}'
-                                docker buildx create --use
+                                docker buildx use multiarch 2>/dev/null || docker buildx create --name multiarch --use
                                 cd ./source/
                                 DOCKER_DEFAULT_PLATFORM='linux/amd64,linux/arm64' ./e2e-tests/build
                                 sudo rm -rf ./build

--- a/cloud/jenkins/pxc_docker_build.groovy
+++ b/cloud/jenkins/pxc_docker_build.groovy
@@ -48,7 +48,7 @@ pipeline {
                         withCredentials([usernamePassword(credentialsId: 'hub.docker.com', passwordVariable: 'PASS', usernameVariable: 'USER')]) {
                             sh """
                                 docker login -u '${USER}' -p '${PASS}'
-                                docker buildx create --use
+                                docker buildx use multiarch 2>/dev/null || docker buildx create --name multiarch --use
                                 cd ./source/
                                 DOCKER_DEFAULT_PLATFORM='linux/amd64,linux/arm64' ./e2e-tests/build
                                 sudo rm -rf ./build

--- a/cloud/jenkins/pxco-aks.groovy
+++ b/cloud/jenkins/pxco-aks.groovy
@@ -98,7 +98,7 @@ void dockerBuildPush() {
             else
                 cd source
                 sg docker -c "
-                    docker buildx create --use
+                    docker buildx use multiarch 2>/dev/null || docker buildx create --name multiarch --use
                     docker login -u '$USER' -p '$PASS'
                     export IMAGE=perconalab/percona-xtradb-cluster-operator:$GIT_BRANCH
                     e2e-tests/build

--- a/cloud/jenkins/pxco-eks.groovy
+++ b/cloud/jenkins/pxco-eks.groovy
@@ -88,7 +88,7 @@ void dockerBuildPush() {
             else
                 cd source
                 sg docker -c "
-                    docker buildx create --use
+                    docker buildx use multiarch 2>/dev/null || docker buildx create --name multiarch --use
                     docker login -u '$USER' -p '$PASS'
                     export IMAGE=perconalab/percona-xtradb-cluster-operator:$GIT_BRANCH
                     e2e-tests/build

--- a/cloud/jenkins/pxco-gke.groovy
+++ b/cloud/jenkins/pxco-gke.groovy
@@ -108,7 +108,7 @@ void dockerBuildPush() {
             else
                 cd source
                 sg docker -c "
-                    docker buildx create --use
+                    docker buildx use multiarch 2>/dev/null || docker buildx create --name multiarch --use
                     docker login -u '$USER' -p '$PASS'
                     export IMAGE=perconalab/percona-xtradb-cluster-operator:$GIT_BRANCH
                     e2e-tests/build

--- a/cloud/jenkins/pxco-minikube.groovy
+++ b/cloud/jenkins/pxco-minikube.groovy
@@ -75,7 +75,7 @@ void dockerBuildPush() {
             else
                 cd source
                 sg docker -c "
-                    docker buildx create --use
+                    docker buildx use multiarch 2>/dev/null || docker buildx create --name multiarch --use
                     docker login -u '$USER' -p '$PASS'
                     export IMAGE=perconalab/percona-xtradb-cluster-operator:$GIT_BRANCH
                     e2e-tests/build

--- a/cloud/jenkins/pxco-openshift.groovy
+++ b/cloud/jenkins/pxco-openshift.groovy
@@ -95,7 +95,7 @@ void dockerBuildPush() {
             else
                 cd source
                 sg docker -c "
-                    docker buildx create --use
+                    docker buildx use multiarch 2>/dev/null || docker buildx create --name multiarch --use
                     docker login -u '$USER' -p '$PASS'
                     export IMAGE=perconalab/percona-xtradb-cluster-operator:$GIT_BRANCH
                     e2e-tests/build


### PR DESCRIPTION
**Bug**
- 28 hetzner-branch call sites run anonymous `docker buildx create --use` with no `docker buildx rm`; every build leaks a running buildkit container plus a named `_state` cache volume that `docker system prune` cannot reclaim, filling worker disks.

**Fix**
- Hetzner-branch sibling of [#4265](https://github.com/Percona-Lab/jenkins-pipelines/pull/4265): the same named use-or-create idiom, `docker buildx use multiarch 2>/dev/null || docker buildx create --name multiarch --use`, at each site.
- One shared builder per worker instead of one leak per build; recreated automatically if removed.

**Tickets**
- [PKG-1427](https://perconadev.atlassian.net/browse/PKG-1427) (this); siblings: [#4265](https://github.com/Percona-Lab/jenkins-pipelines/pull/4265) (master branch), [percona-postgresql-operator#1688](https://github.com/percona/percona-postgresql-operator/pull/1688)

[PKG-1427]: https://perconadev.atlassian.net/browse/PKG-1427?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ