### PR TITLE
PMM-7: Fix empty DOCKER_TAG_UPGRADE in upgrade test runner

### DIFF
--- a/pmm/v3/pmm3-upgrade-test-runner.groovy
+++ b/pmm/v3/pmm3-upgrade-test-runner.groovy
@@ -145,7 +145,10 @@ pipeline {
             steps {
                 script {
                     env.ADMIN_PASSWORD = 'admin'
-                    currentBuild.description = "${env.UPGRADE_FLAG} - ${env.UPGRADE_TYPE} Upgrade for PMM from ${env.DOCKER_TAG.split(":")[1]} to ${env.PMM_SERVER_LATEST}."
+                    if (!params.DOCKER_TAG_UPGRADE?.trim()) {
+                        env.DOCKER_TAG_UPGRADE = "percona/pmm-server:${params.PMM_SERVER_LATEST}"
+                    }
+                    currentBuild.description = "${env.UPGRADE_FLAG} - ${env.UPGRADE_TYPE} Upgrade for PMM from ${env.DOCKER_TAG.split(":")[1]} to ${env.PMM_SERVER_LATEST} (${env.DOCKER_TAG_UPGRADE})."
                 }
                 git poll: false,
                     branch: PMM_UI_PRE_UPGRADE_GIT_BRANCH,


### PR DESCRIPTION
## Summary

Fixes `pmm3-upgrade-test-runner` failing during the Docker upgrade path with:

```
docker: 'docker pull' requires 1 argument
```

## Root cause

`DOCKER_TAG_UPGRADE` defaults to empty, and the Docker upgrade stage always runs:

```bash
docker pull ${DOCKER_TAG_UPGRADE}
```

When the parameter is not set (common for `pmm3-upgrade-tests` runs), the pull command has no image name.

The parameter description already says an empty value should use the version service target; `PMM_SERVER_LATEST` is that resolved version.

## Fix

In the `Prepare` stage, default empty `DOCKER_TAG_UPGRADE` to:

```
percona/pmm-server:${PMM_SERVER_LATEST}
```

Also include the resolved upgrade image in the build description for easier debugging.

## Retest

Run `pmm3-upgrade-test-runner` (or `pmm3-upgrade-tests`) with:
- `UPGRADE_TYPE=DOCKER`
- `DOCKER_TAG_UPGRADE` left empty
- `PMM_SERVER_LATEST` set to the target version (e.g. `3.6.0`)