### PR TITLE
ppg: standardize CI retention to 30d/100 builds, 10 artifacts

### DIFF
--- a/ppg/component-generic-parallel.groovy
+++ b/ppg/component-generic-parallel.groovy
@@ -79,8 +79,9 @@ pipeline {
     options {
         withCredentials(moleculeDistributionJenkinsCreds())
         buildDiscarder(logRotator(
-            numToKeepStr: '50',
-            artifactNumToKeepStr: '50'
+            daysToKeepStr: '30',
+            numToKeepStr: '100',
+            artifactNumToKeepStr: '10'
         ))
         retry(conditions: [agent()], count: 2)
     }

--- a/ppg/component-generic.groovy
+++ b/ppg/component-generic.groovy
@@ -84,8 +84,9 @@ pipeline {
     options {
         withCredentials(moleculeDistributionJenkinsCreds())
         buildDiscarder(logRotator(
-            numToKeepStr: '50',
-            artifactNumToKeepStr: '50'
+            daysToKeepStr: '30',
+            numToKeepStr: '100',
+            artifactNumToKeepStr: '10'
         ))
         retry(conditions: [agent()], count: 2)
     }

--- a/ppg/component-multi-parallel.groovy
+++ b/ppg/component-multi-parallel.groovy
@@ -32,7 +32,7 @@ pipeline {
 
     options {
         withCredentials(moleculeDistributionJenkinsCreds())
-        buildDiscarder(logRotator(numToKeepStr: '50'))
+        buildDiscarder(logRotator(daysToKeepStr: '30', numToKeepStr: '100', artifactNumToKeepStr: '10'))
         retry(conditions: [agent()], count: 2)
     }
 

--- a/ppg/docker-component-multiOS.groovy
+++ b/ppg/docker-component-multiOS.groovy
@@ -75,7 +75,7 @@ pipeline {
     }
     options {
         withCredentials(moleculeDistributionJenkinsCreds())
-        buildDiscarder(logRotator(numToKeepStr: '50'))
+        buildDiscarder(logRotator(daysToKeepStr: '30', numToKeepStr: '100', artifactNumToKeepStr: '10'))
         disableConcurrentBuilds()
         retry(conditions: [agent()], count: 2)
     }

--- a/ppg/docker-component-parallel.groovy
+++ b/ppg/docker-component-parallel.groovy
@@ -75,7 +75,7 @@ pipeline {
     }
     options {
         withCredentials(moleculeDistributionJenkinsCreds())
-        buildDiscarder(logRotator(numToKeepStr: '50'))
+        buildDiscarder(logRotator(daysToKeepStr: '30', numToKeepStr: '100', artifactNumToKeepStr: '10'))
         retry(conditions: [agent()], count: 2)
     }
     stages {

--- a/ppg/docker-component.groovy
+++ b/ppg/docker-component.groovy
@@ -82,7 +82,7 @@ pipeline {
     }
     options {
         withCredentials(moleculeDistributionJenkinsCreds())
-        buildDiscarder(logRotator(numToKeepStr: '50'))
+        buildDiscarder(logRotator(daysToKeepStr: '30', numToKeepStr: '100', artifactNumToKeepStr: '10'))
         retry(conditions: [agent()], count: 2)
     }
     stages {

--- a/ppg/docker-cve-scan.groovy
+++ b/ppg/docker-cve-scan.groovy
@@ -352,7 +352,7 @@ docker.io/perconalab/percona-distribution-postgresql-upgrade-custom:18-17-16''',
     options {
         withCredentials(moleculeDistributionJenkinsCreds())
         timestamps()
-        buildDiscarder(logRotator(numToKeepStr: '50', artifactNumToKeepStr: '50'))
+        buildDiscarder(logRotator(daysToKeepStr: '30', numToKeepStr: '100', artifactNumToKeepStr: '10'))
     }
 
     stages {

--- a/ppg/docker-server-multiOS.groovy
+++ b/ppg/docker-server-multiOS.groovy
@@ -57,7 +57,7 @@ pipeline {
     }
     options {
         withCredentials(moleculeDistributionJenkinsCreds())
-        buildDiscarder(logRotator(numToKeepStr: '50'))
+        buildDiscarder(logRotator(daysToKeepStr: '30', numToKeepStr: '100', artifactNumToKeepStr: '10'))
         disableConcurrentBuilds()
         retry(conditions: [agent()], count: 2)
     }

--- a/ppg/docker-server-parallel-custom-upgrade.groovy
+++ b/ppg/docker-server-parallel-custom-upgrade.groovy
@@ -44,7 +44,7 @@ pipeline {
     options {
         // Ensure this shared library function returns the correct wrapper
         withCredentials(moleculeDistributionJenkinsCreds())
-        buildDiscarder(logRotator(numToKeepStr: '50'))
+        buildDiscarder(logRotator(daysToKeepStr: '30', numToKeepStr: '100', artifactNumToKeepStr: '10'))
         timestamps()
         retry(conditions: [agent()], count: 2)
     }

--- a/ppg/docker-server-parallel-custom.groovy
+++ b/ppg/docker-server-parallel-custom.groovy
@@ -38,7 +38,7 @@ pipeline {
     options {
         // Ensure this shared library function returns the correct wrapper
         withCredentials(moleculeDistributionJenkinsCreds())
-        buildDiscarder(logRotator(numToKeepStr: '50'))
+        buildDiscarder(logRotator(daysToKeepStr: '30', numToKeepStr: '100', artifactNumToKeepStr: '10'))
         timestamps()
         retry(conditions: [agent()], count: 2)
     }

--- a/ppg/docker-server-parallel-generic.groovy
+++ b/ppg/docker-server-parallel-generic.groovy
@@ -44,7 +44,7 @@ pipeline {
     }
     options {
         withCredentials(moleculeDistributionJenkinsCreds())
-        buildDiscarder(logRotator(numToKeepStr: '50'))
+        buildDiscarder(logRotator(daysToKeepStr: '30', numToKeepStr: '100', artifactNumToKeepStr: '10'))
         retry(conditions: [agent()], count: 2)
     }
     stages {

--- a/ppg/docker-server-parallel-upgrade.groovy
+++ b/ppg/docker-server-parallel-upgrade.groovy
@@ -46,7 +46,7 @@ pipeline {
     options {
         // Ensure this shared library function returns the correct wrapper
         withCredentials(moleculeDistributionJenkinsCreds())
-        buildDiscarder(logRotator(numToKeepStr: '50'))
+        buildDiscarder(logRotator(daysToKeepStr: '30', numToKeepStr: '100', artifactNumToKeepStr: '10'))
         timestamps()
         retry(conditions: [agent()], count: 2)
     }

--- a/ppg/docker-server-parallel.groovy
+++ b/ppg/docker-server-parallel.groovy
@@ -57,7 +57,7 @@ pipeline {
     }
     options {
         withCredentials(moleculeDistributionJenkinsCreds())
-        buildDiscarder(logRotator(numToKeepStr: '50'))
+        buildDiscarder(logRotator(daysToKeepStr: '30', numToKeepStr: '100', artifactNumToKeepStr: '10'))
         retry(conditions: [agent()], count: 2)
     }
     stages {

--- a/ppg/docker-server.groovy
+++ b/ppg/docker-server.groovy
@@ -64,7 +64,7 @@ pipeline {
     }
     options {
         withCredentials(moleculeDistributionJenkinsCreds())
-        buildDiscarder(logRotator(numToKeepStr: '50'))
+        buildDiscarder(logRotator(daysToKeepStr: '30', numToKeepStr: '100', artifactNumToKeepStr: '10'))
         retry(conditions: [agent()], count: 2)
     }
     stages {

--- a/ppg/pgsm-multiOS.groovy
+++ b/ppg/pgsm-multiOS.groovy
@@ -69,7 +69,8 @@ pipeline {
         withCredentials(moleculeDistributionJenkinsCreds())
         disableConcurrentBuilds()
         buildDiscarder(logRotator(
-            numToKeepStr: '10',
+            daysToKeepStr: '30',
+            numToKeepStr: '100',
             artifactNumToKeepStr: '10'
         ))
         retry(conditions: [agent()], count: 2)

--- a/ppg/pgsm-parallel.groovy
+++ b/ppg/pgsm-parallel.groovy
@@ -63,7 +63,8 @@ pipeline {
     options {
         withCredentials(moleculeDistributionJenkinsCreds())
         buildDiscarder(logRotator(
-            numToKeepStr: '10',
+            daysToKeepStr: '30',
+            numToKeepStr: '100',
             artifactNumToKeepStr: '10'
         ))
         retry(conditions: [agent()], count: 2)

--- a/ppg/pgsm-pgdg-parallel.groovy
+++ b/ppg/pgsm-pgdg-parallel.groovy
@@ -46,8 +46,9 @@ pipeline {
     options {
         withCredentials(moleculeDistributionJenkinsCreds())
         buildDiscarder(logRotator(
-            numToKeepStr: '50',
-            artifactNumToKeepStr: '50'
+            daysToKeepStr: '30',
+            numToKeepStr: '100',
+            artifactNumToKeepStr: '10'
         ))
         retry(conditions: [agent()], count: 2)
     }

--- a/ppg/pgsm-pgdg.groovy
+++ b/ppg/pgsm-pgdg.groovy
@@ -42,8 +42,9 @@ pipeline {
     options {
         withCredentials(moleculeDistributionJenkinsCreds())
         buildDiscarder(logRotator(
-            numToKeepStr: '50',
-            artifactNumToKeepStr: '50'
+            daysToKeepStr: '30',
+            numToKeepStr: '100',
+            artifactNumToKeepStr: '10'
         ))
         retry(conditions: [agent()], count: 2)
     }

--- a/ppg/pgsm.groovy
+++ b/ppg/pgsm.groovy
@@ -64,7 +64,8 @@ pipeline {
     options {
         withCredentials(moleculeDistributionJenkinsCreds())
         buildDiscarder(logRotator(
-            numToKeepStr: '10',
+            daysToKeepStr: '30',
+            numToKeepStr: '100',
             artifactNumToKeepStr: '10'
         ))
         retry(conditions: [agent()], count: 2)

--- a/ppg/ppg-multiOS-parallel.groovy
+++ b/ppg/ppg-multiOS-parallel.groovy
@@ -63,7 +63,7 @@ pipeline {
     }
     options {
         withCredentials(moleculeDistributionJenkinsCreds())
-        buildDiscarder(logRotator(numToKeepStr: '50'))
+        buildDiscarder(logRotator(daysToKeepStr: '30', numToKeepStr: '100', artifactNumToKeepStr: '10'))
         retry(conditions: [agent()], count: 2)
     }
     stages {

--- a/ppg/ppg-multiOS.groovy
+++ b/ppg/ppg-multiOS.groovy
@@ -63,7 +63,7 @@ pipeline {
     }
     options {
         withCredentials(moleculeDistributionJenkinsCreds())
-        buildDiscarder(logRotator(numToKeepStr: '50'))
+        buildDiscarder(logRotator(daysToKeepStr: '30', numToKeepStr: '100', artifactNumToKeepStr: '10'))
         disableConcurrentBuilds()
         retry(conditions: [agent()], count: 2)
     }

--- a/ppg/ppg-upgrade-multiOS.groovy
+++ b/ppg/ppg-upgrade-multiOS.groovy
@@ -63,7 +63,7 @@ pipeline {
     }
     options {
         withCredentials(moleculeDistributionJenkinsCreds())
-        buildDiscarder(logRotator(numToKeepStr: '50'))
+        buildDiscarder(logRotator(daysToKeepStr: '30', numToKeepStr: '100', artifactNumToKeepStr: '10'))
         disableConcurrentBuilds()
         retry(conditions: [agent()], count: 2)
     }

--- a/ppg/ppg-upgrade-parallel.groovy
+++ b/ppg/ppg-upgrade-parallel.groovy
@@ -63,7 +63,7 @@ pipeline {
     }
     options {
         withCredentials(moleculeDistributionJenkinsCreds())
-        buildDiscarder(logRotator(numToKeepStr: '50'))
+        buildDiscarder(logRotator(daysToKeepStr: '30', numToKeepStr: '100', artifactNumToKeepStr: '10'))
         retry(conditions: [agent()], count: 2)
     }
     stages {

--- a/ppg/ppg-upgrade.groovy
+++ b/ppg/ppg-upgrade.groovy
@@ -63,7 +63,7 @@ pipeline {
     }
     options {
         withCredentials(moleculeDistributionJenkinsCreds())
-        buildDiscarder(logRotator(numToKeepStr: '50'))
+        buildDiscarder(logRotator(daysToKeepStr: '30', numToKeepStr: '100', artifactNumToKeepStr: '10'))
         retry(conditions: [agent()], count: 2)
     }
     stages {

--- a/ppg/ppg.groovy
+++ b/ppg/ppg.groovy
@@ -63,7 +63,7 @@ pipeline {
     }
     options {
         withCredentials(moleculeDistributionJenkinsCreds())
-        buildDiscarder(logRotator(numToKeepStr: '50'))
+        buildDiscarder(logRotator(daysToKeepStr: '30', numToKeepStr: '100', artifactNumToKeepStr: '10'))
         retry(conditions: [agent()], count: 2)
     }
     stages {

--- a/ppg/psp-installcheck-world-multiOS.groovy
+++ b/ppg/psp-installcheck-world-multiOS.groovy
@@ -80,7 +80,8 @@ pipeline {
         withCredentials(moleculeDistributionJenkinsCreds())
         disableConcurrentBuilds()
         buildDiscarder(logRotator(
-            numToKeepStr: '10',
+            daysToKeepStr: '30',
+            numToKeepStr: '100',
             artifactNumToKeepStr: '10'
         ))
         retry(conditions: [agent()], count: 2)

--- a/ppg/psp-installcheck-world-parallel.groovy
+++ b/ppg/psp-installcheck-world-parallel.groovy
@@ -79,7 +79,8 @@ pipeline {
     options {
         withCredentials(moleculeDistributionJenkinsCreds())
         buildDiscarder(logRotator(
-            numToKeepStr: '10',
+            daysToKeepStr: '30',
+            numToKeepStr: '100',
             artifactNumToKeepStr: '10'
         ))
         retry(conditions: [agent()], count: 2)

--- a/ppg/psp-installcheck-world.groovy
+++ b/ppg/psp-installcheck-world.groovy
@@ -80,7 +80,8 @@ pipeline {
     options {
         withCredentials(moleculeDistributionJenkinsCreds())
         buildDiscarder(logRotator(
-            numToKeepStr: '10',
+            daysToKeepStr: '30',
+            numToKeepStr: '100',
             artifactNumToKeepStr: '10'
         ))
         retry(conditions: [agent()], count: 2)

--- a/ppg/tarball-multiOS-ssl1.groovy
+++ b/ppg/tarball-multiOS-ssl1.groovy
@@ -57,7 +57,7 @@ pipeline {
     }
     options {
         withCredentials(moleculeDistributionJenkinsCreds())
-        buildDiscarder(logRotator(numToKeepStr: '50'))
+        buildDiscarder(logRotator(daysToKeepStr: '30', numToKeepStr: '100', artifactNumToKeepStr: '10'))
         disableConcurrentBuilds()
         retry(conditions: [agent()], count: 2)
     }

--- a/ppg/tarball-multiOS-ssl3.groovy
+++ b/ppg/tarball-multiOS-ssl3.groovy
@@ -57,7 +57,7 @@ pipeline {
     }
     options {
         withCredentials(moleculeDistributionJenkinsCreds())
-        buildDiscarder(logRotator(numToKeepStr: '50'))
+        buildDiscarder(logRotator(daysToKeepStr: '30', numToKeepStr: '100', artifactNumToKeepStr: '10'))
         disableConcurrentBuilds()
         retry(conditions: [agent()], count: 2)
     }

--- a/ppg/tarball-multiOS-ssl35.groovy
+++ b/ppg/tarball-multiOS-ssl35.groovy
@@ -57,7 +57,7 @@ pipeline {
     }
     options {
         withCredentials(moleculeDistributionJenkinsCreds())
-        buildDiscarder(logRotator(numToKeepStr: '50'))
+        buildDiscarder(logRotator(daysToKeepStr: '30', numToKeepStr: '100', artifactNumToKeepStr: '10'))
         disableConcurrentBuilds()
         retry(conditions: [agent()], count: 2)
     }

--- a/ppg/tarball-parallel-ssl1.groovy
+++ b/ppg/tarball-parallel-ssl1.groovy
@@ -57,7 +57,7 @@ pipeline {
     }
     options {
         withCredentials(moleculeDistributionJenkinsCreds())
-        buildDiscarder(logRotator(numToKeepStr: '50'))
+        buildDiscarder(logRotator(daysToKeepStr: '30', numToKeepStr: '100', artifactNumToKeepStr: '10'))
         retry(conditions: [agent()], count: 2)
     }
     stages {

--- a/ppg/tarball-parallel-ssl3.groovy
+++ b/ppg/tarball-parallel-ssl3.groovy
@@ -57,7 +57,7 @@ pipeline {
     }
     options {
         withCredentials(moleculeDistributionJenkinsCreds())
-        buildDiscarder(logRotator(numToKeepStr: '50'))
+        buildDiscarder(logRotator(daysToKeepStr: '30', numToKeepStr: '100', artifactNumToKeepStr: '10'))
         retry(conditions: [agent()], count: 2)
     }
     stages {

--- a/ppg/tarball-parallel-ssl35.groovy
+++ b/ppg/tarball-parallel-ssl35.groovy
@@ -57,7 +57,7 @@ pipeline {
     }
     options {
         withCredentials(moleculeDistributionJenkinsCreds())
-        buildDiscarder(logRotator(numToKeepStr: '50'))
+        buildDiscarder(logRotator(daysToKeepStr: '30', numToKeepStr: '100', artifactNumToKeepStr: '10'))
         retry(conditions: [agent()], count: 2)
     }
     stages {

--- a/ppg/tarball.groovy
+++ b/ppg/tarball.groovy
@@ -59,7 +59,7 @@ pipeline {
     }
     options {
         withCredentials(moleculeDistributionJenkinsCreds())
-        buildDiscarder(logRotator(numToKeepStr: '50'))
+        buildDiscarder(logRotator(daysToKeepStr: '30', numToKeepStr: '100', artifactNumToKeepStr: '10'))
         retry(conditions: [agent()], count: 2)
     }
     stages {

--- a/ppg/tde-auxiliary-parallel.groovy
+++ b/ppg/tde-auxiliary-parallel.groovy
@@ -95,7 +95,8 @@ pipeline {
     options {
         withCredentials(moleculeDistributionJenkinsCreds())
         buildDiscarder(logRotator(
-            numToKeepStr: '10',
+            daysToKeepStr: '30',
+            numToKeepStr: '100',
             artifactNumToKeepStr: '10'
         ))
         retry(conditions: [agent()], count: 2)

--- a/ppg/tde-auxiliary.groovy
+++ b/ppg/tde-auxiliary.groovy
@@ -96,7 +96,8 @@ pipeline {
     options {
         withCredentials(moleculeDistributionJenkinsCreds())
         buildDiscarder(logRotator(
-            numToKeepStr: '10',
+            daysToKeepStr: '30',
+            numToKeepStr: '100',
             artifactNumToKeepStr: '10'
         ))
         retry(conditions: [agent()], count: 2)

--- a/ppg/tde-multiOS.groovy
+++ b/ppg/tde-multiOS.groovy
@@ -69,7 +69,8 @@ pipeline {
         withCredentials(moleculeDistributionJenkinsCreds())
         disableConcurrentBuilds()
         buildDiscarder(logRotator(
-            numToKeepStr: '10',
+            daysToKeepStr: '30',
+            numToKeepStr: '100',
             artifactNumToKeepStr: '10'
         ))
         retry(conditions: [agent()], count: 2)

--- a/ppg/tde-parallel.groovy
+++ b/ppg/tde-parallel.groovy
@@ -68,7 +68,8 @@ pipeline {
     options {
         withCredentials(moleculeDistributionJenkinsCreds())
         buildDiscarder(logRotator(
-            numToKeepStr: '10',
+            daysToKeepStr: '30',
+            numToKeepStr: '100',
             artifactNumToKeepStr: '10'
         ))
         retry(conditions: [agent()], count: 2)

--- a/ppg/tde-upgrade-parallel.groovy
+++ b/ppg/tde-upgrade-parallel.groovy
@@ -180,8 +180,9 @@ pipeline {
     options {
         withCredentials(moleculeDistributionJenkinsCreds())
         buildDiscarder(logRotator(
-            numToKeepStr: '50',
-            artifactNumToKeepStr: '50'
+            daysToKeepStr: '30',
+            numToKeepStr: '100',
+            artifactNumToKeepStr: '10'
         ))
         retry(conditions: [agent()], count: 2)
     }

--- a/ppg/tde-upgrade.groovy
+++ b/ppg/tde-upgrade.groovy
@@ -144,8 +144,9 @@ pipeline {
     options {
         withCredentials(moleculeDistributionJenkinsCreds())
         buildDiscarder(logRotator(
-            numToKeepStr: '50',
-            artifactNumToKeepStr: '50'
+            daysToKeepStr: '30',
+            numToKeepStr: '100',
+            artifactNumToKeepStr: '10'
         ))
         retry(conditions: [agent()], count: 2)
     }

--- a/ppg/tde.groovy
+++ b/ppg/tde.groovy
@@ -69,7 +69,8 @@ pipeline {
     options {
         withCredentials(moleculeDistributionJenkinsCreds())
         buildDiscarder(logRotator(
-            numToKeepStr: '10',
+            daysToKeepStr: '30',
+            numToKeepStr: '100',
             artifactNumToKeepStr: '10'
         ))
         retry(conditions: [agent()], count: 2)


### PR DESCRIPTION
Set buildDiscarder across 42 PPG testing pipelines: daysToKeepStr=30, numToKeepStr=100, artifactNumToKeepStr=10 — keep 100 builds/30 days of history+logs, artifacts for the last 10 only.