### PR TITLE
PMM-15210: AMI_ID param and installation_type for nightly GHA

### DIFF
--- a/pmm/v3/pmm3-rc-testing.groovy
+++ b/pmm/v3/pmm3-rc-testing.groovy
@@ -141,6 +141,7 @@ pipeline {
                                     triggerNightlyGhaRc('pmm3-ui-tests-nightly-gha (ami)', [
                                         SERVER_TYPE    : 'ami',
                                         AMI_ID         : params.AMI_ID.trim(),
+                                        DOCKER_VERSION : env.PMM_SERVER_IMAGE,
                                     ])
                                 }
                             }

--- a/pmm/v3/pmm3-rc-testing.groovy
+++ b/pmm/v3/pmm3-rc-testing.groovy
@@ -30,6 +30,7 @@ def triggerNightlyGhaRc(String shortName, Map cfg = [:]) {
         PMM_QA_GIT_BRANCH : 'main',
         SERVER_TYPE       : 'docker',
         DOCKER_VERSION    : env.PMM_SERVER_IMAGE,
+        AMI_ID            : params.AMI_ID.trim(),
         CLIENT_VERSION    : 'pmm3-rc',
         ADMIN_PASSWORD    : 'pmm3admin!',
         HELM_CHART_BRANCH : 'main',
@@ -139,9 +140,7 @@ pipeline {
                             steps {
                                 script {
                                     triggerNightlyGhaRc('pmm3-ui-tests-nightly-gha (ami)', [
-                                        SERVER_TYPE    : 'ami',
-                                        AMI_ID         : params.AMI_ID.trim(),
-                                        DOCKER_VERSION : env.PMM_SERVER_IMAGE,
+                                        SERVER_TYPE: 'ami',
                                     ])
                                 }
                             }

--- a/pmm/v3/pmm3-rc-testing.groovy
+++ b/pmm/v3/pmm3-rc-testing.groovy
@@ -30,7 +30,6 @@ def triggerNightlyGhaRc(String shortName, Map cfg = [:]) {
         PMM_QA_GIT_BRANCH : 'main',
         SERVER_TYPE       : 'docker',
         DOCKER_VERSION    : env.PMM_SERVER_IMAGE,
-        OVA_VERSION       : '',
         CLIENT_VERSION    : 'pmm3-rc',
         ADMIN_PASSWORD    : 'pmm3admin!',
         HELM_CHART_BRANCH : 'main',
@@ -141,7 +140,7 @@ pipeline {
                                 script {
                                     triggerNightlyGhaRc('pmm3-ui-tests-nightly-gha (ami)', [
                                         SERVER_TYPE    : 'ami',
-                                        DOCKER_VERSION : params.AMI_ID.trim(),
+                                        AMI_ID         : params.AMI_ID.trim(),
                                     ])
                                 }
                             }

--- a/pmm/v3/pmm3-ui-tests-nightly-gha.groovy
+++ b/pmm/v3/pmm3-ui-tests-nightly-gha.groovy
@@ -229,6 +229,7 @@ pipeline {
                           --arg branch "$PMM_QA_GIT_BRANCH" \
                           --arg pwd "$ADMIN_PASSWORD" \
                           --arg confidence "${PTS_CONFIDENCE}%" \
+                          --arg installation_type "$SERVER_TYPE" \
                           '{
                              ref: $ref,
                              inputs: {
@@ -237,7 +238,8 @@ pipeline {
                                pmm_server_image: $image,
                                pmm_qa_branch: $branch,
                                admin_password: $pwd,
-                               launchable_confidence: $confidence
+                               launchable_confidence: $confidence,
+                               installation_type: $installation_type
                              }
                            }')
 

--- a/pmm/v3/pmm3-ui-tests-nightly-gha.groovy
+++ b/pmm/v3/pmm3-ui-tests-nightly-gha.groovy
@@ -229,7 +229,6 @@ pipeline {
                           --arg branch "$PMM_QA_GIT_BRANCH" \
                           --arg pwd "$ADMIN_PASSWORD" \
                           --arg confidence "${PTS_CONFIDENCE}%" \
-                          --arg deployment_type "$SERVER_TYPE" \
                           '{
                              ref: $ref,
                              inputs: {
@@ -238,8 +237,7 @@ pipeline {
                                pmm_server_image: $image,
                                pmm_qa_branch: $branch,
                                admin_password: $pwd,
-                               launchable_confidence: $confidence,
-                               deployment_type: $deployment_type
+                               launchable_confidence: $confidence
                              }
                            }')
 

--- a/pmm/v3/pmm3-ui-tests-nightly-gha.groovy
+++ b/pmm/v3/pmm3-ui-tests-nightly-gha.groovy
@@ -61,10 +61,12 @@ def runOpenshiftClusterCreate(String OPENSHIFT_VERSION, DOCKER_VERSION, ADMIN_PA
 
 def runHAClusterCreate(String K8S_VERSION, DOCKER_VERSION, HELM_CHART_BRANCH, ADMIN_PASSWORD) {
     def pmmImageTag = DOCKER_VERSION.split(":")[1]
+    def pmmImageRepo = DOCKER_VERSION.split(":")[0]
 
     clusterCreateJob = build job: 'pmm3-ha-eks', parameters: [
         string(name: 'K8S_VERSION', value: K8S_VERSION),
         string(name: 'HELM_CHART_BRANCH', value: HELM_CHART_BRANCH),
+        string(name: 'PMM_IMAGE_REPOSITORY', value: pmmImageRepo),
         string(name: 'PMM_IMAGE_TAG', value: pmmImageTag),
         string(name: 'PMM_ADMIN_PASSWORD', value: ADMIN_PASSWORD),
         booleanParam(name: 'ENABLE_EXTERNAL_ACCESS', value: true),

--- a/pmm/v3/pmm3-ui-tests-nightly-gha.groovy
+++ b/pmm/v3/pmm3-ui-tests-nightly-gha.groovy
@@ -229,6 +229,7 @@ pipeline {
                           --arg branch "$PMM_QA_GIT_BRANCH" \
                           --arg pwd "$ADMIN_PASSWORD" \
                           --arg confidence "${PTS_CONFIDENCE}%" \
+                          --arg deployment_type "$SERVER_TYPE" \
                           '{
                              ref: $ref,
                              inputs: {
@@ -237,7 +238,8 @@ pipeline {
                                pmm_server_image: $image,
                                pmm_qa_branch: $branch,
                                admin_password: $pwd,
-                               launchable_confidence: $confidence
+                               launchable_confidence: $confidence,
+                               deployment_type: $deployment_type
                              }
                            }')
 

--- a/pmm/v3/pmm3-ui-tests-nightly-gha.groovy
+++ b/pmm/v3/pmm3-ui-tests-nightly-gha.groovy
@@ -3,6 +3,8 @@ library changelog: false, identifier: 'lib@master', retriever: modernSCM([
     remote: 'https://github.com/Percona-Lab/jenkins-pipelines.git'
 ]) _
 
+def defaultAmiId = pmmVersion('v3-ami').values()[-1]
+
 void runStagingServer(String DOCKER_VERSION, CLIENT_VERSION, CLIENTS, CLIENT_INSTANCE, SERVER_IP, PMM_QA_GIT_BRANCH, ADMIN_PASSWORD = "admin") {
     stagingJob = build job: 'pmm3-aws-staging-start', parameters: [
         string(name: 'DOCKER_VERSION', value: DOCKER_VERSION),
@@ -117,6 +119,10 @@ pipeline {
             description: 'PMM Server docker container version (image-name:version-tag)',
             name: 'DOCKER_VERSION')
         string(
+            defaultValue: defaultAmiId,
+            description: '[AMI only] AWS AMI ID (e.g., ami-0669b163befffb6c3).',
+            name: 'AMI_ID')
+        string(
             defaultValue: 'latest-tarball',
             description: 'PMM Client version',
             name: 'CLIENT_VERSION')
@@ -171,7 +177,7 @@ pipeline {
                         expression { env.SERVER_TYPE == "ami" }
                     }
                     steps {
-                        runAMIStagingStart(DOCKER_VERSION)
+                        runAMIStagingStart(AMI_ID)
                     }
                 }
                 stage('Setup Helm PMM Server Instance') {


### PR DESCRIPTION
## Summary

- Add `AMI_ID` parameter to `pmm3-ui-tests-nightly-gha` (default: latest from `pmmVersion('v3-ami')`) and use it for `pmm3-ami-staging-start` instead of overloading `DOCKER_VERSION`
- Pass `SERVER_TYPE` as `installation_type` to the nightly GHA workflow for Launchable test-suite naming (`docker-ui-nightly`, `ami-ui-nightly`, etc.)
- RC testing AMI lane passes `AMI_ID` and keeps `DOCKER_VERSION` as the RC docker image for GHA
- Remove leftover `OVA_VERSION` from `pmm3-rc-testing` defaults (OVF option/field already removed from nightly GHA in PMM-15001)

## Test plan

- [ ] Run `pmm3-ui-tests-nightly-gha` with `SERVER_TYPE=ami` and a valid `AMI_ID` — staging starts and GHA dispatch uses docker image + `installation_type=ami`
- [ ] Run RC testing AMI lane — `AMI_ID` from RC params is used for staging, not passed as `DOCKER_VERSION`
