### PR TITLE
Remove pmm3-migration-tests from RC testing orchestrator

### DIFF
--- a/pmm/v3/pmm3-rc-testing.groovy
+++ b/pmm/v3/pmm3-rc-testing.groovy
@@ -307,21 +307,6 @@ pipeline {
                                 }
                             }
                         }
-                        stage('pmm3-migration-tests') {
-                            steps {
-                                script {
-                                    triggerJenkinsRc('pmm3-migration-tests', 'pmm3-migration-tests', [
-                                        string(name: 'PMM_V3_UI_GIT_BRANCH', value: 'main'),
-                                        string(name: 'PMM_V2_UI_GIT_BRANCH', value: 'v2'),
-                                        string(name: 'DOCKER_VERSION',       value: 'perconalab/pmm-server:2.44.1'),
-                                        string(name: 'CLIENT_VERSION',       value: '2.44.1'),
-                                        string(name: 'ADMIN_PASSWORD',       value: 'pmm3admin!'),
-                                        string(name: 'PMM_QA_GIT_BRANCH',   value: 'v2'),
-                                        string(name: 'UPGRADE_TAG',          value: 'testing'),
-                                    ])
-                                }
-                            }
-                        }
                         stage('pmm3-ui-tests-matrix') {
                             steps {
                                 script {


### PR DESCRIPTION
## Summary

PMM 2 to PMM 3 migration is no longer supported in RC validation. This removes the `pmm3-migration-tests` stage from the RC testing orchestrator.

## Changes

- Remove `pmm3-migration-tests` stage from `pmm/v3/pmm3-rc-testing.groovy` (Lane 3)

## Related

- percona/pmm-qa#1103 — removes the `@pmm-migration` CodeceptJS test suite and updates RC testing docs