### PR TITLE
PKG-1342: Resolve Rocky package-test AMIs dynamically in pg.cd jobs

### DIFF
--- a/vars/moleculeEnvPPG.groovy
+++ b/vars/moleculeEnvPPG.groovy
@@ -3,38 +3,38 @@ def call() {
         export ami_debian11_x86_64=ami-009e9420630204b5d
         export ami_debian12_x86_64=ami-09ca7bd4727fb280b
         export ami_debian13_x86_64=ami-0da1f66573556d917
-        # Oracle Linux AMIs: resolved dynamically to the newest factory-built base
-        # per major+arch (tag role=ppg-package-test) so they auto-update on each
-        # rebake instead of being hand-pinned. boto3 (not the aws CLI):
+        # Oracle Linux + Rocky Linux AMIs: resolved dynamically to the newest
+        # factory-built base per os+major+arch (tag role=ppg-package-test) so they
+        # auto-update on each rebake instead of being hand-pinned. boto3 (not the aws CLI):
         # the molecule agent has boto3 (installMoleculePython39) but not always the CLI.
         # Fail-closed: assign on its own line (a bare assignment propagates the
         # helper's non-zero exit; an inline 'export VAR=...' masks it as export's
         # status), then '|| exit 1' aborts the step rather than launch an empty image.
-        _ppg_ol_ami() { python3 -c "import sys,boto3,botocore.config as C; m,a=sys.argv[1],sys.argv[2]; i=sorted(boto3.client('ec2',region_name='eu-central-1',config=C.Config(retries={'max_attempts':8,'mode':'standard'})).describe_images(Owners=['self'],Filters=[{'Name':'tag:role','Values':['ppg-package-test']},{'Name':'tag:os','Values':['oraclelinux']},{'Name':'tag:os_major','Values':[m]},{'Name':'tag:arch','Values':[a]},{'Name':'state','Values':['available']}])['Images'],key=lambda x:x['CreationDate']); sys.stdout.write(i[-1]['ImageId'] if i else ''); sys.exit(0 if i else 1)" "\$1" "\$2"; }
-        ami_ol8_x86_64=\$(_ppg_ol_ami 8 x86_64) || exit 1; export ami_ol8_x86_64
-        ami_ol9_x86_64=\$(_ppg_ol_ami 9 x86_64) || exit 1; export ami_ol9_x86_64
-        ami_ol10_x86_64=\$(_ppg_ol_ami 10 x86_64) || exit 1; export ami_ol10_x86_64
+        _ppg_ami() { python3 -c "import sys,boto3,botocore.config as C; m,a,o=sys.argv[1],sys.argv[2],sys.argv[3]; i=sorted(boto3.client('ec2',region_name='eu-central-1',config=C.Config(retries={'max_attempts':8,'mode':'standard'})).describe_images(Owners=['self'],Filters=[{'Name':'tag:role','Values':['ppg-package-test']},{'Name':'tag:os','Values':[o]},{'Name':'tag:os_major','Values':[m]},{'Name':'tag:arch','Values':[a]},{'Name':'state','Values':['available']}])['Images'],key=lambda x:x['CreationDate']); sys.stdout.write(i[-1]['ImageId'] if i else ''); sys.exit(0 if i else 1)" "\$1" "\$2" "\$3"; }
+        ami_ol8_x86_64=\$(_ppg_ami 8 x86_64 oraclelinux) || exit 1; export ami_ol8_x86_64
+        ami_ol9_x86_64=\$(_ppg_ami 9 x86_64 oraclelinux) || exit 1; export ami_ol9_x86_64
+        ami_ol10_x86_64=\$(_ppg_ami 10 x86_64 oraclelinux) || exit 1; export ami_ol10_x86_64
         export ami_rhel8_x86_64=ami-0d38405c22c6dfaf3
         export ami_rhel9_x86_64=ami-01ea92f779cc1c71f
         export ami_rhel10_x86_64=ami-01777900cf626c469
-        export ami_rocky8_x86_64=ami-0f99e90e01ec42b57
-        export ami_rocky9_x86_64=ami-019aef84b4837f73d
-        export ami_rocky10_x86_64=ami-09f9edbd6a2d85ba9
+        ami_rocky8_x86_64=\$(_ppg_ami 8 x86_64 rocky) || exit 1; export ami_rocky8_x86_64
+        ami_rocky9_x86_64=\$(_ppg_ami 9 x86_64 rocky) || exit 1; export ami_rocky9_x86_64
+        ami_rocky10_x86_64=\$(_ppg_ami 10 x86_64 rocky) || exit 1; export ami_rocky10_x86_64
         export ami_ubuntu22_x86_64=ami-0b3a21dbff1fffb4c
         export ami_ubuntu24_x86_64=ami-0596cf3199908321b
         export ami_ubuntu26_x86_64=ami-051eaec1417c5d4ae
         export ami_debian11_arm64=ami-08bb051b83411b514
         export ami_debian12_arm64=ami-04991928175cf27a1
         export ami_debian13_arm64=ami-08241d277446b81d7
-        ami_ol8_arm64=\$(_ppg_ol_ami 8 arm64) || exit 1; export ami_ol8_arm64
-        ami_ol9_arm64=\$(_ppg_ol_ami 9 arm64) || exit 1; export ami_ol9_arm64
-        ami_ol10_arm64=\$(_ppg_ol_ami 10 arm64) || exit 1; export ami_ol10_arm64
+        ami_ol8_arm64=\$(_ppg_ami 8 arm64 oraclelinux) || exit 1; export ami_ol8_arm64
+        ami_ol9_arm64=\$(_ppg_ami 9 arm64 oraclelinux) || exit 1; export ami_ol9_arm64
+        ami_ol10_arm64=\$(_ppg_ami 10 arm64 oraclelinux) || exit 1; export ami_ol10_arm64
         export ami_rhel8_arm64=ami-05796f88f5487ea38
         export ami_rhel9_arm64=ami-024a0efb56778bc6b
         export ami_rhel10_arm64=ami-0ad16a1fbf63249be
-        export ami_rocky8_arm64=ami-07212fece0fd77907
-        export ami_rocky9_arm64=ami-02ef97e98cb13bbf6
-        export ami_rocky10_arm64=ami-0ecc8cb2d8f5b6948
+        ami_rocky8_arm64=\$(_ppg_ami 8 arm64 rocky) || exit 1; export ami_rocky8_arm64
+        ami_rocky9_arm64=\$(_ppg_ami 9 arm64 rocky) || exit 1; export ami_rocky9_arm64
+        ami_rocky10_arm64=\$(_ppg_ami 10 arm64 rocky) || exit 1; export ami_rocky10_arm64
         export ami_ubuntu22_arm64=ami-0e61fa0475e5cdf7d
         export ami_ubuntu24_arm64=ami-0abed25eed793978d
         export ami_ubuntu26_arm64=ami-042f11a836094cda0


### PR DESCRIPTION
**Feature**
- pg.cd molecule jobs (the ppg, pg_stat_monitor, pg_tde, psp and tarball suites, about 25 pipelines) resolve Rocky 8/9/10 AMIs dynamically: the newest factory-built, smoke-passed image by tag, the same fail-closed lookup the OL images use.

**Why**
- The hardcoded Rocky 8 pin (`8.10-20240528`) is AWS-deprecated and two years behind on errata. Resolved-by-tag images update on every weekly factory rebake with no pins to chase.
- The initial factory Rocky images for all six major/arch variants are baked, smoke-passed and promoted, so the lookup has matches from day one.
- A missing image aborts the job loudly instead of launching something stale.

**Sequencing**
- Pairs with [#4288](https://github.com/Percona-Lab/jenkins-pipelines/pull/4288), the factory that bakes and weekly-refreshes these images; merge that first. This PR changes a single file and only affects which AMI ids the jobs resolve.

**Tickets**
- [PKG-1343](https://perconadev.atlassian.net/browse/PKG-1343) (Rocky 8), [PKG-1344](https://perconadev.atlassian.net/browse/PKG-1344) (Rocky 9), [PKG-1345](https://perconadev.atlassian.net/browse/PKG-1345) (Rocky 10), under epic [PKG-1342](https://perconadev.atlassian.net/browse/PKG-1342). Prerequisite: [#4288](https://github.com/Percona-Lab/jenkins-pipelines/pull/4288) (the factory).


[PKG-1343]: https://perconadev.atlassian.net/browse/PKG-1343?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[PKG-1344]: https://perconadev.atlassian.net/browse/PKG-1344?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ