### PR TITLE
PKG-1342: Extend the PPG AMI factory to bake Rocky Linux 8/9/10

### DIFF
--- a/.github/workflows/ppg-ami-factory.yml
+++ b/.github/workflows/ppg-ami-factory.yml
@@ -1,22 +1,24 @@
-# Oracle Linux package-test AMI factory.
-# Bakes OL8/OL9 (and later OL10) x86_64+arm64 AMIs with Packer over AWS Session
+# EL package-test AMI factory: Oracle Linux + Rocky Linux.
+# Bakes OL and Rocky 8/9/10 x86_64+arm64 AMIs with Packer over AWS Session
 # Manager (no inbound SSH), authenticated via GitHub OIDC (no static keys), and
 # promotes each via a fresh-boot smoke test. Consumer: pg.cd molecule jobs select
 # the newest role=ppg-package-test AMI by tag (vars/moleculeEnvPPG.groovy).
+# Rocky lineage roots are seeded once per combo via dispatch (just ci-seed-rocky).
 #
-# Triggers: recipe change (paths), weekly security rebake (cron), manual.
+# Triggers: PR validate-only (pull_request -> check job, no AWS), recipe change
+# (paths), weekly security rebake (cron), manual.
 # Actions are pinned to commit SHAs; the trailing "# vX.Y.Z" records the tag.
 
-name: ppg-oracle-ami-factory
-run-name: ppg OL AMI factory (${{ inputs.env || 'prod' }}, ${{ github.event_name }})
+name: ppg-ami-factory
+run-name: ppg AMI factory (${{ inputs.env || 'prod' }}, ${{ github.event_name }})
 
 on:
   workflow_dispatch:
     inputs:
       combos:
-        description: 'JSON matrix include list, e.g. [{"os_major":"9","arch":"x86_64"}]'
+        description: 'JSON matrix include list, e.g. [{"os":"rocky","os_major":"9","arch":"x86_64","seed":true}]; os defaults to oraclelinux, seed to false'
         required: false
-        default: '[{"os_major":"9","arch":"x86_64"}]'
+        default: '[{"os":"oraclelinux","os_major":"9","arch":"x86_64"}]'
       env:
         description: 'prod (real factory tags) or test (isolated tags, never consumed by pg.cd)'
         required: false
@@ -27,9 +29,13 @@ on:
     branches: [master]
     paths:
       - 'ppg/packer/**'
-      - '.github/workflows/ppg-oracle-ami-factory.yml'
+      - '.github/workflows/ppg-ami-factory.yml'
+  pull_request:
+    paths:
+      - 'ppg/packer/**'
+      - '.github/workflows/ppg-ami-factory.yml'
   schedule:
-    - cron: '0 6 * * 1' # weekly Mon 06:00 UTC - absorb Oracle security errata
+    - cron: '0 6 * * 1' # weekly Mon 06:00 UTC - absorb OL + Rocky security errata
 
 permissions:
   contents: read # workflow-level default: read-only
@@ -44,8 +50,9 @@ env:
 
 jobs:
   # No-AWS gate: a malformed template or bad combo fails HERE, before bake spins
-  # up any EC2. Mirrors the local `just check` (fmt-check + validate every combo +
-  # smoke). No id-token, so this job can never assume the factory role.
+  # up any EC2. Runs scripts/check.sh, the SAME file `just check` runs, so the
+  # CI and local gates cannot drift. No id-token, so this job can never assume
+  # the factory role.
   check:
     name: Validate templates (no AWS)
     runs-on: ubuntu-latest
@@ -64,28 +71,12 @@ jobs:
         working-directory: ppg/packer
         run: |
           set -euo pipefail
-          packer fmt -check -diff .
-          packer fmt -check -diff smoke
-          packer init .
-          for m in 8 9 10; do
-            for a in x86_64 arm64; do
-              echo "validate OL$m $a"
-              packer validate -var "os_major=$m" -var "arch=$a" .
-            done
-          done
-          ( cd smoke && packer init . && packer validate \
-              -var candidate_ami=ami-00000000000000000 \
-              -var os_major=9 -var arch=x86_64 . )
-          # drift guard (mirrors `just check`): justfile root_gib must equal var.volume_size,
-          # else a reimaged base would be the wrong root size for the refresh to launch.
-          rg=$(awk -F'"' '/^root_gib[[:space:]]*:=/{print $2; exit}' justfile)
-          vs=$(awk '/variable "volume_size"/{f=1} f&&/default/{gsub(/[^0-9]/,"");print;exit}' oracle-linux.pkr.hcl)
-          [[ -n "$rg" && "$rg" == "$vs" ]] || { echo "DRIFT: justfile root_gib=$rg != var.volume_size=$vs"; exit 1; }
-          echo "check OK"
+          bash scripts/check.sh
 
   bake:
-    name: OL${{ matrix.os_major }} ${{ matrix.arch }}
+    name: ${{ matrix.os || 'oraclelinux' }} ${{ matrix.os_major }} ${{ matrix.arch }}
     needs: check # no EC2 launches until templates validate
+    if: github.event_name != 'pull_request' # PRs run the no-AWS check only
     runs-on: ubuntu-latest
     timeout-minutes: 60
     permissions:
@@ -93,9 +84,9 @@ jobs:
       id-token: write # ONLY this job mints the OIDC token
     strategy:
       fail-fast: false
-      max-parallel: 2
+      max-parallel: 12
       matrix:
-        include: ${{ fromJSON(github.event.inputs.combos || '[{"os_major":"8","arch":"x86_64"},{"os_major":"8","arch":"arm64"},{"os_major":"9","arch":"x86_64"},{"os_major":"9","arch":"arm64"},{"os_major":"10","arch":"x86_64"},{"os_major":"10","arch":"arm64"}]') }}
+        include: ${{ fromJSON(github.event.inputs.combos || '[{"os":"oraclelinux","os_major":"8","arch":"x86_64"},{"os":"oraclelinux","os_major":"8","arch":"arm64"},{"os":"oraclelinux","os_major":"9","arch":"x86_64"},{"os":"oraclelinux","os_major":"9","arch":"arm64"},{"os":"oraclelinux","os_major":"10","arch":"x86_64"},{"os":"oraclelinux","os_major":"10","arch":"arm64"},{"os":"rocky","os_major":"8","arch":"x86_64"},{"os":"rocky","os_major":"8","arch":"arm64"},{"os":"rocky","os_major":"9","arch":"x86_64"},{"os":"rocky","os_major":"9","arch":"arm64"},{"os":"rocky","os_major":"10","arch":"x86_64"},{"os":"rocky","os_major":"10","arch":"arm64"}]') }}
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
@@ -129,18 +120,22 @@ jobs:
         working-directory: ppg/packer
         run: packer init .
 
-      - name: Build candidate AMI (OL${{ matrix.os_major }} ${{ matrix.arch }}, env=${{ env.FACTORY_ENV }})
+      - name: Build candidate AMI (${{ matrix.os || 'oraclelinux' }} ${{ matrix.os_major }} ${{ matrix.arch }}, env=${{ env.FACTORY_ENV }})
         id: build
         working-directory: ppg/packer
         # Matrix values via env, not inline ${{ }}, so they reach packer as data
         # (quoted shell vars) and cannot break out of the run shell.
         env:
+          OS: ${{ matrix.os || 'oraclelinux' }}
+          SEED: ${{ matrix.seed || false }}
           OS_MAJOR: ${{ matrix.os_major }}
           ARCH: ${{ matrix.arch }}
         run: |
           set -euo pipefail
           rm -f manifest.json
           packer build -color=false \
+            -var "os=${OS}" \
+            -var "seed=${SEED}" \
             -var "os_major=${OS_MAJOR}" \
             -var "arch=${ARCH}" \
             -var "region=${AWS_REGION}" \
@@ -149,7 +144,7 @@ jobs:
           echo "ami=$AMI" >> "$GITHUB_OUTPUT"
           echo "built candidate: $AMI"
           {
-            echo "### OL${OS_MAJOR} ${ARCH}"
+            echo "### ${OS} ${OS_MAJOR} ${ARCH}"
             echo "- built: $AMI"
           } >> "$GITHUB_STEP_SUMMARY"
 
@@ -157,6 +152,7 @@ jobs:
         working-directory: ppg/packer
         env:
           AMI: ${{ steps.build.outputs.ami }}
+          OS: ${{ matrix.os || 'oraclelinux' }}
           OS_MAJOR: ${{ matrix.os_major }}
           ARCH: ${{ matrix.arch }}
         run: |
@@ -164,7 +160,7 @@ jobs:
           echo "smoke candidate: $AMI"
           # Deregister ONLY on a real boot/install failure (never on a later promote-tag failure).
           ( cd smoke && packer init . && packer build -color=false \
-              -var "candidate_ami=$AMI" -var "os_major=${OS_MAJOR}" \
+              -var "candidate_ami=$AMI" -var "os=${OS}" -var "os_major=${OS_MAJOR}" \
               -var "arch=${ARCH}" -var "region=${AWS_REGION}" . ) \
           || { echo "smoke (boot+install) failed; deregistering $AMI + its snapshots"; aws ec2 deregister-image --delete-associated-snapshots --region "$AWS_REGION" --image-id "$AMI"; echo "- smoke: FAIL (deregistered $AMI)" >> "$GITHUB_STEP_SUMMARY"; exit 1; }
           echo "- smoke: pass" >> "$GITHUB_STEP_SUMMARY"
@@ -186,7 +182,9 @@ jobs:
 
   notify:
     needs: bake
-    if: failure()
+    # failure() is true when ANY ancestor failed, including a check failure on a
+    # pull_request run where bake was skipped. Never ping the webhook for PR lint.
+    if: failure() && github.event_name != 'pull_request'
     runs-on: ubuntu-latest
     # Job-level so the step `if` below reads it reliably; a step-scoped env can be
     # unavailable to its own step's `if`, which would skip the alert silently.
@@ -202,4 +200,4 @@ jobs:
           webhook: ${{ env.SLACK_WEBHOOK }}
           webhook-type: incoming-webhook
           payload: |
-            text: "PPG-OL-AMI factory FAILED - ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+            text: "PPG AMI factory FAILED - ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"

--- a/ppg/packer/README.md
+++ b/ppg/packer/README.md
@@ -1,12 +1,14 @@
-# PPG Oracle Linux AMI factory
+# PPG EL AMI factory (Oracle Linux + Rocky Linux)
 
-Builds the Oracle Linux package-test target AMIs that PG release testing runs
-against, so we stop hand-maintaining them (launch base, `dnf update`, snapshot).
+Builds the Oracle Linux and Rocky Linux package-test target AMIs that PG release
+testing runs against, so we stop hand-maintaining them (launch base,
+`dnf update`, snapshot).
 
 ## Why this exists
 
-There is no off-the-shelf AWS image that is all of: genuine Oracle Linux,
-OL8/OL9/OL10, x86_64 **and** arm64, free of software fees, and maintained.
+**Oracle Linux**: there is no off-the-shelf AWS image that is all of: genuine
+Oracle Linux, OL8/OL9/OL10, x86_64 **and** arm64, free of software fees, and
+maintained.
 
 - Oracle stopped publishing official AWS AMIs. The newest public Oracle images
   (owner `131827586825`) are OL8.9 / OL9.3 from Feb 2024 and were all deprecated
@@ -17,16 +19,31 @@ OL8/OL9/OL10, x86_64 **and** arm64, free of software fees, and maintained.
 - AlmaLinux is free + current + both-arch, but it is an EL clone, fine as
   supplemental smoke coverage, not a replacement for the Oracle Linux gate.
 
+**Rocky Linux**: official community AMIs exist (owner `792107900819`, no fees,
+no product codes), but Rocky 8 publishing is patchy. The June 2026 `8.10-20260625`
+refresh reached the community owner only in us-east-1, and eu-central-1 (where
+this factory bakes) got it only as a Marketplace image whose product code would
+propagate into every derived AMI. Under the community owner in eu-central-1 the
+newest Rocky 8 AMI remains `8.10-20240528`, AWS-deprecated since 2026-05-31, so
+the previously hand-pinned Rocky 8 AMI aged two years of errata into every
+molecule run. The
+factory seeds each Rocky lineage once from the official AMI, then refreshes it
+weekly like OL, which keeps Rocky 8 current even though upstream no longer
+ships AWS images for it. The official 10 GiB roots restore fine onto the factory's
+`var.volume_size` (EBS only refuses to shrink), so Rocky needs no
+bootstrap/re-image machinery.
+
 So we bake our own, on a schedule, in the CI build account (eu-central-1). The
 same Packer templates + scripts run whether driven locally (`justfile`) or by the
 GitHub Actions workflow. Builds connect over AWS Session Manager (no inbound SSH)
 and authenticate via GitHub OIDC (no static keys).
 
-## Three build paths
+## Build paths
 
 | Path | Covers | Mechanism |
 |------|--------|-----------|
-| **Refresh** (`oracle-linux.pkr.hcl`) | OL8, OL9, OL10 (x86_64 + arm64) | `amazon-ebs`: launch the latest self-owned base of the same major+arch, `dnf update`, validate (fail-closed), snapshot. Each build's output is the next build's source. |
+| **Refresh** (`refresh.pkr.hcl`) | OL + Rocky 8/9/10 (x86_64 + arm64) | `amazon-ebs`: launch the latest self-owned base of the same os+major+arch, `dnf update`, validate (fail-closed), snapshot. Each build's output is the next build's source. |
+| **Seed** (`refresh.pkr.hcl -var seed=true`) | Rocky lineage roots, one-time per combo | Same bake, but sourced from the official Rocky community AMI (`include_deprecated` covers the frozen Rocky 8). Promoted seeds become the refresh lineage. |
 | **Bootstrap** (`scripts/bootstrap-ol10.sh`) | OL10 lineage root, one-time per arch | Import Oracle's official OL10 cloud image (arm64 `*-kvm-cloud-*.qcow2`, x86_64 `*-aws-*.vmdk`) via `aws ec2 import-snapshot`, register the raw base, then `packer build bootstrap/finalize-ol10.pkr.hcl` (adds `ec2-user` + `amazon-ssm-agent` + `dnf update`). Needed because Oracle ships no OL10 AWS AMI. Promotes to a `prebase` role: Oracle's full-size root cannot launch on `var.volume_size`, so `reimage-ol10` shrinks it before it becomes the consumed base. Idempotent. |
 | **Re-image** (`scripts/reimage-ol10.sh`) | OL10 root shrink, one-time per arch | Copy the current base's root onto a fresh `var.volume_size` GiB volume on a builder, snapshot + register, then `reimage-ol10-verify` boot-tests two sizes + smoke + size-gate + promote. Needed because EBS cannot restore a volume below its source snapshot and XFS cannot shrink in place. Full internals (`dd` /boot, LVM-to-plain, the gates): [docs/reimage.md](docs/reimage.md). |
 
@@ -35,8 +52,12 @@ and authenticate via GitHub OIDC (no static keys).
 ```bash
 export AWS_PROFILE=percona-dev-admin
 just check                              # fmt-check + validate every combo (no AWS)
-just bake 9 x86_64                      # build + smoke + promote one combo
+just bake 9 x86_64                      # build + smoke + promote one OL combo
+just bake 9 x86_64 prod rocky           # same for a seeded Rocky combo
+just seed-rocky 9 x86_64 prod           # one-time Rocky lineage root for ONE combo (bake + smoke + promote)
+just ci-seed-rocky                      # dispatch the GHA workflow to seed ALL six Rocky combos (env=prod)
 just all                                # build + promote every OL major x arch
+just all prod rocky                     # same for Rocky (after seeding)
 just bootstrap-ol10-prep                # one-time: import bucket + vmimport role + boot-test SG/key
 just bootstrap-ol10 x86_64              # one-time OL10 lineage root for an arch
 just bootstrap-ol10-verify <ami> x86_64 # boot-validate a candidate then promote it (prebase)
@@ -44,15 +65,18 @@ just reimage-ol10 x86_64                # shrink the OL10 base root to var.volum
 just reimage-ol10-verify <ami> x86_64   # boot-test two sizes + smoke + size-gate + promote
 ```
 
-Each build registers `OL<major>-<arch>-<UTCstamp>` tagged `os=oraclelinux`,
+Each build registers `OL<major>-<arch>-<UTCstamp>` / `Rocky<major>-<arch>-<UTCstamp>`
+tagged `os=oraclelinux|rocky`,
 `os_major`, `arch`, `source=factory` with **`role=ppg-candidate`**, then the
 native-Packer smoke (`smoke/smoke.pkr.hcl`) fresh-boot-tests it. The smoke
 template ONLY validates; **promotion to `role=ppg-package-test` is a separate,
 retried step** in the `justfile`/workflow that runs after a passing smoke, so a
 transient tag-API failure can never deregister a smoke-passed AMI. A real
 boot/install failure deregisters the candidate + its snapshots.
-Consumers and the next build's source filter select only `role=ppg-package-test`,
-so a non-booting image is never selectable and AMI IDs are never pinned. "Latest"
+The jobs and the next build's source filter select only `role=ppg-package-test`,
+so a non-booting image is never selectable and AMI IDs are never pinned.
+Login user: `ec2-user` on OL, `rocky` on Rocky (the images keep their distro's
+cloud-init default user, matching what the molecule scenarios already use). "Latest"
 is the newest `role=ppg-package-test` AMI by `CreationDate` (no SSM parameter).
 
 ## Housekeeping (all via `just`, fail-safe)
@@ -69,12 +93,14 @@ just prune-stale         # raw/candidate intermediates + orphans;    add 1 to de
 just prune-all           # prune-test + prune-stale
 just teardown-temp       # temp builder/vmimport/key/SG;             add 1 to delete
 just ci-validate         # trigger the GHA workflow matrix (env=test)
+just ci-seed-rocky       # dispatch all six Rocky seeds (env=prod; every combo must be seeded once)
 ```
 
-## Consumer lookup (replaces hardcoded IDs)
+## Job AMI lookup (replaces hardcoded IDs)
 
 `vars/moleculeEnvPPG.groovy` resolves each Oracle target at pipeline time
-(fail-closed: the job aborts if no base AMI is found):
+(fail-closed: the job aborts if no base AMI is found). A follow-up PR switches
+the pg.cd jobs' Rocky targets to the same lookup with `Name=tag:os,Values=rocky`:
 
 ```bash
 ami_ol9_x86_64=$(aws ec2 describe-images --region eu-central-1 --owners self \
@@ -89,11 +115,12 @@ ami_ol9_x86_64=$(aws ec2 describe-images --region eu-central-1 --owners self \
 `scripts/validate.sh` runs as the last provisioner; any failure aborts the build
 so a broken/mislabeled image is never registered:
 
-1. `/etc/oracle-release` major matches the target (fidelity).
+1. `/etc/os-release` `ID` + `VERSION_ID` major match the target (fidelity, release-file names cannot tell EL distros apart).
 2. `uname -m` matches the target arch.
-3. `ol<major>_codeready_builder` repo is defined (PG CRB deps resolvable).
+3. The CRB repo is defined: `ol<major>_codeready_builder` (OL), `powertools`
+   (Rocky 8) or `crb` (Rocky 9/10). PG -devel deps resolve from it.
 4. `cloud-init` present.
-5. SELinux `enforcing` in `/etc/selinux/config` (fail-closed; stock OL ships enforcing).
+5. SELinux `enforcing` in `/etc/selinux/config` (fail-closed, stock OL and Rocky ship enforcing).
 6. `dnf makecache` succeeds (repos healthy).
 
 De-instancing is native: Packer's `ssh_clear_authorized_keys` strips the temp key,

--- a/ppg/packer/justfile
+++ b/ppg/packer/justfile
@@ -1,4 +1,4 @@
-# Oracle Linux AMI factory - local build management.
+# EL AMI factory (Oracle Linux + Rocky Linux) - local build management.
 #
 # Runs the SAME packer template + scripts the GitHub Actions workflow uses, so an
 # AMI built locally is identical to a CI-built one. Recipes are parameterized by
@@ -21,7 +21,9 @@ region          := "eu-central-1"
 profile         := env_var_or_default("AWS_PROFILE", "percona-dev-admin")
 
 # --- factory identity: SINGLE SOURCE OF TRUTH (retag here to lift this dir to another product) ---
-os_name         := "oraclelinux"
+os_name         := "oraclelinux"                # OL identity for the OL10 bootstrap path (refresh recipes take an os arg)
+os_list         := "oraclelinux rocky"          # refresh os dimension, space-separated (recipe loops)
+os_csv          := "oraclelinux,rocky"          # same dimension, comma-separated (describe-images OR filters)
 billing_tag     := "ppg-ami-factory"            # iit-billing-tag value (cost attribution + IAM fence)
 role_prod       := "ppg-package-test"           # promoted role the pg.cd consumer selects
 role_test       := "ppg-test-package-test"      # isolated promoted role for env=test bakes
@@ -36,7 +38,7 @@ boottest_sg     := "ppg-ol10-boottest-sg"       # OL10 boot-test SSH security gr
 # --- build matrix dimensions ---
 os_majors       := "8 9 10"
 arches          := "x86_64 arm64"
-root_gib        := "20"                          # reimage target root GiB; MUST match var.volume_size in oracle-linux.pkr.hcl
+root_gib        := "20"                          # reimage target root GiB, MUST match var.volume_size in refresh.pkr.hcl
 
 # common create-tags / role-tags set (billing only), reused everywhere
 common_tags     := "Key=iit-billing-tag,Value=" + billing_tag
@@ -106,7 +108,7 @@ _prune-by-filter apply +filters:
     done
 
 # ===========================================================================
-# packer build / validate (OL8/9 refresh + OL10 once bootstrapped)
+# packer build / validate (OL + Rocky refresh, Rocky lineage roots via seed-rocky)
 # ===========================================================================
 
 # install/upgrade the amazon plugin
@@ -120,109 +122,117 @@ fmt:
     packer fmt reimage
     packer fmt bootstrap
 
-# validate one combo  (maj=8|9|10  arch=x86_64|arm64)
-validate maj="9" arch="x86_64":
-    packer validate -var os_major={{maj}} -var arch={{arch}} .
+# validate one combo  (maj=8|9|10  arch=x86_64|arm64  os=oraclelinux|rocky)
+validate maj="9" arch="x86_64" os="oraclelinux":
+    packer validate -var os={{os}} -var os_major={{maj}} -var arch={{arch}} .
 
-# validate every OL major x arch combo + the smoke template
-validate-all:
-    #!/usr/bin/env bash
-    set -euo pipefail
-    packer init . >/dev/null
-    for m in {{os_majors}}; do for a in {{arches}}; do
-      echo "validate OL$m $a"; packer validate -var os_major=$m -var arch=$a .
-    done; done
-    ( cd smoke && packer init . >/dev/null && packer validate -var candidate_ami=ami-00000000000000000 -var os_major=9 -var arch=x86_64 . )
-    ( cd reimage && packer init . >/dev/null && packer validate -var arch=x86_64 . )
-    ( cd bootstrap && packer init . >/dev/null && packer validate -var raw_ami=ami-00000000000000000 -var arch=x86_64 . )
-
-# fmt-check + validate everything + actionlint the GHA workflow (CI gate, no AWS)
+# fmt-check + validate everything + drift guards (scripts/check.sh, the SAME
+# file the workflow check job runs, so the two gates cannot drift) + actionlint
 check:
     #!/usr/bin/env bash
     set -euo pipefail
-    packer fmt -check -diff . && packer fmt -check -diff smoke && packer fmt -check -diff reimage && packer fmt -check -diff bootstrap
-    just validate-all
-    command -v actionlint >/dev/null && actionlint ../../.github/workflows/ppg-oracle-ami-factory.yml || echo "actionlint not installed; skipping workflow lint"
-    # drift guard: {{root_gib}} must equal var.volume_size in BOTH the refresh + reimage templates
-    # (reimage-surgery partitions root to {{root_gib}}; a mismatch sizes the AMI wrong for the refresh).
-    vs=$(awk '/variable "volume_size"/{f=1} f&&/default/{gsub(/[^0-9]/,"");print;exit}' oracle-linux.pkr.hcl)
-    rvs=$(awk '/variable "volume_size"/{f=1} f&&/default/{gsub(/[^0-9]/,"");print;exit}' reimage/reimage-ol10.pkr.hcl)
-    { [ "$vs" = "{{root_gib}}" ] && [ "$rvs" = "{{root_gib}}" ]; } || { echo "DRIFT: root_gib={{root_gib}} != refresh=$vs / reimage=$rvs"; exit 1; }
-    # plugin-pin parity: the amazon plugin must be pinned to ONE version across every template, so a
-    # supply-chain bump is all-or-nothing instead of drifting silently per-file.
-    amazon_pin() { awk '/hashicorp\/amazon/{f=1} f&&/version =/{gsub(/[^0-9.]/,"");print;exit}' "$1"; }
-    pins=$(for f in oracle-linux.pkr.hcl smoke/smoke.pkr.hcl reimage/reimage-ol10.pkr.hcl bootstrap/finalize-ol10.pkr.hcl; do amazon_pin "$f"; done)
-    n=$(printf '%s\n' "$pins" | grep -c .); u=$(printf '%s\n' "$pins" | sort -u | grep -c .)
-    { [ "$n" -eq 4 ] && [ "$u" -eq 1 ]; } || { echo "DRIFT: amazon plugin pin not uniform across the 4 templates:"; printf '%s\n' "$pins"; exit 1; }
-    echo "check OK"
+    bash scripts/check.sh
 
-# trigger the GHA factory workflow for the full matrix (drive CI from just). Targets the
-# current repo's origin; env=test isolates from the pg.cd consumer (use for validation).
-[doc("trigger the GHA factory workflow matrix (env=test; isolated from the pg.cd consumer)")]
+    if command -v actionlint >/dev/null; then
+      actionlint ../../.github/workflows/ppg-ami-factory.yml
+    else
+      echo "actionlint not installed; skipping workflow lint"
+    fi
+
+# trigger the GHA factory workflow for the FULL os x major x arch matrix, derived
+# from the dimension constants above so it never drifts from them. Targets the
+# current repo's origin; env=test isolates from the pg.cd jobs (use for validation).
+[doc("trigger the GHA factory workflow for the full 12-combo matrix (env=test isolates)")]
 ci-validate ref="master" env="test":
-    gh workflow run ppg-oracle-ami-factory.yml --ref {{ref}} -f env={{env}} \
-      -f combos='[{"os_major":"8","arch":"x86_64"},{"os_major":"8","arch":"arm64"},{"os_major":"9","arch":"x86_64"},{"os_major":"9","arch":"arm64"},{"os_major":"10","arch":"x86_64"},{"os_major":"10","arch":"arm64"}]'
-    @echo "dispatched on {{ref}} (env={{env}}); list runs: gh run list --workflow ppg-oracle-ami-factory.yml -L1"
+    #!/usr/bin/env bash
+    set -euo pipefail
+    combos=$(python3 -c "import json,sys; oses,majors,arches=(part.split() for part in sys.argv[1:4]); print(json.dumps([{'os':os_name,'os_major':major,'arch':arch} for os_name in oses for major in majors for arch in arches]))" "{{os_list}}" "{{os_majors}}" "{{arches}}")
+    gh workflow run ppg-ami-factory.yml --ref "{{ref}}" -f "env={{env}}" -f "combos=${combos}"
+    echo "dispatched {{ref}} (env={{env}}) with the full matrix; list runs: gh run list --workflow ppg-ami-factory.yml -L1"
+
+# dispatch the GHA workflow to seed the six Rocky lineage roots. Defaults to
+# env=prod like seed-rocky: a test seed promotes only the isolated test role,
+# which the prod-role refresh lineage lookup never sees (env=test validates only).
+[doc("dispatch the GHA workflow to seed all six Rocky lineage roots (env=prod|test)")]
+ci-seed-rocky ref="master" env="prod":
+    gh workflow run ppg-ami-factory.yml --ref {{ref}} -f env={{env}} \
+      -f combos='[{"os":"rocky","os_major":"8","arch":"x86_64","seed":true},{"os":"rocky","os_major":"8","arch":"arm64","seed":true},{"os":"rocky","os_major":"9","arch":"x86_64","seed":true},{"os":"rocky","os_major":"9","arch":"arm64","seed":true},{"os":"rocky","os_major":"10","arch":"x86_64","seed":true},{"os":"rocky","os_major":"10","arch":"arm64","seed":true}]'
+    @echo "dispatched Rocky seeds on {{ref}} (env={{env}}); list runs: gh run list --workflow ppg-ami-factory.yml -L1"
 
 # build one combo  (env=prod real tags | test isolated tags)  -- candidate only, no promote
-build maj="9" arch="x86_64" env="prod":
+build maj="9" arch="x86_64" env="prod" os="oraclelinux" seed="false":
     #!/usr/bin/env bash
     set -euo pipefail
     eval "$(aws configure export-credentials --profile {{profile}} --format env)"; unset AWS_PROFILE
     rm -f manifest.json
     AWS_REGION={{region}} packer build -color=false \
-      -var os_major={{maj}} -var arch={{arch}} -var env={{env}} -var region={{region}} .
+      -var os={{os}} -var seed={{seed}} -var os_major={{maj}} -var arch={{arch}} -var env={{env}} -var region={{region}} .
 
 # smoke-test (boot+install) an already-built AMI, then promote on success.
 # Promotion is a SEPARATE retried step: deregister ONLY on a real boot/install
 # failure, never on a transient promote-tag failure.
 [doc("smoke-test (boot+install) an AMI then promote on pass; deregister only on real failure")]
-smoke ami maj arch promote_role=role_prod:
+smoke ami maj arch promote_role=role_prod os="oraclelinux":
     #!/usr/bin/env bash
     set -euo pipefail
     eval "$(aws configure export-credentials --profile {{profile}} --format env)"; unset AWS_PROFILE
     ( cd smoke && packer init . >/dev/null && \
-      packer build -color=false -var candidate_ami={{ami}} -var os_major={{maj}} -var arch={{arch}} \
+      packer build -color=false -var candidate_ami={{ami}} -var os={{os}} -var os_major={{maj}} -var arch={{arch}} \
         -var region={{region}} . ) \
       || { echo "smoke (boot+install) failed; deregistering {{ami}}"; just _deregister {{ami}}; exit 1; }
     just _promote {{ami}} {{promote_role}}
 
 # full one-combo factory run: build (env) -> native smoke boot-test -> promote
-bake maj="9" arch="x86_64" env="prod":
+bake maj="9" arch="x86_64" env="prod" os="oraclelinux" seed="false":
     #!/usr/bin/env bash
     set -euo pipefail
     eval "$(aws configure export-credentials --profile {{profile}} --format env)"; unset AWS_PROFILE
     rm -f manifest.json
     AWS_REGION={{region}} packer build -color=false \
-      -var os_major={{maj}} -var arch={{arch}} -var env={{env}} -var region={{region}} .
+      -var os={{os}} -var seed={{seed}} -var os_major={{maj}} -var arch={{arch}} -var env={{env}} -var region={{region}} .
     AMI=$(python3 -c "import json;print(json.load(open('manifest.json'))['builds'][-1]['artifact_id'].split(':')[-1])")
-    pr={{role_prod}}; [ "{{env}}" = "test" ] && pr={{role_test}}
-    echo "smoke (boot+install) $AMI"
-    ( cd smoke && packer init . >/dev/null && packer build -color=false \
-        -var candidate_ami=$AMI -var os_major={{maj}} -var arch={{arch}} -var region={{region}} . ) \
-      || { echo "smoke (boot+install) failed; deregistering $AMI"; just _deregister $AMI; exit 1; }
-    just _promote $AMI $pr
+    promote_role={{role_prod}}
+    [[ "{{env}}" = "test" ]] && promote_role={{role_test}}
+    just smoke "$AMI" {{maj}} {{arch}} "$promote_role" {{os}}
 
 # isolated TEST bake of one combo (env=test) - never consumed by pg.cd
-test maj="9" arch="x86_64":
-    @just bake {{maj}} {{arch}} test
+test maj="9" arch="x86_64" os="oraclelinux":
+    @just bake {{maj}} {{arch}} test {{os}}
+
+# one-time per combo: seed a Rocky lineage root from the official community AMI
+# (owner 792107900819, include_deprecated covers the frozen and AWS-deprecated Rocky 8),
+# then smoke + promote. After this, `just bake <maj> <arch> prod rocky` refreshes it.
+# Defaults to env=prod like `bake`: a test seed promotes only the isolated test
+# role, which the refresh lineage lookup (pinned to the prod role) never sees.
+[doc("seed a Rocky lineage root from the official community AMI: bake + smoke + promote (env=test isolates)")]
+seed-rocky maj="9" arch="x86_64" env="prod":
+    @just bake {{maj}} {{arch}} {{env}} rocky true
 
 # build + promote ALL OL major x arch  (env=prod by default; pass test for isolated).
 # Resilient: a failed combo is recorded and the rest still run; exits non-zero with a
 # summary if any combo failed (each combo's own deregister-on-smoke-failure still applies).
-[doc("build + promote every OL major x arch (env=prod|test); resilient, non-zero if any combo fails")]
-all env="prod":
+[doc("build + promote every major x arch for one os (env=prod|test); resilient, non-zero if any combo fails")]
+all env="prod" os="oraclelinux":
     #!/usr/bin/env bash
     set -uo pipefail
-    ok=""; fail=""
-    for m in {{os_majors}}; do for a in {{arches}}; do
-      echo "=========== bake OL$m $a (env={{env}}) ==========="
-      if just bake $m $a {{env}}; then ok="$ok OL$m-$a"; else fail="$fail OL$m-$a"; fi
-    done; done
+    ok=""
+    fail=""
+
+    for major in {{os_majors}}; do
+      for arch in {{arches}}; do
+        echo "=========== bake {{os}} ${major} ${arch} (env={{env}}) ==========="
+
+        if just bake "${major}" "${arch}" {{env}} {{os}}; then
+          ok="${ok} {{os}}${major}-${arch}"
+        else
+          fail="${fail} {{os}}${major}-${arch}"
+        fi
+      done
+    done
     echo "=========== summary (env={{env}}) ==========="
     echo "  ok:    ${ok:- none}"
     echo "  failed:${fail:- none}"
-    [ -z "$fail" ] || exit 1
+    [[ -z "${fail}" ]] || exit 1
 
 # list factory AMIs for an env (prod|test) with role + creation date
 list env="prod":
@@ -232,9 +242,9 @@ list env="prod":
       --output table
 
 # resolve the newest promoted AMI for a combo (exactly what moleculeEnvPPG does)
-latest maj="9" arch="x86_64" role=role_prod:
+latest maj="9" arch="x86_64" role=role_prod os="oraclelinux":
     aws ec2 describe-images --profile {{profile}} --region {{region}} --owners self \
-      --filters Name=tag:role,Values={{role}} Name=tag:os,Values={{os_name}} \
+      --filters Name=tag:role,Values={{role}} Name=tag:os,Values={{os}} \
                 Name=tag:os_major,Values={{maj}} Name=tag:arch,Values={{arch}} Name=state,Values=available \
       --query 'sort_by(Images,&CreationDate)[-1].ImageId' --output text
 
@@ -243,8 +253,8 @@ prune-test apply="0":
     @echo "prune-test (apply={{apply}}; lists unless apply=1):"
     @just _prune-by-filter "{{apply}}" --filters Name=tag:factory_env,Values=test
 
-# deregister stale factory intermediates: factory-owned OL AMIs (selected by the
-# {{billing_tag}} + {{os_name}} VARIABLES, not by role name) that are neither the
+# deregister stale factory intermediates: factory-owned OL/Rocky AMIs (selected by
+# the {{billing_tag}} + {{os_csv}} VARIABLES, not by role name) that are neither the
 # promoted prod base (role={{role_prod}}) nor an isolated test AMI (factory_env=test).
 # Selecting by factory-ownership instead of enumerating role literals catches every
 # transient (raw, refresh/bootstrap candidates, renamed orphans) and never drifts as
@@ -255,7 +265,7 @@ prune-stale apply="0":
     set -euo pipefail
     echo "prune-stale (apply={{apply}}; lists unless apply=1):"
     ids=$(aws ec2 describe-images --profile {{profile}} --region {{region}} --owners self \
-      --filters Name=tag:iit-billing-tag,Values={{billing_tag}} Name=tag:os,Values={{os_name}} \
+      --filters Name=tag:iit-billing-tag,Values={{billing_tag}} Name=tag:os,Values={{os_csv}} \
       --query 'Images[].ImageId' --output text)
     [ -z "$ids" ] && { echo "  (no factory AMIs)"; exit 0; }
     for ami in $ids; do
@@ -286,14 +296,27 @@ prune-superseded apply="0":
     set -euo pipefail
     echo "prune-superseded (apply={{apply}}; lists unless apply=1):"
     aws ec2 describe-images --profile {{profile}} --region {{region}} --owners self \
-      --filters Name=tag:role,Values={{role_prod}} Name=tag:os,Values={{os_name}} Name=state,Values=available \
-      --query "reverse(sort_by(Images,&CreationDate))[].[ImageId, Tags[?Key=='os_major']|[0].Value, Tags[?Key=='arch']|[0].Value]" --output text \
-      | { declare -A keep; while read -r id maj arch; do
-            [ -z "$id" ] && continue
-            { [ "$maj" = None ] || [ "$arch" = None ]; } && { echo "  SKIP $id (untagged maj/arch)"; continue; }
-            k="$maj/$arch"
-            if [ -z "${keep[$k]:-}" ]; then keep[$k]=$id; echo "  KEEP $id (OL$maj $arch, newest)"; continue; fi
-            if [ "{{apply}}" = "1" ]; then echo "  deregister $id (OL$maj $arch, superseded)"; just _deregister "$id"; else echo "  would deregister $id (OL$maj $arch, superseded)"; fi
+      --filters Name=tag:role,Values={{role_prod}} Name=tag:os,Values={{os_csv}} Name=state,Values=available \
+      --query "reverse(sort_by(Images,&CreationDate))[].[ImageId, Tags[?Key=='os']|[0].Value, Tags[?Key=='os_major']|[0].Value, Tags[?Key=='arch']|[0].Value]" --output text \
+      | { declare -A keep
+
+          while read -r ami_id os_name major arch; do
+            [[ -z "${ami_id}" ]] && continue
+            [[ "${os_name}" = None || "${major}" = None || "${arch}" = None ]] && { echo "  SKIP ${ami_id} (untagged os/major/arch)"; continue; }
+            combo_key="${os_name}/${major}/${arch}"
+
+            if [[ -z "${keep[${combo_key}]:-}" ]]; then
+              keep[${combo_key}]=${ami_id}
+              echo "  KEEP ${ami_id} (${os_name}${major} ${arch}, newest)"
+              continue
+            fi
+
+            if [[ "{{apply}}" = "1" ]]; then
+              echo "  deregister ${ami_id} (${os_name}${major} ${arch}, superseded)"
+              just _deregister "${ami_id}"
+            else
+              echo "  would deregister ${ami_id} (${os_name}${major} ${arch}, superseded)"
+            fi
           done; }
 
 # create the SSM builder instance profile locally (one-time, for local builds).

--- a/ppg/packer/refresh.pkr.hcl
+++ b/ppg/packer/refresh.pkr.hcl
@@ -1,22 +1,21 @@
-# Oracle Linux AMI factory (refresh path).
+# EL package-test AMI factory (refresh path): Oracle Linux + Rocky Linux.
 #
-# Rebakes a current Oracle Linux package-test target AMI from the latest
-# self-owned base of the same major+arch: launch -> dnf update -> validate
-# (fail-closed) -> snapshot. Replaces the manual launch/dnf/snapshot toil and
-# chains forward (each build's output is the next build's source).
+# Rebakes a current package-test target AMI from the latest self-owned base of
+# the same os+major+arch: launch -> dnf update -> validate (fail-closed) ->
+# snapshot. Replaces the manual launch/dnf/snapshot toil and chains forward
+# (each build's output is the next build's source).
 #
 # Usage (one combo per invocation):
 #   packer init .
-#   packer build -var os_major=9 -var arch=x86_64 .
-#   packer build -var os_major=9 -var arch=arm64  .
-#   packer build -var os_major=8 -var arch=x86_64 .
-#   packer build -var os_major=8 -var arch=arm64  .
-#   packer build -var os_major=10 -var arch=x86_64 .
-#   packer build -var os_major=10 -var arch=arm64  .
+#   packer build -var os=oraclelinux -var os_major=9 -var arch=x86_64 .
+#   packer build -var os=rocky -var os_major=9 -var arch=arm64 .
 #
-# OL10's lineage-root base is created once per arch by scripts/bootstrap-ol10.sh
-# (imports Oracle's official OL10 cloud image, finalizes ec2-user + ssm-agent);
-# after it is tagged role=ppg-package-test, OL10 refreshes here exactly like OL8/9.
+# Lineage roots (the first self-owned base each refresh chain grows from):
+#   - OL8/9: pre-existing self-owned bases. OL10: scripts/bootstrap-ol10.sh
+#     (imports Oracle's official cloud image, no OL10 AMI exists on AWS).
+#   - Rocky 8/9/10: seed once per major+arch with `-var seed=true`, which
+#     sources the official Rocky community AMI instead of the self-owned
+#     lineage. Once the seed is promoted, Rocky refreshes here exactly like OL.
 
 packer {
   required_plugins {
@@ -61,6 +60,21 @@ variable "arch" {
   }
 }
 
+variable "os" {
+  type    = string # "oraclelinux" | "rocky"
+  default = "oraclelinux"
+  validation {
+    condition     = contains(["oraclelinux", "rocky"], var.os)
+    error_message = "Value of os must be oraclelinux or rocky."
+  }
+}
+
+variable "seed" {
+  type        = bool
+  default     = false
+  description = "First bake per combo (Rocky only): source the official upstream AMI instead of the self-owned lineage base. After the seed is promoted, the normal refresh takes over."
+}
+
 variable "volume_size" {
   type    = number
   default = 20
@@ -98,8 +112,52 @@ locals {
   # role=ppg-package-test, source=factory) never picks them up.
   candidate_role = var.env == "test" ? "ppg-test-candidate" : "ppg-candidate"
   src_tag        = var.env == "test" ? "factory-test" : "factory"
-  name_prefix    = var.env == "test" ? "TEST-OL" : "OL"
-  ami_name       = "${local.name_prefix}${var.os_major}-${var.arch}-${local.ts}"
+  os_short       = var.os == "rocky" ? "Rocky" : "OL"
+  # Rocky cloud images create "rocky" as the cloud-init default user (no
+  # ec2-user), and the temp Packer key lands on the default user. Keeping it
+  # also keeps the baked image drop-in for the molecule scenarios, which
+  # already log in as "rocky" on rocky-* platforms.
+  ssh_user    = var.os == "rocky" ? "rocky" : "ec2-user"
+  name_prefix = var.env == "test" ? "TEST-${local.os_short}" : local.os_short
+  ami_name    = "${local.name_prefix}${var.os_major}-${var.arch}-${local.ts}"
+
+  # Seed source: the official Rocky community AMIs (owner 792107900819) are free
+  # of software fees and product codes, so they can root the lineage directly.
+  # include_deprecated is required for Rocky 8: in eu-central-1 the newest
+  # community-owner Rocky 8 AMI is 8.10-20240528, AWS-deprecated since
+  # 2026-05-31 (newer refreshes reached other regions or only Marketplace,
+  # whose product codes would propagate into derived AMIs). Launching a
+  # deprecated AMI still works, and the seed's dnf update absorbs the errata.
+  # Oracle Linux has no seedable upstream AMI (see scripts/bootstrap-ol10.sh).
+  # The impossible owner below makes `-var seed=true -var os=oraclelinux` fail
+  # loud ("no AMI found") instead of silently sourcing something wrong.
+  seed_owners = var.os == "rocky" ? ["792107900819"] : ["000000000000"]
+
+  # Filter keys shared by both source paths.
+  common_source_filters = {
+    architecture        = var.arch
+    root-device-type    = "ebs"
+    virtualization-type = "hvm"
+    state               = "available"
+  }
+
+  seed_filters = merge(local.common_source_filters, {
+    name = "Rocky-${var.os_major}-EC2-Base-*.${local.uname_arch}"
+  })
+
+  # Refresh source: latest self-owned base of the same os+major+arch, selected
+  # by FACTORY TAGS (not a name glob): a name glob could match a foreign or
+  # experimental self-owned image as AMIs accumulate, but tag selection only
+  # ever picks images this factory (or the tagged lineage root) produced.
+  # The role pin is env-blind by design: test bakes SOURCE the prod lineage
+  # (isolation applies to what they produce, not what they read), so a lineage
+  # root must be seeded with env=prod to be refreshable.
+  lineage_filters = merge(local.common_source_filters, {
+    "tag:os"       = var.os
+    "tag:os_major" = var.os_major
+    "tag:arch"     = var.arch
+    "tag:role"     = "ppg-package-test"
+  })
 
   # Bootstrap the SSM agent on the builder at boot so session_manager can
   # connect even though the Oracle Linux source AMI does not ship it (chicken-
@@ -114,7 +172,7 @@ locals {
   EOT
 }
 
-source "amazon-ebs" "ol" {
+source "amazon-ebs" "el" {
   region        = var.region
   instance_type = local.instance_type
   ami_name      = local.ami_name
@@ -123,7 +181,7 @@ source "amazon-ebs" "ol" {
   # no inbound SG, no public-key, works from a dynamic-egress GHA runner.
   # There is NO communicator="ssm"; this is the supported mechanism.
   communicator              = "ssh"
-  ssh_username              = "ec2-user"
+  ssh_username              = local.ssh_user
   ssh_interface             = "session_manager"
   ssh_timeout               = "12m"
   ssh_clear_authorized_keys = true # native: strip packer's temp key from the image
@@ -137,25 +195,13 @@ source "amazon-ebs" "ol" {
   # weekly images age out without a custom deregister-old sweep.
   deprecate_at = timeadd(timestamp(), "840h")
 
-  # Latest self-owned base of the same major+arch, selected by FACTORY TAGS
-  # (not a name glob): an `OL<major>*` glob could match a foreign or
-  # experimental self-owned image as AMIs accumulate, but tag selection only
-  # ever picks images this factory (or the tagged lineage base) produced.
-  # The clean lineage root is re-established periodically by bootstrap-ol*.sh
-  # (a source build from Oracle yum) so the chain never drifts unreproducibly.
+  # Refresh: latest self-owned lineage base (see local.lineage_filters).
+  # Seed (Rocky only): the official upstream AMI (see local.seed_filters).
   source_ami_filter {
-    filters = {
-      "tag:os"            = "oraclelinux"
-      "tag:os_major"      = var.os_major
-      "tag:arch"          = var.arch
-      "tag:role"          = "ppg-package-test"
-      architecture        = var.arch
-      root-device-type    = "ebs"
-      virtualization-type = "hvm"
-      state               = "available"
-    }
-    owners      = ["self"]
-    most_recent = true
+    filters            = var.seed ? local.seed_filters : local.lineage_filters
+    owners             = var.seed ? local.seed_owners : ["self"]
+    most_recent        = true
+    include_deprecated = var.seed # Rocky 8's official images are past their AWS DeprecationTime
   }
 
   subnet_id                   = var.subnet_id
@@ -178,7 +224,7 @@ source "amazon-ebs" "ol" {
   }
 
   run_tags = {
-    Name            = "packer-ppg-ol-factory"
+    Name            = "packer-ppg-ami-factory"
     iit-billing-tag = "ppg-ami-factory"
   }
   run_volume_tags = {
@@ -190,7 +236,7 @@ source "amazon-ebs" "ol" {
   # select). A non-booting image therefore never becomes selectable.
   tags = {
     Name            = local.ami_name
-    os              = "oraclelinux"
+    os              = var.os
     os_major        = var.os_major
     arch            = var.arch
     role            = local.candidate_role
@@ -211,8 +257,8 @@ source "amazon-ebs" "ol" {
 }
 
 build {
-  name    = "ppg-oracle-linux"
-  sources = ["source.amazon-ebs.ol"]
+  name    = "ppg-el-refresh"
+  sources = ["source.amazon-ebs.el"]
 
   provisioner "shell" {
     script = "${path.root}/scripts/provision.sh"
@@ -228,6 +274,7 @@ build {
   provisioner "shell" {
     script = "${path.root}/scripts/validate.sh"
     environment_vars = [
+      "OS=${var.os}",
       "OS_MAJOR=${var.os_major}",
       "UNAME_ARCH=${local.uname_arch}",
     ]
@@ -240,6 +287,7 @@ build {
     output     = "${path.root}/manifest.json"
     strip_path = true
     custom_data = {
+      os       = var.os
       os_major = var.os_major
       arch     = var.arch
       ami_name = local.ami_name

--- a/ppg/packer/scripts/check.sh
+++ b/ppg/packer/scripts/check.sh
@@ -1,0 +1,94 @@
+#!/bin/bash
+# Single no-AWS gate for the factory templates: fmt-check, validate every
+# os x major x arch combo (plus Rocky seed variants and the sub-templates),
+# and the drift guards. Run from ppg/packer. Both `just check` and the
+# workflow check job execute THIS file, so the two gates cannot drift apart.
+set -euo pipefail
+
+packer fmt -check -diff .
+packer fmt -check -diff smoke
+packer fmt -check -diff reimage
+packer fmt -check -diff bootstrap
+
+packer init .
+
+for os_name in oraclelinux rocky; do
+  for major in 8 9 10; do
+    for arch in x86_64 arm64; do
+      echo "validate ${os_name} ${major} ${arch}"
+      packer validate -var "os=${os_name}" -var "os_major=${major}" -var "arch=${arch}" .
+    done
+  done
+done
+
+for major in 8 9 10; do
+  for arch in x86_64 arm64; do
+    echo "validate rocky seed ${major} ${arch}"
+    packer validate -var os=rocky -var seed=true -var "os_major=${major}" -var "arch=${arch}" .
+  done
+done
+
+(
+  cd smoke
+  packer init .
+  packer validate -var candidate_ami=ami-00000000000000000 -var os=oraclelinux -var os_major=9 -var arch=x86_64 .
+  packer validate -var candidate_ami=ami-00000000000000000 -var os=rocky -var os_major=8 -var arch=x86_64 .
+)
+
+(
+  cd reimage
+  packer init .
+  packer validate -var arch=x86_64 .
+)
+
+(
+  cd bootstrap
+  packer init .
+  packer validate -var raw_ami=ami-00000000000000000 -var arch=x86_64 .
+)
+
+# Drift guards: root_gib must equal var.volume_size in BOTH the refresh and
+# reimage templates, else a reimaged base would be the wrong root size for the
+# refresh to launch.
+root_gib=$(awk -F'"' '/^root_gib[[:space:]]*:=/{print $2; exit}' justfile)
+refresh_size=$(awk '/variable "volume_size"/{f=1} f&&/default/{gsub(/[^0-9]/,"");print;exit}' refresh.pkr.hcl)
+reimage_size=$(awk '/variable "volume_size"/{f=1} f&&/default/{gsub(/[^0-9]/,"");print;exit}' reimage/reimage-ol10.pkr.hcl)
+
+if [[ -z "${root_gib}" || "${root_gib}" != "${refresh_size}" || "${root_gib}" != "${reimage_size}" ]]; then
+  echo "DRIFT: root_gib=${root_gib} != refresh=${refresh_size} / reimage=${reimage_size}" >&2
+  exit 1
+fi
+
+# Packer HCL escapes ONLY $${ (and %%{). A bare $$ before anything else passes
+# through literally and the target shell then expands $$ to its process id,
+# which broke the smoke identity check once. Fail on any $$ not followed by {.
+for template in refresh.pkr.hcl smoke/smoke.pkr.hcl reimage/reimage-ol10.pkr.hcl bootstrap/finalize-ol10.pkr.hcl; do
+  # shellcheck disable=SC2016  # the regex must stay literal, no expansion wanted
+  if grep -nE '\$\$([^{]|$)' "${template}"; then
+    echo "DRIFT: bare \$\$ in ${template} renders literally and the shell expands it to a PID; use \$\${...} for shell expansions" >&2
+    exit 1
+  fi
+done
+
+# The amazon plugin must be pinned to ONE version across every template, so a
+# supply-chain bump is all-or-nothing instead of drifting silently per file.
+amazon_pin() {
+  awk '/hashicorp\/amazon/{f=1} f&&/version =/{gsub(/[^0-9.]/,"");print;exit}' "$1"
+}
+
+pins=""
+
+for template in refresh.pkr.hcl smoke/smoke.pkr.hcl reimage/reimage-ol10.pkr.hcl bootstrap/finalize-ol10.pkr.hcl; do
+  pins+="$(amazon_pin "${template}")"$'\n'
+done
+
+pin_count=$(printf '%s' "${pins}" | grep -c .)
+unique_pins=$(printf '%s' "${pins}" | sort -u | grep -c .)
+
+if [[ "${pin_count}" -ne 4 || "${unique_pins}" -ne 1 ]]; then
+  echo "DRIFT: amazon plugin pin not uniform across the 4 templates:" >&2
+  printf '%s' "${pins}" >&2
+  exit 1
+fi
+
+echo "check OK"

--- a/ppg/packer/scripts/validate.sh
+++ b/ppg/packer/scripts/validate.sh
@@ -1,58 +1,84 @@
 #!/usr/bin/env bash
-# Fail-closed identity/health gates for an Oracle Linux package-test
-# target AMI. Runs as the LAST provisioner: any non-zero exit aborts the build
-# so a broken or mislabeled image is never registered. De-instancing is native
-# (see the tail note): Packer clears the temp key and cloud-init re-seeds on boot.
+# Fail-closed identity/health gates for an Oracle Linux / Rocky Linux
+# package-test target AMI. Runs as the LAST provisioner: any non-zero exit
+# aborts the build so a broken or mislabeled image is never registered.
+# De-instancing is native (see the tail note): Packer clears the temp key and
+# cloud-init re-seeds on boot.
 #
-# Env (from packer): OS_MAJOR (8|9|10), UNAME_ARCH (x86_64|aarch64)
+# Env (from packer): OS (oraclelinux|rocky, defaulting to oraclelinux so the OL10
+# bootstrap/reimage callers stay unchanged), OS_MAJOR (8|9|10), UNAME_ARCH
+# (x86_64|aarch64)
 set -euo pipefail
 
 : "${OS_MAJOR:?OS_MAJOR not set}"
 : "${UNAME_ARCH:?UNAME_ARCH not set}"
+: "${OS:=oraclelinux}"
 
 fail() { echo "VALIDATE FAIL: $*" >&2; exit 1; }
 
 . /etc/os-release
-echo "VALIDATE: ${PRETTY_NAME:-?} $(uname -m) (want OL${OS_MAJOR} / ${UNAME_ARCH})"
+echo "VALIDATE: ${PRETTY_NAME:-?} $(uname -m) (want ${OS} ${OS_MAJOR} / ${UNAME_ARCH})"
 
-# 1. Genuine Oracle Linux of the expected major (fidelity gate).
-[ -f /etc/oracle-release ] || fail "no /etc/oracle-release (not Oracle Linux)"
-grep -Eq "release[[:space:]]+${OS_MAJOR}\." /etc/oracle-release \
-  || fail "oracle-release major != ${OS_MAJOR}: $(cat /etc/oracle-release)"
+# 1. Genuine OS of the expected major (fidelity gate). Keyed on /etc/os-release
+#    ID + VERSION_ID (sourced above): distro release-file names cannot tell EL
+#    distros apart once more are added (every clone ships /etc/redhat-release).
+case "${OS}" in
+  oraclelinux) expected_id=ol ;;
+  rocky)       expected_id=rocky ;;
+  *)           fail "unknown OS '${OS}' (want oraclelinux|rocky)" ;;
+esac
+
+[[ "${ID:-}" = "${expected_id}" ]] || fail "os-release ID '${ID:-}' != '${expected_id}'"
+os_major_found="${VERSION_ID:-}"
+os_major_found="${os_major_found%%.*}"
+[[ "${os_major_found}" = "${OS_MAJOR}" ]] \
+  || fail "os-release major '${os_major_found}' != '${OS_MAJOR}' (VERSION_ID='${VERSION_ID:-}')"
 
 # 2. Architecture matches the target.
-[ "$(uname -m)" = "${UNAME_ARCH}" ] || fail "arch $(uname -m) != ${UNAME_ARCH}"
+[[ "$(uname -m)" = "${UNAME_ARCH}" ]] || fail "arch $(uname -m) != ${UNAME_ARCH}"
 
-# 3. CodeReady Builder repo must RESOLVE packages (PG -devel deps need it). It is
-#    disabled by default on Oracle Linux; enable it just for the query and assert
-#    it returns packages (defined-but-404 would pass a mere repolist grep).
-crb="ol${OS_MAJOR}_codeready_builder"
-# The CRB repo must be DEFINED on the image (it is disabled by default). The
-# AUTHORITATIVE resolvability check is the smoke test, which enables CRB and
-# actually installs percona-postgresql17-server (pulls CRB deps); a builder-side
-# repoquery proved fragile (disabled-repo metadata not fetched), so this gate
-# only asserts the repo exists.
-dnf repolist --all 2>/dev/null | grep -qiE "codeready" \
-  || fail "CRB repo ($crb) not defined on image"
-echo "  CRB ok: repo defined ($crb)"
+# 3. The CRB repo must be DEFINED on the image (disabled by default, and PG
+#    -devel deps need it). One mapping per distro/major, one anchored grep. The
+#    AUTHORITATIVE resolvability check is the smoke test, which enables it and
+#    actually installs percona-postgresql17-server. A builder-side repoquery
+#    proved fragile (disabled-repo metadata not fetched), so this gate only
+#    asserts the repo exists.
+case "${OS}/${OS_MAJOR}" in
+  oraclelinux/*) crb="ol${OS_MAJOR}_codeready_builder" ;;
+  rocky/8)       crb="powertools" ;;
+  rocky/*)       crb="crb" ;;
+  *)             fail "no CRB mapping for ${OS}/${OS_MAJOR}" ;;
+esac
+
+dnf repolist --all 2>/dev/null | grep -qiE "^${crb}([[:space:]]|$)" \
+  || fail "CRB repo (${crb}) not defined on image"
+echo "  CRB ok: repo defined (${crb})"
 
 # 4. cloud-init present (instance bootstrap).
 command -v cloud-init >/dev/null 2>&1 || fail "cloud-init missing"
 
-# 5. SELinux configured enforcing (fail-closed fidelity gate; stock OL ships enforcing).
+# 5. SELinux configured enforcing (fail-closed fidelity gate, stock OL and Rocky ship enforcing).
 grep -Eq "^SELINUX=enforcing" /etc/selinux/config 2>/dev/null \
   || fail "SELINUX not 'enforcing' in /etc/selinux/config"
 
 # 6. dnf metadata is fresh enough to confirm the refresh ran.
 dnf -q makecache >/dev/null 2>&1 || fail "dnf makecache failed (broken repos)"
 
-# 7. Refresh actually applied: count packages still upgradable (informational;
-#    provision.sh runs `dnf -y update` under set -e, so a hard failure aborts there).
-upd=$(dnf -q check-update 2>/dev/null | grep -cE '^[A-Za-z0-9]' || true)
-[ "${upd:-0}" -eq 0 ] && echo "  update ok: 0 packages upgradable" \
-  || echo "VALIDATE WARN: ${upd} packages still upgradable after dnf update"
+# 7. Refresh actually applied: list what is still upgradable (informational;
+#    provision.sh runs `dnf -y update` under set -e, so a hard failure aborts
+#    there). The Obsoleting Packages section and "Security: ..." advisory
+#    notices (installed-vs-running kernel on the never-rebooted builder) are
+#    excluded: neither is a pending upgrade, but a bare count included them.
+pending=$(dnf -q check-update 2>/dev/null | sed '/^Obsoleting Packages/,$d' | grep -E '^[A-Za-z0-9]' | grep -vE '^Security: ' || true)
 
-echo "VALIDATE OK: OL${OS_MAJOR} ${UNAME_ARCH}"
+if [[ -z "${pending}" ]]; then
+  echo "  update ok: 0 packages upgradable"
+else
+  echo "VALIDATE WARN: packages still upgradable after dnf update:"
+  printf '%s\n' "${pending}"
+fi
+
+echo "VALIDATE OK: ${OS} ${OS_MAJOR} ${UNAME_ARCH}"
 # De-instancing is native now: packer `ssh_clear_authorized_keys` strips the temp
 # key, and cloud-init's default `ssh_deletekeys: true` regenerates host keys on
 # first boot. provision.sh already ran `cloud-init clean` + reset machine-id.

--- a/ppg/packer/smoke/smoke.pkr.hcl
+++ b/ppg/packer/smoke/smoke.pkr.hcl
@@ -9,7 +9,7 @@
 # retried step ONLY after a pass, so a transient promote-tag failure can never
 # delete a smoke-passed AMI.
 #
-#   packer init . && packer build -var candidate_ami=ami-... -var os_major=9 -var arch=x86_64 .
+#   packer init . && packer build -var candidate_ami=ami-... -var os=rocky -var os_major=9 -var arch=x86_64 .
 
 packer {
   required_plugins {
@@ -21,6 +21,14 @@ packer {
 }
 
 variable "candidate_ami" { type = string }
+variable "os" {
+  type    = string # "oraclelinux" | "rocky"
+  default = "oraclelinux"
+  validation {
+    condition     = contains(["oraclelinux", "rocky"], var.os)
+    error_message = "Value of os must be oraclelinux or rocky."
+  }
+}
 variable "os_major" { type = string }
 variable "arch" { type = string } # x86_64 | arm64
 variable "region" {
@@ -43,6 +51,13 @@ variable "builder_security_group_name" {
 locals {
   instance_type = var.arch == "arm64" ? "t4g.large" : "t3.large"
   uname_arch    = var.arch == "arm64" ? "aarch64" : "x86_64"
+  # Identity via /etc/os-release ID (release-file names cannot tell EL distros
+  # apart once more are added: every clone ships /etc/redhat-release).
+  expected_id = var.os == "rocky" ? "rocky" : "ol"
+  # Rocky images use "rocky" as the cloud-init default user, OL uses ec2-user.
+  ssh_user = var.os == "rocky" ? "rocky" : "ec2-user"
+  # CRB naming differs per distro: OL "ol<major>_codeready_builder", Rocky "powertools" (8) / "crb" (9/10).
+  crb_repo = var.os == "rocky" ? (var.os_major == "8" ? "powertools" : "crb") : "ol${var.os_major}_codeready_builder"
 }
 
 source "amazon-ebs" "smoke" {
@@ -50,10 +65,10 @@ source "amazon-ebs" "smoke" {
   instance_type = local.instance_type
   source_ami    = var.candidate_ami
   # ami_name is required by the builder even though we create nothing.
-  ami_name                    = "ppg-smoke-noop-${var.os_major}-${var.arch}"
+  ami_name                    = "ppg-smoke-noop-${var.os}-${var.os_major}-${var.arch}"
   skip_create_ami             = true # boot-test only; produce no image
   communicator                = "ssh"
-  ssh_username                = "ec2-user"
+  ssh_username                = local.ssh_user
   ssh_interface               = "session_manager"
   ssh_timeout                 = "10m"
   iam_instance_profile        = var.builder_instance_profile
@@ -81,12 +96,13 @@ build {
   provisioner "shell" {
     inline = [
       "set -euo pipefail",
-      "grep -Eq 'release[[:space:]]+${var.os_major}\\.' /etc/oracle-release || { echo \"wrong OL major: $(cat /etc/oracle-release)\"; exit 1; }",
+      ". /etc/os-release; [ \"$ID\" = '${local.expected_id}' ] || { echo \"wrong distro ID $ID (want ${local.expected_id})\"; exit 1; }",
+      ". /etc/os-release; [ \"$${VERSION_ID%%.*}\" = '${var.os_major}' ] || { echo \"wrong major $VERSION_ID (want ${var.os_major})\"; exit 1; }",
       "[ \"$(uname -m)\" = '${local.uname_arch}' ] || { echo \"wrong arch $(uname -m)\"; exit 1; }",
       "sudo cloud-init status --wait 2>/dev/null | grep -qE 'done|disabled' || { echo 'cloud-init not done'; exit 1; }",
       "rpm -q amazon-ssm-agent >/dev/null || { echo 'ssm-agent not baked'; exit 1; }",
       "sudo dnf -y install dnf-plugins-core || true",
-      "sudo dnf config-manager --set-enabled ol${var.os_major}_codeready_builder 2>/dev/null || true",
+      "sudo dnf config-manager --set-enabled ${local.crb_repo} 2>/dev/null || true",
       "sudo dnf -y install https://repo.percona.com/yum/percona-release-latest.noarch.rpm",
       "sudo percona-release enable-only ppg-17 release",
       "sudo dnf -qy module reset postgresql 2>/dev/null || true",


### PR DESCRIPTION
**Feature**
- The PPG package-test AMI factory now bakes Rocky Linux 8/9/10 (x86_64 + arm64) alongside Oracle Linux: same refresh pipeline, fail-closed validate, fresh-boot PPG smoke, and tag-flip promotion.
- The workflow is renamed `ppg-ami-factory.yml` and runs its `check` job (template validation only, no AWS credentials, so nothing can launch or spend) on pull requests.

**Why**
- The pg.cd molecule jobs pin static Rocky AMIs. The Rocky 8 pin (`8.10-20240528`) is AWS-deprecated and two years behind on errata, and Rocky's June 2026 refresh reached eu-central-1 only as a Marketplace image whose product code would propagate into derived AMIs.
- Each Rocky base image is seeded once from the official community AMI (`just seed-rocky`, `include_deprecated` covers Rocky 8), then refreshed weekly like OL, keeping Rocky 8 current even when upstream skips our region.
- Rocky is in the weekly scheduled rebake from this PR on. The initial Rocky images are already baked, smoke-passed and promoted, so every scheduled run has a source AMI to build from (each rebake selects the newest promoted image as its source).
- The Rocky jobs keep launching the old hand-pinned AMIs for now. The follow-up PR points them at the factory images instead (`moleculeEnvPPG.groovy` resolves the newest promoted AMI by tag in place of six hardcoded ids).

**Tickets**
- [PKG-1343](https://perconadev.atlassian.net/browse/PKG-1343) (Rocky 8), [PKG-1344](https://perconadev.atlassian.net/browse/PKG-1344) (Rocky 9), [PKG-1345](https://perconadev.atlassian.net/browse/PKG-1345) (Rocky 10), under epic [PKG-1342](https://perconadev.atlassian.net/browse/PKG-1342)


[PKG-1343]: https://perconadev.atlassian.net/browse/PKG-1343?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ