### PR TITLE
PMM-7: Fix package testing checkout and Ubuntu Resolute upgrade runs

### DIFF
--- a/pmm/v3/pmm3-package-testing-amd64.groovy
+++ b/pmm/v3/pmm3-package-testing-amd64.groovy
@@ -76,10 +76,21 @@ void setup_ubuntu_package_tests()
     '''
 }
 
+String resolvePmmQaBranch(String branch) {
+    def mergedBranches = [
+        'PMM-14766': 'main',
+    ]
+    return mergedBranches.get(branch, branch)
+}
+
 void run_package_tests(String GIT_BRANCH, String TESTS, String INSTALL_REPO, String TARBALL)
 {
+    def pmmQaBranch = resolvePmmQaBranch(GIT_BRANCH)
+    if (pmmQaBranch != GIT_BRANCH) {
+        echo "pmm-qa branch '${GIT_BRANCH}' was merged; checking out '${pmmQaBranch}' instead"
+    }
     deleteDir()
-    git poll: false, branch: GIT_BRANCH, url: 'https://github.com/percona/pmm-qa'
+    git poll: false, branch: pmmQaBranch, url: 'https://github.com/percona/pmm-qa'
     sh """
         export install_repo=${INSTALL_REPO}
         export TARBALL_LINK=${TARBALL}
@@ -101,7 +112,7 @@ pipeline {
     parameters {
         string(
             defaultValue: 'main',
-            description: 'Tag/Branch for pmm-qa repository',
+            description: 'Tag/Branch for pmm-qa repository (merged feature branches such as PMM-14766 resolve to main)',
             name: 'GIT_BRANCH',
             trim: true)
         string(
@@ -213,6 +224,9 @@ pipeline {
                     }
                 }
                 stage('Ubuntu 26.04 Resolute - AMD64') {
+                    when {
+                        expression { !env.TESTS?.contains("upgrade") }
+                    }
                     agent {
                         label 'min-resolute-x64'
                     }

--- a/pmm/v3/pmm3-package-testing-arm64.groovy
+++ b/pmm/v3/pmm3-package-testing-arm64.groovy
@@ -76,10 +76,21 @@ void setup_ubuntu_package_tests()
     '''
 }
 
+String resolvePmmQaBranch(String branch) {
+    def mergedBranches = [
+        'PMM-14766': 'main',
+    ]
+    return mergedBranches.get(branch, branch)
+}
+
 void run_package_tests(String GIT_BRANCH, String TESTS, String INSTALL_REPO, String TARBALL)
 {
+    def pmmQaBranch = resolvePmmQaBranch(GIT_BRANCH)
+    if (pmmQaBranch != GIT_BRANCH) {
+        echo "pmm-qa branch '${GIT_BRANCH}' was merged; checking out '${pmmQaBranch}' instead"
+    }
     deleteDir()
-    git poll: false, branch: GIT_BRANCH, url: 'https://github.com/percona/pmm-qa'
+    git poll: false, branch: pmmQaBranch, url: 'https://github.com/percona/pmm-qa'
     sh """
         export install_repo=${INSTALL_REPO}
         export TARBALL_LINK=${TARBALL}
@@ -101,7 +112,7 @@ pipeline {
     parameters {
         string(
             defaultValue: 'main',
-            description: 'Tag/Branch for pmm-qa repository',
+            description: 'Tag/Branch for pmm-qa repository (merged feature branches such as PMM-14766 resolve to main)',
             name: 'GIT_BRANCH',
             trim: true)
         string(
@@ -216,6 +227,9 @@ pipeline {
                     }
                 }
                 stage('Ubuntu 26.04 Resolute - ARM64') {
+                    when {
+                        expression { !env.TESTS?.contains("upgrade") }
+                    }
                     agent {
                         label 'min-resolute-arm64'
                     }


### PR DESCRIPTION
## Summary

Fixes the `pmm3-package-testing` pipeline failures seen when Jenkins is still configured with a deleted `pmm-qa` branch and when running upgrade playbooks on Ubuntu 26.04 Resolute.

This replaces the orphaned `PMM-7-ubuntu-resolute` branch with a proper branch off `master`, keeping only the package-testing changes that are still relevant.

## Problem

The Jenkins job failed during `pmm-qa` checkout:

```
ERROR: Couldn't find any revision to build.
> git rev-parse refs/remotes/origin/PMM-14766^{commit}
```

`PMM-14766` was merged to `main` in percona/pmm-qa (#1055) and the feature branch no longer exists, but Jenkins jobs can still pass `GIT_BRANCH=PMM-14766`.

## Changes

- Map merged `pmm-qa` feature branches (`PMM-14766` → `main`) before checkout, with a log message when remapped
- Skip Ubuntu 26.04 Resolute stages for upgrade playbooks (`TESTS` containing `upgrade`), matching the intent of `PMM-7-ubuntu-resolute`
- Apply the same fixes to both `pmm3-package-testing-amd64.groovy` and `pmm3-package-testing-arm64.groovy`

## Retest instructions

1. Point `pmm3-package-testing` at this branch: `cursor/package-testing-ubuntu-resolute-fix-e69e`
2. Keep `GIT_BRANCH=PMM-14766` (should auto-resolve to `main`) or set `GIT_BRANCH=main`
3. Re-run the package test matrix

## Notes

The existing `PMM-7-ubuntu-resolute` branch is an orphan single-commit branch and is behind `master` in several unrelated PMM pipelines. This PR intentionally ports only the package-testing fixes onto current `master`.