### PR TITLE
CLOUD-929 Update PSMDB Operator pipelines to run pytest

### DIFF
--- a/cloud/common/files/google-cloud-sdk.repo
+++ b/cloud/common/files/google-cloud-sdk.repo
@@ -1,6 +1,6 @@
 [google-cloud-cli]
 name=Google Cloud CLI
-baseurl=https://packages.cloud.google.com/yum/repos/cloud-sdk-el7-x86_64
+baseurl=https://packages.cloud.google.com/yum/repos/cloud-sdk-el9-x86_64
 enabled=1
 gpgcheck=1
 repo_gpgcheck=0

--- a/cloud/common/libraries.groovy
+++ b/cloud/common/libraries.groovy
@@ -5,6 +5,9 @@ def loadLibraries() {
         tools       : load('cloud/common/vars/tools.groovy'),
         gcloud      : load('cloud/common/vars/gcloud.groovy'),
         rancher     : load('cloud/common/vars/rancher.groovy'),
+        eks         : load('cloud/common/vars/eks.groovy'),
+        openshift   : load('cloud/common/vars/openshift.groovy'),
+        minikube    : load('cloud/common/vars/minikube.groovy'),
         tests       : load('cloud/common/vars/tests.groovy')
     ]
 }

--- a/cloud/common/vars/azure.groovy
+++ b/cloud/common/vars/azure.groovy
@@ -7,4 +7,55 @@ void auth() {
     }
 }
 
+def getPlatformVersion(String prefixVersion) {
+    return prefixVersion
+}
+
+def getLatestPlatformVersion(Map testVariables) {
+    return sh(
+        script: "az aks get-versions --location ${testVariables.region} --output json | jq -r '.values | max_by(.patchVersions) | .patchVersions | keys[]' | sort --version-sort | tail -1",
+        returnStdout: true
+    ).trim()
+}
+
+def getMachineType(String arch) {
+    return arch
+}
+
+void createCluster(Map clusterCfg) {
+    def clusterFullName = "${clusterCfg.clusterName}-${clusterCfg.clusterSuffix}"
+
+    timeout(time: 30, unit: 'MINUTES') {
+        sh """
+            export KUBECONFIG=/tmp/${clusterFullName}
+            az aks create -n ${clusterFullName} \
+                -g percona-operators \
+                --subscription eng-cloud-dev \
+                --load-balancer-sku standard \
+                --enable-managed-identity \
+                --node-count 3 \
+                --node-vm-size Standard_B4ms \
+                --node-osdisk-size 30 \
+                --generate-ssh-keys \
+                --outbound-type loadbalancer \
+                --kubernetes-version ${clusterCfg.platformVersion} \
+                --tags team=cloud delete-cluster-after-hours=6 creation-time=\$(date -u +%s) \
+                -l ${clusterCfg.region}
+            az aks get-credentials --subscription eng-cloud-dev --resource-group percona-operators --name ${clusterFullName} --overwrite-existing
+        """
+    }
+}
+
+void shutdownCluster(Map clusterCfg) {
+    def clusterFullName = "${clusterCfg.clusterName}-${clusterCfg.clusterSuffix}"
+
+    timeout(time: 30, unit: 'MINUTES') {
+        withCredentials([azureServicePrincipal('PERCONA-OPERATORS-SP')]) {
+            sh """
+                az aks delete --name ${clusterFullName} --resource-group percona-operators --subscription eng-cloud-dev --yes || true
+            """
+        }
+    }
+}
+
 return this

--- a/cloud/common/vars/dependencies.groovy
+++ b/cloud/common/vars/dependencies.groovy
@@ -73,6 +73,29 @@ void install(Map config = [:]) {
     }
 }
 
+void installUv() {
+    sh '''
+        set -euo pipefail
+        export PATH="$HOME/.local/bin:$PATH"
+        if command -v uv >/dev/null 2>&1; then
+            echo "uv already installed: $(uv --version)"
+        else
+            curl -LsSf https://astral.sh/uv/install.sh | sh
+            export PATH="$HOME/.local/bin:$PATH"
+        fi
+        uv --version
+    '''
+}
+
+void syncPythonDeps(String sourceDir = 'source') {
+    sh """
+        set -euo pipefail
+        export PATH="\$HOME/.local/bin:\$PATH"
+        cd ${sourceDir}
+        uv sync --locked
+    """
+}
+
 void installGoogleCLI() {
     sh '''
         sudo cp cloud/common/files/google-cloud-sdk.repo /etc/yum.repos.d/google-cloud-sdk.repo

--- a/cloud/common/vars/eks.groovy
+++ b/cloud/common/vars/eks.groovy
@@ -1,0 +1,158 @@
+def getPlatformVersion(String prefixVersion) {
+    return prefixVersion
+}
+
+def getLatestPlatformVersion(Map testVariables) {
+    return withCredentials([aws(credentialsId: 'AMI/OVF', accessKeyVariable: 'AWS_ACCESS_KEY_ID', secretKeyVariable: 'AWS_SECRET_ACCESS_KEY')]) {
+        sh(
+            script: "aws eks describe-addon-versions --query 'addons[].addonVersions[].compatibilities[].clusterVersion' --output json | jq -r 'flatten | unique | sort | reverse | .[0]'",
+            returnStdout: true
+        ).trim()
+    }
+}
+
+def getMachineType(String arch) {
+    return arch
+}
+
+void createCluster(Map clusterCfg) {
+    def clusterSuffix = clusterCfg.clusterSuffix
+    def clusterFullName = "${clusterCfg.clusterName}-${clusterSuffix}"
+
+    timeout(time: 30, unit: 'MINUTES') {
+        sh """
+            timestamp="\$(date +%s)"
+tee cluster-${clusterSuffix}.yaml << EOF
+apiVersion: eksctl.io/v1alpha5
+kind: ClusterConfig
+metadata:
+  name: ${clusterFullName}
+  region: ${clusterCfg.region}
+  version: "${clusterCfg.platformVersion}"
+  tags:
+    'delete-cluster-after-hours': '6'
+    'creation-time': '\$timestamp'
+    'team': 'cloud'
+iam:
+  withOIDC: true
+addons:
+- name: aws-ebs-csi-driver
+  wellKnownPolicies:
+    ebsCSIController: true
+- name: snapshot-controller
+nodeGroups:
+- name: ng-1
+  minSize: 3
+  maxSize: 4
+  iam:
+    attachPolicyARNs:
+    - arn:aws:iam::aws:policy/AmazonEKSWorkerNodePolicy
+    - arn:aws:iam::aws:policy/AmazonEKS_CNI_Policy
+    - arn:aws:iam::aws:policy/AmazonEC2ContainerRegistryReadOnly
+    - arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore
+  instancesDistribution:
+    instanceTypes: ["m5.xlarge", "m5.2xlarge"] # At least two instance types should be specified
+  tags:
+    'iit-billing-tag': 'jenkins-eks'
+    'delete-cluster-after-hours': '6'
+    'team': 'cloud'
+    'product': '${clusterCfg.product}'
+EOF
+        """
+
+        withCredentials([aws(credentialsId: 'eks-cicd', accessKeyVariable: 'AWS_ACCESS_KEY_ID', secretKeyVariable: 'AWS_SECRET_ACCESS_KEY')]) {
+            sh """
+                export KUBECONFIG=/tmp/${clusterFullName}
+
+                eksctl create cluster -f cluster-${clusterSuffix}.yaml
+                
+                # Use GP3 storage class as default, recommended by the provider
+                kubectl apply -f cloud/common/files/eks-storage-gp3.yaml
+
+                # Remove GP2 storage class default label, for old clusters
+                kubectl annotate storageclass gp2 \
+                    storageclass.kubernetes.io/is-default-class- \
+                    --overwrite 2>/dev/null || true
+
+                kubectl create clusterrolebinding cluster-admin-binding1 \
+                    --clusterrole=cluster-admin \
+                    --user="\$(aws sts get-caller-identity|jq -r '.Arn')"
+
+                kubectl get storageclass
+            """
+        }
+    }
+
+    verifyVolumeSnapshotResources(clusterFullName)
+}
+
+void verifyVolumeSnapshotResources(String clusterFullName) {
+    withCredentials([aws(accessKeyVariable: 'AWS_ACCESS_KEY_ID', credentialsId: 'eks-cicd', secretKeyVariable: 'AWS_SECRET_ACCESS_KEY')]) {
+        sh """
+            export KUBECONFIG=/tmp/${clusterFullName}
+            export PATH=/home/ec2-user/.local/bin:\$PATH
+
+            wait_for_deployment() {
+                local deployment_name="\$1"
+
+                for i in \$(seq 1 60); do
+                    if kubectl get deployment "\$deployment_name" -n kube-system >/dev/null 2>&1; then
+                        kubectl wait --for=condition=Available deployment/"\$deployment_name" -n kube-system --timeout=10m
+                        return 0
+                    fi
+                    sleep 10
+                done
+
+                kubectl get deployment -n kube-system
+                return 1
+            }
+
+            wait_for_deployment ebs-csi-controller
+            wait_for_deployment snapshot-controller
+
+            kubectl get crd volumesnapshots.snapshot.storage.k8s.io volumesnapshotcontents.snapshot.storage.k8s.io volumesnapshotclasses.snapshot.storage.k8s.io
+            kubectl api-resources --api-group=snapshot.storage.k8s.io
+        """
+    }
+}
+
+void shutdownCluster(Map clusterCfg) {
+    def clusterSuffix = clusterCfg.clusterSuffix
+    def clusterFullName = "${clusterCfg.clusterName}-${clusterSuffix}"
+    def region = clusterCfg.region
+
+    timeout(time: 30, unit: 'MINUTES') {
+        withCredentials([aws(credentialsId: 'eks-cicd', accessKeyVariable: 'AWS_ACCESS_KEY_ID', secretKeyVariable: 'AWS_SECRET_ACCESS_KEY')]) {
+            sh """
+                VPC_ID=\$(eksctl get cluster --name ${clusterFullName} --region ${region} -ojson | jq --raw-output '.[0].ResourcesVpcConfig.VpcId' || true)
+                if [ -n "\$VPC_ID" ]; then
+                    LOADBALS=\$(aws elb describe-load-balancers --region ${region} --output json | jq --raw-output '.LoadBalancerDescriptions[] | select(.VPCId == "'\$VPC_ID'").LoadBalancerName')
+                    for loadbal in \$LOADBALS; do
+                        aws elb delete-load-balancer --load-balancer-name \$loadbal --region ${region}
+                    done
+                    eksctl delete cluster -f cluster-${clusterSuffix}.yaml --wait --force --disable-nodegroup-eviction || true
+
+                    VPC_DESC=\$(aws ec2 describe-vpcs --vpc-id \$VPC_ID --region ${region} || true)
+                    if [ -n "\$VPC_DESC" ]; then
+                        aws ec2 delete-vpc --vpc-id \$VPC_ID --region ${region} || true
+                    fi
+                    VPC_DESC=\$(aws ec2 describe-vpcs --vpc-id \$VPC_ID --region ${region} || true)
+                    if [ -n "\$VPC_DESC" ]; then
+                        for secgroup in \$(aws ec2 describe-security-groups --filters Name=vpc-id,Values=\$VPC_ID --query 'SecurityGroups[*].GroupId' --output text --region ${region}); do
+                            aws ec2 delete-security-group --group-id \$secgroup --region ${region} || true
+                        done
+
+                        aws ec2 delete-vpc --vpc-id \$VPC_ID --region ${region} || true
+                    fi
+                fi
+                aws cloudformation delete-stack --stack-name eksctl-${clusterFullName}-cluster --region ${region} || true
+                aws cloudformation wait stack-delete-complete --stack-name eksctl-${clusterFullName}-cluster --region ${region} || true
+
+                eksctl get cluster --name ${clusterFullName} --region ${region} || true
+                aws cloudformation list-stacks --region ${region} | jq '.StackSummaries[] | select(.StackName | startswith("'eksctl-${clusterFullName}-cluster'"))' || true
+            """
+        }
+    }
+}
+
+return this

--- a/cloud/common/vars/gcloud.groovy
+++ b/cloud/common/vars/gcloud.groovy
@@ -7,4 +7,100 @@ void auth() {
     }
 }
 
+def getPlatformVersion(String prefixVersion) {
+    return prefixVersion
+}
+
+def getLatestPlatformVersion(Map testVariables) {
+    return sh(
+        script: "gcloud container get-server-config --region=${testVariables.zone} --flatten=channels --filter='channels.channel=${testVariables.platform_channel}' --format='value(channels.validVersions)' | cut -d- -f1",
+        returnStdout: true
+    ).trim()
+}
+
+def getMachineType(String arch) {
+    switch (arch) {
+        case 'amd64':
+            return 'n1-standard-4'
+        case 'arm64':
+            return 't2a-standard-4'
+        default:
+            error("Unknown architecture: ${arch}")
+    }
+}
+
+void createCluster(Map clusterCfg) {
+    timeout(time: 30, unit: 'MINUTES') {
+        withCredentials([string(credentialsId: 'GCP_PROJECT_ID', variable: 'GCP_PROJECT'), file(credentialsId: 'gcloud-key-file', variable: 'CLIENT_SECRET_FILE')]) {
+            withEnv([
+                "CLUSTER_SUFFIX=${clusterCfg.clusterSuffix}",
+                "CLUSTER_NAME=${clusterCfg.clusterName}",
+                "GKE_RELEASE_CHANNEL=${clusterCfg.platformChannel}",
+                "GKE_REGION=${clusterCfg.zone}",
+                "PLATFORM_VER=${clusterCfg.platformVersion}",
+                "MACHINE_TYPE=${clusterCfg.machineType}"
+            ]) {
+                sh '''
+                    export KUBECONFIG=/tmp/$CLUSTER_NAME-$CLUSTER_SUFFIX
+                    maxRetries=15
+                    exitCode=1
+
+                    while [[ $exitCode != 0 && $maxRetries > 0 ]]; do
+                        gcloud container clusters create $CLUSTER_NAME-$CLUSTER_SUFFIX \
+                            --release-channel $GKE_RELEASE_CHANNEL \
+                            --zone $GKE_REGION \
+                            --cluster-version $PLATFORM_VER \
+                            --preemptible \
+                            --disk-size 30 \
+                            --machine-type $MACHINE_TYPE \
+                            --num-nodes=3 \
+                            --network=jenkins-vpc \
+                            --subnetwork=jenkins-$CLUSTER_SUFFIX \
+                            --cluster-ipv4-cidr=/21 \
+                            --labels delete-cluster-after-hours=6 \
+                            --enable-ip-alias \
+                            --monitoring=NONE \
+                            --logging=NONE \
+                            --no-enable-managed-prometheus \
+                            --workload-pool=cloud-dev-112233.svc.id.goog \
+                            --quiet &&\
+                        kubectl create clusterrolebinding cluster-admin-binding1 --clusterrole=cluster-admin --user=$(gcloud config get-value core/account)
+                        exitCode=$?
+                        if [[ $exitCode == 0 ]]; then break; fi
+                        (( maxRetries -- ))
+                        sleep 1
+                    done
+                    if [[ $exitCode != 0 ]]; then exit $exitCode; fi
+
+                    CURRENT_TIME=$(date --rfc-3339=seconds)
+                    FUTURE_TIME=$(date -d '6 hours' --rfc-3339=seconds)
+
+                    gcloud container clusters update $CLUSTER_NAME-$CLUSTER_SUFFIX \
+                        --zone $GKE_REGION \
+                        --add-maintenance-exclusion-start "$CURRENT_TIME" \
+                        --add-maintenance-exclusion-end "$FUTURE_TIME"
+
+                    kubectl get nodes -o custom-columns="NAME:.metadata.name,TAINTS:.spec.taints,AGE:.metadata.creationTimestamp"
+                '''
+            }
+        }
+    }
+}
+
+void shutdownCluster(Map clusterCfg) {
+    timeout(time: 30, unit: 'MINUTES') {
+        withCredentials([string(credentialsId: 'GCP_PROJECT_ID', variable: 'GCP_PROJECT'), file(credentialsId: 'gcloud-key-file', variable: 'CLIENT_SECRET_FILE')]) {
+            withEnv([
+                "CLUSTER_SUFFIX=${clusterCfg.clusterSuffix}",
+                "CLUSTER_NAME=${clusterCfg.clusterName}",
+                "GKE_REGION=${clusterCfg.zone}"
+            ]) {
+                sh '''
+                    gcloud container clusters delete --async --zone $GKE_REGION $CLUSTER_NAME-$CLUSTER_SUFFIX --quiet || true
+                '''
+            }
+        }
+    }
+}
+
 return this

--- a/cloud/common/vars/minikube.groovy
+++ b/cloud/common/vars/minikube.groovy
@@ -1,0 +1,20 @@
+def getPlatformVersion(String prefixVersion) {
+    return prefixVersion
+}
+
+def getLatestPlatformVersion(Map testVariables) {
+    return testVariables.platform_version
+}
+
+def getMachineType(String arch) {
+    return arch
+}
+
+void createCluster(Map clusterCfg) {
+    sh """
+        export CHANGE_MINIKUBE_NONE_USER=true
+        minikube start --kubernetes-version ${clusterCfg.platformVersion} --cpus=6 --memory=28G --force
+    """
+}
+
+return this

--- a/cloud/common/vars/openshift.groovy
+++ b/cloud/common/vars/openshift.groovy
@@ -1,0 +1,158 @@
+def getPlatformVersion(String prefixVersion) {
+    return prefixVersion
+}
+
+def getLatestPlatformVersion(Map testVariables) {
+    return sh(
+        script: "curl -s https://mirror.openshift.com/pub/openshift-v4/x86_64/clients/ocp/latest/release.txt | sed -n 's/^\\s*Version:\\s\\+\\(\\S\\+\\)\\s*\$/\\1/p'",
+        returnStdout: true
+    ).trim()
+}
+
+def getMachineType(String arch) {
+    return arch
+}
+
+void createCluster(Map clusterCfg) {
+    def clusterSuffix = clusterCfg.clusterSuffix
+
+    timeout(time: 60, unit: 'MINUTES') {
+        withCredentials([aws(credentialsId: 'openshift-cicd', accessKeyVariable: 'AWS_ACCESS_KEY_ID', secretKeyVariable: 'AWS_SECRET_ACCESS_KEY'), file(credentialsId: 'aws-openshift-41-key-pub', variable: 'AWS_NODES_KEY_PUB'), file(credentialsId: 'openshift4-secrets', variable: 'OPENSHIFT_CONF_FILE'), usernamePassword(credentialsId: 'docker.io', passwordVariable: 'DOCKER_READ_PASS', usernameVariable: 'DOCKER_READ_USER')]) {
+            withEnv(["CLUSTER_SUFFIX=${clusterSuffix}", "CLUSTER_NAME=${clusterCfg.clusterName}"]) {
+                sh """
+                    mkdir -p openshift/\$CLUSTER_SUFFIX
+                    timestamp="\$(date +%s)"
+tee openshift/\$CLUSTER_SUFFIX/install-config.yaml << EOF
+additionalTrustBundlePolicy: Proxyonly
+credentialsMode: Mint
+apiVersion: v1
+baseDomain: cd.percona.com
+compute:
+- architecture: amd64
+  hyperthreading: Enabled
+  name: worker
+  platform:
+    aws:
+      type: m5.xlarge
+  replicas: 3
+controlPlane:
+  architecture: amd64
+  hyperthreading: Enabled
+  name: master
+  platform: {}
+  replicas: 1
+metadata:
+  creationTimestamp: null
+  name: \$CLUSTER_NAME-\$CLUSTER_SUFFIX
+networking:
+  clusterNetwork:
+  - cidr: 10.128.0.0/14
+    hostPrefix: 23
+  machineNetwork:
+  - cidr: 10.0.0.0/16
+  networkType: OVNKubernetes
+  serviceNetwork:
+  - 172.30.0.0/16
+platform:
+  aws:
+    region: ${clusterCfg.region}
+    userTags:
+      iit-billing-tag: openshift
+      delete-cluster-after-hours: 7
+      team: cloud
+      product: ${clusterCfg.product}
+      creation-time: \$timestamp
+
+publish: External
+EOF
+                    cat \$OPENSHIFT_CONF_FILE >> openshift/\$CLUSTER_SUFFIX/install-config.yaml
+                """
+                sshagent(['aws-openshift-41-key']) {
+                    sh '''
+                        /usr/local/bin/openshift-install create cluster --dir=openshift/$CLUSTER_SUFFIX --log-level=debug || {
+                            /usr/local/bin/openshift-install gather bootstrap --dir=openshift/$CLUSTER_SUFFIX || true
+                            exit 1
+                        }
+                        export KUBECONFIG=openshift/$CLUSTER_SUFFIX/auth/kubeconfig
+                        TMP=$(mktemp)
+                        oc get secret/pull-secret -n openshift-config --template='{{index .data ".dockerconfigjson" | base64decode}}' > $TMP
+                        oc registry login --registry='docker.io' --auth-basic="$DOCKER_READ_USER:$DOCKER_READ_PASS" --to=$TMP
+                        oc set data secret/pull-secret -n openshift-config --from-file=.dockerconfigjson=$TMP
+                        rm -rf $TMP
+                    '''
+                }
+            }
+        }
+    }
+
+    enableVolumeSnapshotResources(clusterSuffix)
+    verifyVolumeSnapshotResources(clusterSuffix)
+}
+
+void enableVolumeSnapshotResources(String clusterSuffix) {
+    sh """
+        export KUBECONFIG=\$WORKSPACE/openshift/${clusterSuffix}/auth/kubeconfig
+
+        for i in \$(seq 1 60); do
+            if kubectl get crd csisnapshotcontrollers.operator.openshift.io >/dev/null 2>&1; then
+                break
+            fi
+            sleep 10
+        done
+
+        cat <<EOF | kubectl apply -f -
+apiVersion: operator.openshift.io/v1
+kind: CSISnapshotController
+metadata:
+  name: cluster
+spec:
+  managementState: Managed
+EOF
+
+        kubectl get csisnapshotcontroller cluster -o yaml
+    """
+}
+
+void verifyVolumeSnapshotResources(String clusterSuffix) {
+    sh """
+        export KUBECONFIG=\$WORKSPACE/openshift/${clusterSuffix}/auth/kubeconfig
+
+        wait_for_deployment() {
+            local deployment_name="\$1"
+            local namespace="\$2"
+
+            for i in \$(seq 1 60); do
+                if kubectl get deployment "\$deployment_name" -n "\$namespace" >/dev/null 2>&1; then
+                    kubectl wait --for=condition=Available deployment/"\$deployment_name" -n "\$namespace" --timeout=10m
+                    return 0
+                fi
+                sleep 10
+            done
+
+            kubectl get deployment -n "\$namespace" || true
+            return 1
+        }
+
+        wait_for_deployment csi-snapshot-controller-operator openshift-cluster-storage-operator
+        wait_for_deployment csi-snapshot-controller openshift-cluster-storage-operator
+
+        kubectl get crd volumesnapshots.snapshot.storage.k8s.io volumesnapshotcontents.snapshot.storage.k8s.io volumesnapshotclasses.snapshot.storage.k8s.io
+        kubectl api-resources --api-group=snapshot.storage.k8s.io
+    """
+}
+
+void shutdownCluster(Map clusterCfg) {
+    def clusterSuffix = clusterCfg.clusterSuffix
+
+    timeout(time: 30, unit: 'MINUTES') {
+        withCredentials([aws(credentialsId: 'openshift-cicd', accessKeyVariable: 'AWS_ACCESS_KEY_ID'), file(credentialsId: 'aws-openshift-41-key-pub', variable: 'AWS_NODES_KEY_PUB'), file(credentialsId: 'openshift-secret-file', variable: 'OPENSHIFT-CONF-FILE')]) {
+            sshagent(['aws-openshift-41-key']) {
+                sh """
+                    /usr/local/bin/openshift-install destroy cluster --dir=openshift/${clusterSuffix} || true
+                """
+            }
+        }
+    }
+}
+
+return this

--- a/cloud/common/vars/rancher.groovy
+++ b/cloud/common/vars/rancher.groovy
@@ -69,8 +69,10 @@ void shutdownCluster(Map clusterCfg) {
     }
 }
 
-def getLatestPlatformVersion(String channel) {
-    sh(
+def getLatestPlatformVersion(Map testVariables) {
+    def channel = testVariables.platform_channel
+
+    return sh(
         script: """
             curl -fsSL https://update.rke2.io/v1-release/channels \
             | jq -r --arg channel "${channel}" '.data[] | select(.id == \$channel) | .latest'

--- a/cloud/common/vars/tests.groovy
+++ b/cloud/common/vars/tests.groovy
@@ -536,7 +536,12 @@ void runTest(Map testConfig) {
 
                     ${exports}
 
-                    ${command}
+                    mkdir -p e2e-tests/logs e2e-tests/reports
+                    bash -o pipefail <<BASH
+                    {
+                        ${command}
+                    } 2>&1 | tee e2e-tests/logs/${testName}.log
+BASH
                 """
             }
 
@@ -565,6 +570,14 @@ void runTest(Map testConfig) {
 
         } finally {
             updateTestTime(testVariables.tests, testId, elapsedSeconds(System.currentTimeMillis() - timeStart))
+            try {
+                pushLogFile(testName, [
+                    sourceDir     : 'source',
+                    gitShortCommit: testVariables.git_short_commit
+                ])
+            } catch (logErr) {
+                echo "Warning: failed to push log for ${testName}: ${logErr}"
+            }
             echo "The ${testName} test was finished!"
         }
     }
@@ -663,17 +676,194 @@ Map getParallelStages(Map testVariables) {
     return parallelStages
 }
 
-void makeReport(List tests, Map testVariables) {
-    echo "=========================[ Generating Test Report ]========================="
-    tests = tests ?: []
-
-    def testsReport = "<testsuite name=\"$JOB_NAME\">\n"
-    tests.each { test ->
-        testsReport += "<testcase name=\"${test.name}\" time=\"${test.time}\"><${test.result}/></testcase>\n"
+String formatTime(def time) {
+    if (!time || time == "N/A") {
+        return "N/A"
     }
 
-    testsReport += "</testsuite>\n"
+    try {
+        def totalSeconds = time as Double
+        def hours = (totalSeconds / 3600) as Integer
+        def minutes = ((totalSeconds % 3600) / 60) as Integer
+        def seconds = (totalSeconds % 60) as Integer
 
+        return String.format("%02d:%02d:%02d", hours, minutes, seconds)
+    } catch (Exception e) {
+        println("Error converting time: ${e.message}")
+        return time.toString()
+    }
+}
+
+void pushLogFile(String testName, Map config = [:]) {
+    def sourceDir = config.sourceDir ?: 'source'
+    def gitShortCommit = config.gitShortCommit ?: env.GIT_SHORT_COMMIT
+    def logFilePath = "${sourceDir}/e2e-tests/logs/${testName}.log"
+    def logFileName = "${testName}.log"
+
+    echo "Push logfile ${logFileName} to S3!"
+    withCredentials([aws(credentialsId: 'AMI/OVF', accessKeyVariable: 'AWS_ACCESS_KEY_ID', secretKeyVariable: 'AWS_SECRET_ACCESS_KEY')]) {
+        sh """
+            S3_PATH=s3://percona-jenkins-artifactory-public/\$JOB_NAME/${gitShortCommit}
+            if [ ! -f ${logFilePath} ]; then
+                mkdir -p ${sourceDir}/e2e-tests/logs
+                cat > ${logFilePath} <<EOF
+Log file ${logFileName} was not found in Jenkins workspace.
+The test may have timed out or terminated before the test runner created/flushed the log.
+Build URL: ${BUILD_URL}
+EOF
+            fi
+            aws s3 ls \$S3_PATH/${logFileName} || :
+            aws s3 cp --content-type text/plain --quiet ${logFilePath} \$S3_PATH/${logFileName}
+        """
+    }
+}
+
+void pushReportFile(String reportHtml, String gitShortCommit) {
+    echo "Push ${reportHtml} to S3!"
+    withCredentials([aws(credentialsId: 'AMI/OVF', accessKeyVariable: 'AWS_ACCESS_KEY_ID', secretKeyVariable: 'AWS_SECRET_ACCESS_KEY')]) {
+        sh """
+            S3_PATH=s3://percona-jenkins-artifactory-public/\$JOB_NAME/${gitShortCommit}
+            aws s3 cp --content-type text/html --quiet ${reportHtml} \$S3_PATH/${reportHtml} || :
+        """
+    }
+}
+
+void normalizeReports(List tests, String sourceDir = 'source') {
+    def reportsDir = "${sourceDir}/e2e-tests/reports"
+    sh "mkdir -p ${reportsDir}"
+
+    for (int i = 0; i < tests.size(); i++) {
+        def testName = tests[i]["name"] ?: tests[i].name
+        def testResult = tests[i]["result"] ?: tests[i].result
+        def testTime = (tests[i]["time"] ?: tests[i].time) ?: 0
+
+        if (testResult == "skipped") {
+            continue
+        }
+
+        def xmlFile = "${reportsDir}/${testName}.xml"
+        def htmlFile = "${reportsDir}/${testName}.html"
+
+        def failures = testResult == "failure" ? 1 : 0
+        def errors = testResult == "error" ? 1 : 0
+        def resultElement = ""
+        if (testResult == "failure") {
+            resultElement = '<failure message="Jenkins reported test failure">Jenkins reported this test as failed. See the HTML report for details.</failure>'
+        } else if (testResult == "error") {
+            resultElement = '<error message="Jenkins reported test error">Jenkins reported this test as errored (infrastructure/timeout). See the HTML report for details.</error>'
+        }
+
+        writeFile file: xmlFile, text: """<?xml version="1.0" encoding="utf-8"?>
+<testsuites name="pytest tests">
+<testsuite name="psmdb-e2e" errors="${errors}" failures="${failures}" skipped="0" tests="1" time="${testTime}">
+<testcase classname="" name="${testName}" time="${testTime}">
+${resultElement}
+</testcase>
+</testsuite>
+</testsuites>"""
+
+        if (!fileExists(htmlFile)) {
+            def formattedTime = formatTime(testTime)
+            def resultCapitalized
+            def logMessage
+            if (testResult == "failure") {
+                resultCapitalized = "Failed"
+                logMessage = "Test did not produce a report"
+            } else if (testResult == "error") {
+                resultCapitalized = "Error"
+                logMessage = "Test errored (infrastructure/timeout) and did not produce a report"
+            } else {
+                resultCapitalized = "Passed"
+                logMessage = "Test marked as passed (from previous run)"
+            }
+
+            writeFile file: htmlFile, text: """<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8"/>
+<title id="head-title">${testName}.html</title>
+</head>
+<body>
+<div id="data-container" data-jsonblob='{"environment": {"Note": "Placeholder report generated because the test report was missing"}, "tests": {"${testName}": [{"extras": [], "result": "${resultCapitalized}", "testId": "${testName}", "duration": "${formattedTime}", "resultsTableRow": ["<td class=\\"col-result\\">${resultCapitalized}</td>", "<td>-</td>", "<td class=\\"col-testId\\">${testName}</td>", "<td class=\\"col-duration\\">${formattedTime}</td>", "<td>-</td>"], "log": "${logMessage}"}]}}'></div>
+</body>
+</html>"""
+        }
+    }
+}
+
+void formatReportDuration(String htmlFile) {
+    def marker = ' tests ran in '
+    def suffix = ' seconds'
+    def html = readFile(htmlFile)
+
+    def valueStart = html.indexOf(marker)
+    if (valueStart < 0) {
+        return
+    }
+    valueStart += marker.length()
+
+    def valueEnd = html.indexOf(suffix, valueStart)
+    if (valueEnd < 0) {
+        return
+    }
+
+    def formatted = formatTime(html.substring(valueStart, valueEnd))
+    writeFile file: htmlFile, text: html.substring(0, valueStart) + formatted + html.substring(valueEnd + suffix.length())
+}
+
+void writePipelineParameters(String pipelineParameters) {
+    writeFile file: 'PipelineParameters.txt', text: pipelineParameters
+    addSummary(icon: 'symbol-aperture-outline plugin-ionicons-api',
+        text: "<pre>${pipelineParameters}</pre>"
+    )
+}
+
+void publishPytestReports(Map config) {
+    def tests = config.tests ?: []
+    def sourceDir = config.sourceDir ?: 'source'
+    def reportHtml = config.reportHtml ?: 'e2e-test-report.html'
+    def reportXml = config.reportXml ?: 'e2e-test-report.xml'
+    def gitShortCommit = config.gitShortCommit ?: env.GIT_SHORT_COMMIT
+    def gitBranch = config.gitBranch ?: env.GIT_BRANCH
+    def title = config.title ?: "PSMDB e2e tests - ${gitBranch} (${gitShortCommit})"
+    def pushToS3 = config.containsKey('pushToS3') ? config.pushToS3 : true
+
+    echo "=========================[ Publishing pytest HTML/JUnit reports ]========================="
+
+    def startedTests = tests.findAll { test ->
+        def result = test.containsKey("result") ? test.result : test["result"]
+        result && result != "skipped"
+    }
+
+    if (!startedTests) {
+        echo "No started tests; skipping pytest report merge."
+        return
+    }
+
+    try {
+        normalizeReports(tests, sourceDir)
+
+        sh """
+            set -euo pipefail
+            export PATH="\$HOME/.local/bin:\$PATH"
+            cd ${sourceDir}
+            uv run pytest_html_merger -i e2e-tests/reports -o "\$WORKSPACE/${reportHtml}" -t "${title}"
+            uv run junitparser merge --glob 'e2e-tests/reports/*.xml' "\$WORKSPACE/${reportXml}"
+        """
+
+        formatReportDuration(reportHtml)
+        junit testResults: reportXml, healthScaleFactor: 1.0, allowEmptyResults: true
+        archiveArtifacts artifacts: "${reportXml}, ${reportHtml}, PipelineParameters.txt", allowEmptyArchive: true
+
+        if (pushToS3 && gitShortCommit) {
+            pushReportFile(reportHtml, gitShortCommit)
+        }
+    } catch (err) {
+        echo "Warning: pytest report publish failed: ${err}"
+    }
+}
+
+void makeReport(List tests, Map testVariables) {
     echo "=========================[ Generating Parameters Report ]========================="
 
     def pipelineParameters = "testsuite name=${testVariables.job_name}\n"
@@ -686,11 +876,13 @@ void makeReport(List tests, Map testVariables) {
     pipelineParameters += "PLATFORM_ARCH=${testVariables.platform_arch ?: 'e2e_defaults'}\n"
     pipelineParameters += "CLUSTER_WIDE=${testVariables.cluster_wide ?: 'e2e_defaults'}\n"
 
-    writeFile file: "TestsReport.xml", text: testsReport
-    writeFile file: "PipelineParameters.txt", text: pipelineParameters
+    writePipelineParameters(pipelineParameters)
 
-    addSummary(icon: 'symbol-aperture-outline plugin-ionicons-api',
-        text: "<pre>${pipelineParameters}</pre>"
+    publishPytestReports(
+        tests         : tests,
+        gitShortCommit: testVariables.git_short_commit,
+        gitBranch     : testVariables.git_branch,
+        title         : "PSMDB e2e tests - ${testVariables.git_branch ?: env.GIT_BRANCH} (${testVariables.git_short_commit})"
     )
 }
 

--- a/cloud/common/vars/tests.groovy
+++ b/cloud/common/vars/tests.groovy
@@ -125,7 +125,7 @@ void resolveReleaseRunParams(Map testVariables) {
 
     testVariables.images = resolveImages(testVariables)
 
-    def supportedPlatforms = ["gke", "azs", "openshift", "doks", "rke2", "minikube"]
+    def supportedPlatforms = ["gke", "aks", "eks", "openshift", "doks", "rke2", "minikube"]
     if (!(testVariables.platform in supportedPlatforms)) {
         error("Unsupported platform: ${testVariables.platform}")
     }
@@ -158,10 +158,8 @@ Boolean resolveReleasePlatformVersion(Map testVariables) {
 
 void resolvePlatformVersion(Map testVariables, Boolean platformFromReleaseVersions) {
     def library = testVariables.libraries[testVariables.platform_provider]
-    if (testVariables.platform_version == "latest" && testVariables.platform_channel) {
-        testVariables.platform_version = library.getLatestPlatformVersion(
-            testVariables.platform_channel
-        )
+    if (testVariables.platform_version == "latest") {
+        testVariables.platform_version = library.getLatestPlatformVersion(testVariables)
     } else if (!platformFromReleaseVersions) {
         testVariables.platform_version = library.getPlatformVersion(
             testVariables.platform_version

--- a/cloud/common/vars/tests.groovy
+++ b/cloud/common/vars/tests.groovy
@@ -355,7 +355,12 @@ Map resolveImages(Map testVariables) {
 String getExportedVariablesForTests(Map testVariables, String clusterSuffix) {
     def exports = []
 
-    exports << "export KUBECONFIG=${testVariables.kubeconfigPath ?: '/tmp'}/${getClusterFullName(testVariables.cluster_name, clusterSuffix)}"
+    if (testVariables.kubeconfig) {
+        exports << "export KUBECONFIG=${testVariables.kubeconfig}"
+    } else if (!testVariables.skip_kubeconfig) {
+        exports << "export KUBECONFIG=${testVariables.kubeconfigPath ?: '/tmp'}/${getClusterFullName(testVariables.cluster_name, clusterSuffix)}"
+    }
+
     exports << "[[ '${testVariables.debug_tests}' == 'YES' ]] && export DEBUG_TESTS=1"
     exports << "[[ '${testVariables.cluster_wide}' == 'YES' ]] && export OPERATOR_NS='${testVariables.operator}'"
     exports << """
@@ -372,6 +377,12 @@ String getExportedVariablesForTests(Map testVariables, String clusterSuffix) {
         exports << "export PG_VER=\$(echo \$IMAGE_POSTGRESQL | sed -E 's/.*:(.*ppg)?([0-9]+).*/\\2/')"
     }
 
+    if (testVariables.test_executor_type == "make") {
+        exports << 'export PATH="$HOME/.local/bin:$PATH"'
+        exports << 'export SKIP_DELETE=0'
+        exports << 'export COLUMNS=200'
+    }
+
     testVariables.extra_envs?.each { key, value ->
         exports << "export ${key}='${value ?: ""}'"
     }
@@ -379,9 +390,29 @@ String getExportedVariablesForTests(Map testVariables, String clusterSuffix) {
     return exports.join("\n")
 }
 
+Map buildPsmdbTestVariables(Map config) {
+    return [
+        cluster_name           : config.cluster_name,
+        kubeconfigPath         : config.kubeconfigPath ?: '/tmp',
+        kubeconfig             : config.kubeconfig,
+        skip_kubeconfig        : config.skip_kubeconfig ?: false,
+        debug_tests            : config.debug_tests,
+        cluster_wide           : config.cluster_wide,
+        operator               : 'psmdb-operator',
+        default_operator_image : config.default_operator_image,
+        test_executor_type     : 'make',
+        images                 : config.images,
+        extra_envs             : config.extra_envs ?: [:]
+    ]
+}
+
 String defineTestCommand(Map testVariables, String testName) {
     if (testVariables.test_executor_type == "kuttl") {
         return "kubectl kuttl test --config e2e-tests/kuttl.yaml --test '^${testName}\$'"
+    }
+
+    if (testVariables.test_executor_type == "make") {
+        return "make e2e-test TEST=${testName}"
     }
 
     return "e2e-tests/${testName}/run"

--- a/cloud/common/vars/tests.groovy
+++ b/cloud/common/vars/tests.groovy
@@ -733,9 +733,9 @@ void normalizeReports(List tests, String sourceDir = 'source') {
     sh "mkdir -p ${reportsDir}"
 
     for (int i = 0; i < tests.size(); i++) {
-        def testName = tests[i]["name"] ?: tests[i].name
-        def testResult = tests[i]["result"] ?: tests[i].result
-        def testTime = (tests[i]["time"] ?: tests[i].time) ?: 0
+        def testName = tests[i]["name"]
+        def testResult = tests[i]["result"]
+        def testTime = tests[i]["time"] ?: 0
 
         if (testResult == "skipped") {
             continue
@@ -744,6 +744,8 @@ void normalizeReports(List tests, String sourceDir = 'source') {
         def xmlFile = "${reportsDir}/${testName}.xml"
         def htmlFile = "${reportsDir}/${testName}.html"
 
+        // Always collapse to a single testcase per test so python (multi-method) and
+        // bash-wrapper tests are counted identically in JUnit. Detail stays in the HTML.
         def failures = testResult == "failure" ? 1 : 0
         def errors = testResult == "error" ? 1 : 0
         def resultElement = ""
@@ -844,19 +846,25 @@ void publishPytestReports(Map config) {
         normalizeReports(tests, sourceDir)
 
         sh """
-            set -euo pipefail
             export PATH="\$HOME/.local/bin:\$PATH"
             cd ${sourceDir}
             uv run pytest_html_merger -i e2e-tests/reports -o "\$WORKSPACE/${reportHtml}" -t "${title}"
             uv run junitparser merge --glob 'e2e-tests/reports/*.xml' "\$WORKSPACE/${reportXml}"
         """
 
-        formatReportDuration(reportHtml)
+        if (fileExists(reportHtml)) {
+            formatReportDuration(reportHtml)
+        }
+
         junit testResults: reportXml, healthScaleFactor: 1.0, allowEmptyResults: true
         archiveArtifacts artifacts: "${reportXml}, ${reportHtml}, PipelineParameters.txt", allowEmptyArchive: true
 
-        if (pushToS3 && gitShortCommit) {
+        if (pushToS3 && gitShortCommit && fileExists(reportHtml)) {
             pushReportFile(reportHtml, gitShortCommit)
+
+            def reportUrl = "https://percona-jenkins-artifactory-public.s3.amazonaws.com/${env.JOB_NAME}/${gitShortCommit}/${reportHtml}"
+            def reportLink = "<a href=\"${reportUrl}\">Test report</a>"
+            currentBuild.description = currentBuild.description ? "${currentBuild.description} | ${reportLink}" : reportLink
         }
     } catch (err) {
         echo "Warning: pytest report publish failed: ${err}"

--- a/cloud/common/vars/tools.groovy
+++ b/cloud/common/vars/tools.groovy
@@ -71,6 +71,7 @@ void dockerBuildAndPush(Map cfg) {
                     docker buildx create --use || true
                     echo "\$PASS" | docker login -u "\$USER" --password-stdin
                     export IMAGE=${cfg.operatorImage}:${cfg.branch}
+                    ${cfg.platform ? "export DOCKER_DEFAULT_PLATFORM=${cfg.platform}" : ""}
                     e2e-tests/build
                     docker logout
                 '

--- a/cloud/common/vars/tools.groovy
+++ b/cloud/common/vars/tools.groovy
@@ -33,7 +33,7 @@ def kubernetesCleanupCluster(String kubeconfig) {
         if [ -s "\$KUBECONFIG" ] && kubectl get --raw='/healthz' --request-timeout=5s >/dev/null 2>&1; then
             for namespace in \$(kubectl get namespaces --request-timeout=5s --no-headers \
                 | awk '{print \$1}' \
-                | grep -vE "^kube-|^gke-|^cattle-" \
+                | grep -vE "^kube-|^gke-|^cattle-|^openshift" \
                 | sed '/-operator/ s/^/1-/' \
                 | sort \
                 | sed 's/^1-//'); do

--- a/cloud/jenkins/psmdbo_aks.groovy
+++ b/cloud/jenkins/psmdbo_aks.groovy
@@ -214,12 +214,12 @@ void runTest(Integer TEST_ID) {
 
     waitUntil {
         def timeStart = new Date().getTime()
+        def testsLib = load('cloud/common/vars/tests.groovy')
         try {
             echo "The $testName test was started on cluster $CLUSTER_NAME-$clusterSuffix !"
             tests[TEST_ID]["result"] = "failure"
 
             timeout(time: 90, unit: 'MINUTES') {
-                def testsLib = load('cloud/common/vars/tests.groovy')
                 def testVars = testsLib.buildPsmdbTestVariables(
                     cluster_name: CLUSTER_NAME,
                     debug_tests: DEBUG_TESTS,
@@ -244,7 +244,12 @@ void runTest(Integer TEST_ID) {
 
                     ${exports}
 
-                    ${testCmd}
+                    mkdir -p e2e-tests/logs e2e-tests/reports
+                    bash -o pipefail <<BASH
+                    {
+                        ${testCmd}
+                    } 2>&1 | tee e2e-tests/logs/${testName}.log
+BASH
                 """
             }
             pushArtifactFile("$GIT_BRANCH-$GIT_SHORT_COMMIT-$testName-$PLATFORM_VER-$DB_TAG-CW_$CLUSTER_WIDE-$PARAMS_HASH")
@@ -263,6 +268,11 @@ void runTest(Integer TEST_ID) {
             def timeStop = new Date().getTime()
             def durationSec = (timeStop - timeStart) / 1000
             tests[TEST_ID]["time"] = durationSec
+            try {
+                testsLib.pushLogFile(testName, [gitShortCommit: GIT_SHORT_COMMIT])
+            } catch (logErr) {
+                echo "Warning: failed to push log for $testName: ${logErr}"
+            }
             echo "The $testName test was finished!"
         }
     }
@@ -282,15 +292,8 @@ void pushArtifactFile(String FILE_NAME) {
 }
 
 void makeReport() {
-    echo "=========================[ Generating Test Report ]========================="
-    testsReport = "<testsuite name=\"$JOB_NAME\">\n"
-    for (int i = 0; i < tests.size(); i ++) {
-        testsReport += '<testcase name="' + tests[i]["name"] + '" time="' + tests[i]["time"] + '"><'+ tests[i]["result"] +'/></testcase>\n'
-    }
-    testsReport += '</testsuite>\n'
-
     echo "=========================[ Generating Parameters Report ]========================="
-    pipelineParameters = """
+    def pipelineParameters = """
 testsuite name=$JOB_NAME
 IMAGE_OPERATOR=${IMAGE_OPERATOR ?: 'e2e_defaults'}
 IMAGE_MONGOD=${IMAGE_MONGOD ?: 'e2e_defaults'}
@@ -303,11 +306,13 @@ IMAGE_LOGCOLLECTOR=${IMAGE_LOGCOLLECTOR ?: 'e2e_defaults'}
 IMAGE_SEARCH=${IMAGE_SEARCH ?: 'e2e_defaults'}
 PLATFORM_VER=$PLATFORM_VER"""
 
-    writeFile file: "TestsReport.xml", text: testsReport
-    writeFile file: 'PipelineParameters.txt', text: pipelineParameters
-
-    addSummary(icon: 'symbol-aperture-outline plugin-ionicons-api',
-        text: "<pre>${pipelineParameters}</pre>"
+    def testsLib = load('cloud/common/vars/tests.groovy')
+    testsLib.writePipelineParameters(pipelineParameters)
+    testsLib.publishPytestReports(
+        tests         : tests,
+        gitShortCommit: GIT_SHORT_COMMIT,
+        gitBranch     : GIT_BRANCH,
+        title         : "PSMDB e2e tests - ${GIT_BRANCH} (${GIT_SHORT_COMMIT})"
     )
 }
 
@@ -408,8 +413,6 @@ pipeline {
         always {
             echo "CLUSTER ASSIGNMENTS\n" + tests.toString().replace("], ","]\n").replace("]]","]").replaceFirst("\\[","")
             makeReport()
-            junit testResults: '*.xml', healthScaleFactor: 1.0
-            archiveArtifacts '*.xml,*.txt'
 
             script {
                 try {

--- a/cloud/jenkins/psmdbo_aks.groovy
+++ b/cloud/jenkins/psmdbo_aks.groovy
@@ -29,17 +29,13 @@ String getParam(String paramName, String keyName = null) {
 void prepareNode() {
     location = params.AKS_LOCATION ?: getLocation(JOB_NAME)
 
-    echo "=========================[ Cloning the sources ]========================="
     checkout(scm)
-    sh """
-        # sudo is needed for better node recovery after compilation failure
-        # if building failed on compilation stage directory will have files owned by docker user
-        sudo git config --global --add safe.directory '*'
-        sudo git reset --hard
-        sudo git clean -xdf
-        sudo rm -rf source
-        git clone -b $GIT_BRANCH https://github.com/percona/percona-server-mongodb-operator source
-    """
+    def libraries = load('cloud/common/libraries.groovy').loadLibraries()
+    libraries.tools.gitResetWorkspace()
+    libraries.tools.gitClone(
+        branch: GIT_BRANCH,
+        repo: 'https://github.com/percona/percona-server-mongodb-operator'
+    )
 
     if ("$PILLAR_VERSION" != "none") {
         echo "=========================[ Getting parameters for release test ]========================="
@@ -60,7 +56,6 @@ void prepareNode() {
     }
 
     echo "=========================[ Installing tools on the Jenkins executor ]========================="
-    def libraries = load('cloud/common/libraries.groovy').loadLibraries()
     libraries.dependencies.install()
     libraries.dependencies.installGoogleCLI()
     libraries.dependencies.installAzureCLI()
@@ -292,48 +287,33 @@ void pushArtifactFile(String FILE_NAME) {
 }
 
 void makeReport() {
-    echo "=========================[ Generating Parameters Report ]========================="
-    def pipelineParameters = """
-testsuite name=$JOB_NAME
-IMAGE_OPERATOR=${IMAGE_OPERATOR ?: 'e2e_defaults'}
-IMAGE_MONGOD=${IMAGE_MONGOD ?: 'e2e_defaults'}
-IMAGE_BACKUP=${IMAGE_BACKUP ?: 'e2e_defaults'}
-IMAGE_PMM_CLIENT=${IMAGE_PMM_CLIENT ?: 'e2e_defaults'}
-IMAGE_PMM_SERVER=${IMAGE_PMM_SERVER ?: 'e2e_defaults'}
-IMAGE_PMM3_CLIENT=${IMAGE_PMM3_CLIENT ?: 'e2e_defaults'}
-IMAGE_PMM3_SERVER=${IMAGE_PMM3_SERVER ?: 'e2e_defaults'}
-IMAGE_LOGCOLLECTOR=${IMAGE_LOGCOLLECTOR ?: 'e2e_defaults'}
-IMAGE_SEARCH=${IMAGE_SEARCH ?: 'e2e_defaults'}
-PLATFORM_VER=$PLATFORM_VER"""
-
-    def testsLib = load('cloud/common/vars/tests.groovy')
-    testsLib.writePipelineParameters(pipelineParameters)
-    testsLib.publishPytestReports(
-        tests         : tests,
-        gitShortCommit: GIT_SHORT_COMMIT,
-        gitBranch     : GIT_BRANCH,
-        title         : "PSMDB e2e tests - ${GIT_BRANCH} (${GIT_SHORT_COMMIT})"
-    )
+    def libraries = load('cloud/common/libraries.groovy').loadLibraries()
+    libraries.tests.makeReport(tests, [
+        job_name         : JOB_NAME,
+        git_branch       : GIT_BRANCH,
+        git_short_commit : GIT_SHORT_COMMIT,
+        platform_version : PLATFORM_VER,
+        cluster_wide     : CLUSTER_WIDE,
+        images: [
+            IMAGE_OPERATOR    : IMAGE_OPERATOR,
+            IMAGE_MONGOD      : IMAGE_MONGOD,
+            IMAGE_BACKUP      : IMAGE_BACKUP,
+            IMAGE_PMM_CLIENT  : IMAGE_PMM_CLIENT,
+            IMAGE_PMM_SERVER  : IMAGE_PMM_SERVER,
+            IMAGE_PMM3_CLIENT : IMAGE_PMM3_CLIENT,
+            IMAGE_PMM3_SERVER : IMAGE_PMM3_SERVER,
+            IMAGE_LOGCOLLECTOR: IMAGE_LOGCOLLECTOR,
+            IMAGE_SEARCH      : IMAGE_SEARCH
+        ]
+    ])
 }
 
 void shutdownCluster(String CLUSTER_SUFFIX) {
     timeout(time: 30, unit: 'MINUTES') {
         withCredentials([azureServicePrincipal('PERCONA-OPERATORS-SP')]) {
+            def libraries = load('cloud/common/libraries.groovy').loadLibraries()
+            libraries.tools.kubernetesCleanupCluster("/tmp/${CLUSTER_NAME}-${CLUSTER_SUFFIX}")
             sh """
-                export KUBECONFIG=/tmp/$CLUSTER_NAME-$CLUSTER_SUFFIX
-                if [ -s "\$KUBECONFIG" ] && kubectl get --raw='/healthz' --request-timeout=5s >/dev/null 2>&1; then
-                    for namespace in \$(kubectl get namespaces --request-timeout=5s --no-headers | awk '{print \$1}' | grep -vE "^kube-" | sed '/-operator/ s/^/1-/' | sort | sed 's/^1-//'); do
-                        kubectl delete deployments --all -n \$namespace --force --grace-period=0 --request-timeout=10s || true
-                        kubectl delete sts --all -n \$namespace --force --grace-period=0 --request-timeout=10s || true
-                        kubectl delete replicasets --all -n \$namespace --force --grace-period=0 --request-timeout=10s || true
-                        kubectl delete poddisruptionbudget --all -n \$namespace --force --grace-period=0 --request-timeout=10s || true
-                        kubectl delete services --all -n \$namespace --force --grace-period=0 --request-timeout=10s || true
-                        kubectl delete pods --all -n \$namespace --force --grace-period=0 --request-timeout=10s || true
-                    done
-                else
-                    echo "Skipping namespace cleanup: Kubernetes API is not reachable for $CLUSTER_NAME-$CLUSTER_SUFFIX"
-                fi
-
                 az aks delete --name $CLUSTER_NAME-$CLUSTER_SUFFIX --resource-group percona-operators --subscription eng-cloud-dev --yes || true
             """
         }
@@ -431,11 +411,11 @@ pipeline {
                 }
 
                 clusters.each { shutdownCluster(it) }
+
+                def libraries = load('cloud/common/libraries.groovy').loadLibraries()
+                libraries.tools.dockerCleanupVolumes()
             }
 
-            sh """
-                sudo docker system prune --volumes -af
-            """
             deleteDir()
         }
     }

--- a/cloud/jenkins/psmdbo_aks.groovy
+++ b/cloud/jenkins/psmdbo_aks.groovy
@@ -78,6 +78,7 @@ void prepareNode() {
     IMAGE_PMM3_SERVER = testVariables.images.IMAGE_PMM3_SERVER
     IMAGE_LOGCOLLECTOR = testVariables.images.IMAGE_LOGCOLLECTOR
     IMAGE_SEARCH = testVariables.images.IMAGE_SEARCH
+    DB_TAG = testVariables.db_tag
     GIT_SHORT_COMMIT = testVariables.git_short_commit
     CLUSTER_NAME = testVariables.cluster_name
     PARAMS_HASH = testVariables.params_hash

--- a/cloud/jenkins/psmdbo_aks.groovy
+++ b/cloud/jenkins/psmdbo_aks.groovy
@@ -26,30 +26,6 @@ String getParam(String paramName, String keyName = null) {
     return param
 }
 
-void downloadKubectl() {
-    sh """
-        KUBECTL_VERSION="\$(curl -L -s https://api.github.com/repos/kubernetes/kubernetes/releases/latest | jq -r .tag_name)"
-        for i in {1..5}; do
-          if [ -f /usr/local/bin/kubectl ]; then
-              break
-          fi
-          echo "Attempt \$i: downloading kubectl..."
-          sudo curl -s -L -o /usr/local/bin/kubectl "https://dl.k8s.io/release/\${KUBECTL_VERSION}/bin/linux/amd64/kubectl"
-          sudo curl -s -L -o /tmp/kubectl.sha256 "https://dl.k8s.io/release/\${KUBECTL_VERSION}/bin/linux/amd64/kubectl.sha256"
-          if echo "\$(cat /tmp/kubectl.sha256) /usr/local/bin/kubectl" | sha256sum --check --status; then
-            echo 'Download passed checksum'
-            sudo chmod +x /usr/local/bin/kubectl
-            kubectl version --client --output=yaml
-            break
-          else
-            echo 'Checksum failed, retrying...'
-            sudo rm -f /usr/local/bin/kubectl /tmp/kubectl.sha256
-            sleep 5
-          fi
-        done
-    """
-}
-
 void prepareNode() {
     location = params.AKS_LOCATION ?: getLocation(JOB_NAME)
 
@@ -84,35 +60,13 @@ void prepareNode() {
     }
 
     echo "=========================[ Installing tools on the Jenkins executor ]========================="
-    sh """
-        sudo curl -fsSL https://github.com/mikefarah/yq/releases/download/v4.44.1/yq_linux_amd64 -o /usr/local/bin/yq && sudo chmod +x /usr/local/bin/yq
-        sudo curl -fsSL https://github.com/jqlang/jq/releases/download/jq-1.7.1/jq-linux64 -o /usr/local/bin/jq && sudo chmod +x /usr/local/bin/jq
-    """
-    downloadKubectl()
-    sh """
-        curl -fsSL https://get.helm.sh/helm-v3.20.0-linux-amd64.tar.gz | sudo tar -C /usr/local/bin --strip-components 1 -xzf - linux-amd64/helm
-    """
-
-    sh '''
-        if ! command -v gsutil &>/dev/null; then
-            echo "gsutil not found, installing google-cloud-cli..."
-            sudo tee /etc/yum.repos.d/google-cloud-sdk.repo << EOF
-[google-cloud-cli]
-name=Google Cloud CLI
-baseurl=https://packages.cloud.google.com/yum/repos/cloud-sdk-el7-x86_64
-enabled=1
-gpgcheck=1
-repo_gpgcheck=0
-gpgkey=https://packages.cloud.google.com/yum/doc/rpm-package-key.gpg
-EOF
-            sudo yum install -y google-cloud-cli
-        fi
-        command -v gsutil
-        gsutil version -l | head -n1
-    '''
-
-    installAzureCLI()
-    azureAuth()
+    def libraries = load('cloud/common/libraries.groovy').loadLibraries()
+    libraries.dependencies.install()
+    libraries.dependencies.installGoogleCLI()
+    libraries.dependencies.installAzureCLI()
+    libraries.dependencies.installUv()
+    libraries.dependencies.syncPythonDeps()
+    libraries.azure.auth()
 
     if ("$PLATFORM_VER" == "latest") {
         PLATFORM_VER = sh(script: "az aks get-versions --location $location --output json | jq -r '.values | max_by(.patchVersions) | .patchVersions | keys[]' | sort --version-sort | tail -1", returnStdout: true).trim()
@@ -265,23 +219,32 @@ void runTest(Integer TEST_ID) {
             tests[TEST_ID]["result"] = "failure"
 
             timeout(time: 90, unit: 'MINUTES') {
+                def testsLib = load('cloud/common/vars/tests.groovy')
+                def testVars = testsLib.buildPsmdbTestVariables(
+                    cluster_name: CLUSTER_NAME,
+                    debug_tests: DEBUG_TESTS,
+                    cluster_wide: CLUSTER_WIDE,
+                    default_operator_image: "perconalab/percona-server-mongodb-operator:${GIT_BRANCH}",
+                    images: [
+                        IMAGE_OPERATOR    : IMAGE_OPERATOR,
+                        IMAGE_MONGOD      : IMAGE_MONGOD,
+                        IMAGE_BACKUP      : IMAGE_BACKUP,
+                        IMAGE_PMM_CLIENT  : IMAGE_PMM_CLIENT,
+                        IMAGE_PMM_SERVER  : IMAGE_PMM_SERVER,
+                        IMAGE_PMM3_CLIENT : IMAGE_PMM3_CLIENT,
+                        IMAGE_PMM3_SERVER : IMAGE_PMM3_SERVER,
+                        IMAGE_LOGCOLLECTOR: IMAGE_LOGCOLLECTOR,
+                        IMAGE_SEARCH      : IMAGE_SEARCH
+                    ]
+                )
+                def exports = testsLib.getExportedVariablesForTests(testVars, clusterSuffix)
+                def testCmd = testsLib.defineTestCommand(testVars, testName)
                 sh """
                     cd source
 
-                    [[ "$DEBUG_TESTS" == "YES" ]] && export DEBUG_TESTS=1
-                    [[ "$CLUSTER_WIDE" == "YES" ]] && export OPERATOR_NS=psmdb-operator
-                    [[ "$IMAGE_OPERATOR" ]] && export IMAGE=$IMAGE_OPERATOR || export IMAGE=perconalab/percona-server-mongodb-operator:$GIT_BRANCH
-                    export IMAGE_MONGOD=$IMAGE_MONGOD
-                    export IMAGE_BACKUP=$IMAGE_BACKUP
-                    export IMAGE_PMM_CLIENT=$IMAGE_PMM_CLIENT
-                    export IMAGE_PMM_SERVER=$IMAGE_PMM_SERVER
-                    export IMAGE_PMM3_CLIENT=$IMAGE_PMM3_CLIENT
-                    export IMAGE_PMM3_SERVER=$IMAGE_PMM3_SERVER
-                    export IMAGE_LOGCOLLECTOR=$IMAGE_LOGCOLLECTOR
-                    export IMAGE_SEARCH=$IMAGE_SEARCH
-                    export KUBECONFIG=/tmp/$CLUSTER_NAME-$clusterSuffix
+                    ${exports}
 
-                    e2e-tests/$testName/run
+                    ${testCmd}
                 """
             }
             pushArtifactFile("$GIT_BRANCH-$GIT_SHORT_COMMIT-$testName-$PLATFORM_VER-$DB_TAG-CW_$CLUSTER_WIDE-$PARAMS_HASH")
@@ -346,39 +309,6 @@ PLATFORM_VER=$PLATFORM_VER"""
     addSummary(icon: 'symbol-aperture-outline plugin-ionicons-api',
         text: "<pre>${pipelineParameters}</pre>"
     )
-}
-
-void azureAuth() {
-    withCredentials([azureServicePrincipal('PERCONA-OPERATORS-SP')]) {
-        sh '''
-            az login --service-principal -u "$AZURE_CLIENT_ID" -p "$AZURE_CLIENT_SECRET" -t "$AZURE_TENANT_ID"  --allow-no-subscriptions
-            az account set -s "$AZURE_SUBSCRIPTION_ID"
-        '''
-    }
-}
-
-void installAzureCLI() {
-    sh """
-        if ! command -v az &>/dev/null; then
-            if [ "\$JENKINS_AGENT" = "AWS" ]; then
-                curl -s -L https://azurecliprod.blob.core.windows.net/install.py -o install.py
-                printf "/usr/azure-cli\\n/usr/bin" | sudo python3 install.py
-                sudo /usr/azure-cli/bin/python -m pip install "urllib3<2.0.0" > /dev/null
-            else
-                echo "Installing Azure CLI for Hetzner instances..."
-                sudo rpm --import https://packages.microsoft.com/keys/microsoft.asc
-                cat <<EOF | sudo tee /etc/yum.repos.d/azure-cli.repo
-[azure-cli]
-name=Azure CLI
-baseurl=https://packages.microsoft.com/yumrepos/azure-cli
-enabled=1
-gpgcheck=1
-gpgkey=https://packages.microsoft.com/keys/microsoft.asc
-EOF
-                sudo dnf install azure-cli -y
-            fi
-        fi
-    """
 }
 
 void shutdownCluster(String CLUSTER_SUFFIX) {

--- a/cloud/jenkins/psmdbo_aks.groovy
+++ b/cloud/jenkins/psmdbo_aks.groovy
@@ -5,6 +5,7 @@ import groovy.transform.Field
 @Field def tests = []
 @Field def clusters = []
 @Field def release_versions = "source/e2e-tests/release_versions"
+@Field Map testVariables = [:]
 
 String getLocation(String job_name) {
     if ("$job_name" == 'psmdbo-aks-1') {
@@ -12,18 +13,6 @@ String getLocation(String job_name) {
     } else {
         return 'norwayeast'
     }
-}
-
-String getParam(String paramName, String keyName = null) {
-    keyName = keyName ?: paramName
-
-    def param = sh(script: "grep -iE '^\\s*$keyName=' $release_versions | cut -d = -f 2 | tr -d \'\"\'| tail -1", returnStdout: true).trim()
-    if ("$param") {
-        echo "$paramName=$param (from params file)"
-    } else {
-        error("$keyName not found in params file $release_versions")
-    }
-    return param
 }
 
 void prepareNode() {
@@ -37,24 +26,6 @@ void prepareNode() {
         repo: 'https://github.com/percona/percona-server-mongodb-operator'
     )
 
-    if ("$PILLAR_VERSION" != "none") {
-        echo "=========================[ Getting parameters for release test ]========================="
-        IMAGE_OPERATOR = IMAGE_OPERATOR ?: getParam("IMAGE_OPERATOR")
-        IMAGE_MONGOD = IMAGE_MONGOD ?: getParam("IMAGE_MONGOD", "IMAGE_MONGOD${PILLAR_VERSION}")
-        IMAGE_BACKUP = IMAGE_BACKUP ?: getParam("IMAGE_BACKUP")
-        IMAGE_PMM_CLIENT = IMAGE_PMM_CLIENT ?: getParam("IMAGE_PMM_CLIENT")
-        IMAGE_PMM_SERVER = IMAGE_PMM_SERVER ?: getParam("IMAGE_PMM_SERVER")
-        IMAGE_PMM3_CLIENT = IMAGE_PMM3_CLIENT ?: getParam("IMAGE_PMM3_CLIENT")
-        IMAGE_PMM3_SERVER = IMAGE_PMM3_SERVER ?: getParam("IMAGE_PMM3_SERVER")
-        IMAGE_LOGCOLLECTOR = IMAGE_LOGCOLLECTOR ?: getParam("IMAGE_LOGCOLLECTOR")
-        IMAGE_SEARCH = IMAGE_SEARCH ?: getParam("IMAGE_SEARCH")
-        if ("$PLATFORM_VER".toLowerCase() == "min" || "$PLATFORM_VER".toLowerCase() == "max") {
-            PLATFORM_VER = getParam("PLATFORM_VER", "AKS_${PLATFORM_VER}")
-        }
-    } else {
-        echo "=========================[ Not a release run. Using job params only! ]========================="
-    }
-
     echo "=========================[ Installing tools on the Jenkins executor ]========================="
     libraries.dependencies.install()
     libraries.dependencies.installGoogleCLI()
@@ -63,39 +34,58 @@ void prepareNode() {
     libraries.dependencies.syncPythonDeps()
     libraries.azure.auth()
 
-    if ("$PLATFORM_VER" == "latest") {
-        PLATFORM_VER = sh(script: "az aks get-versions --location $location --output json | jq -r '.values | max_by(.patchVersions) | .patchVersions | keys[]' | sort --version-sort | tail -1", returnStdout: true).trim()
+    def platformVersion = "$PLATFORM_VER"
+    if ("$PILLAR_VERSION" != "none" && (platformVersion.toLowerCase() in ["min", "max"])) {
+        platformVersion = libraries.tests.getReleaseVersionsParam(release_versions, "PLATFORM_VER", "AKS_${platformVersion.toUpperCase()}")
     }
+
+    testVariables = libraries.tests.prepareVersions([
+        libraries             : libraries,
+        release_versions      : release_versions,
+        operator              : 'psmdb-operator',
+        platform              : 'aks',
+        platform_provider     : 'azure',
+        platform_version      : platformVersion,
+        region                : location,
+        cluster_wide          : CLUSTER_WIDE,
+        pillar_version        : PILLAR_VERSION,
+        git_branch            : GIT_BRANCH,
+        job_name              : JOB_NAME,
+        db_tag                : DB_TAG,
+        debug_tests           : DEBUG_TESTS,
+        test_executor_type    : 'make',
+        default_operator_image: "perconalab/percona-server-mongodb-operator:${GIT_BRANCH}",
+        images: [
+            IMAGE_OPERATOR    : IMAGE_OPERATOR,
+            IMAGE_MONGOD      : IMAGE_MONGOD,
+            IMAGE_BACKUP      : IMAGE_BACKUP,
+            IMAGE_PMM_CLIENT  : IMAGE_PMM_CLIENT,
+            IMAGE_PMM_SERVER  : IMAGE_PMM_SERVER,
+            IMAGE_PMM3_CLIENT : IMAGE_PMM3_CLIENT,
+            IMAGE_PMM3_SERVER : IMAGE_PMM3_SERVER,
+            IMAGE_LOGCOLLECTOR: IMAGE_LOGCOLLECTOR,
+            IMAGE_SEARCH      : IMAGE_SEARCH
+        ]
+    ])
+
+    PLATFORM_VER = testVariables.platform_version
+    IMAGE_OPERATOR = testVariables.images.IMAGE_OPERATOR
+    IMAGE_MONGOD = testVariables.images.IMAGE_MONGOD
+    IMAGE_BACKUP = testVariables.images.IMAGE_BACKUP
+    IMAGE_PMM_CLIENT = testVariables.images.IMAGE_PMM_CLIENT
+    IMAGE_PMM_SERVER = testVariables.images.IMAGE_PMM_SERVER
+    IMAGE_PMM3_CLIENT = testVariables.images.IMAGE_PMM3_CLIENT
+    IMAGE_PMM3_SERVER = testVariables.images.IMAGE_PMM3_SERVER
+    IMAGE_LOGCOLLECTOR = testVariables.images.IMAGE_LOGCOLLECTOR
+    IMAGE_SEARCH = testVariables.images.IMAGE_SEARCH
+    GIT_SHORT_COMMIT = testVariables.git_short_commit
+    CLUSTER_NAME = testVariables.cluster_name
+    PARAMS_HASH = testVariables.params_hash
 
     if ("$IMAGE_MONGOD") {
         cw = ("$CLUSTER_WIDE" == "YES") ? "CW" : "NON-CW"
         currentBuild.displayName = "#" + currentBuild.number + " $GIT_BRANCH"
         currentBuild.description = "$PLATFORM_VER " + "$IMAGE_MONGOD".split(":")[1] + " $cw"
-    }
-
-    GIT_SHORT_COMMIT = sh(script: 'git -C source rev-parse --short HEAD', returnStdout: true).trim()
-    CLUSTER_NAME = sh(script: "echo jenkins-$JOB_NAME-$GIT_SHORT_COMMIT | tr '[:upper:]' '[:lower:]'", returnStdout: true).trim()
-    PARAMS_HASH = sh(script: "echo $GIT_BRANCH-$GIT_SHORT_COMMIT-$PLATFORM_VER-$CLUSTER_WIDE-$IMAGE_OPERATOR-$IMAGE_MONGOD-$IMAGE_BACKUP-$IMAGE_PMM_CLIENT-$IMAGE_PMM_SERVER-$IMAGE_PMM3_CLIENT-$IMAGE_PMM3_SERVER-$IMAGE_LOGCOLLECTOR-$IMAGE_SEARCH | md5sum | cut -d' ' -f1", returnStdout: true).trim()
-}
-
-void dockerBuildPush() {
-    echo "=========================[ Building and Pushing the operator Docker image ]========================="
-    withCredentials([usernamePassword(credentialsId: 'hub.docker.com', passwordVariable: 'PASS', usernameVariable: 'USER')]) {
-        sh '''
-            if [[ "$IMAGE_OPERATOR" ]]; then
-                echo "SKIP: Build is not needed, operator image was set!"
-            else
-                cd source
-                sg docker -c '
-                    docker buildx create --use
-                    echo "$PASS" | docker login -u "$USER" --password-stdin
-                    export IMAGE=perconalab/percona-server-mongodb-operator:$GIT_BRANCH
-                    DOCKER_DEFAULT_PLATFORM=linux/amd64,linux/arm64 e2e-tests/build
-                    docker logout
-                '
-                sudo rm -rf build
-            fi
-        '''
     }
 }
 
@@ -181,25 +171,13 @@ void clusterRunner(String cluster) {
 void createCluster(String CLUSTER_SUFFIX) {
     clusters.add("$CLUSTER_SUFFIX")
 
-    timeout(time: 30, unit: 'MINUTES') {
-        sh """
-            export KUBECONFIG=/tmp/$CLUSTER_NAME-$CLUSTER_SUFFIX
-            az aks create -n $CLUSTER_NAME-$CLUSTER_SUFFIX \
-                -g percona-operators \
-                --subscription eng-cloud-dev \
-                --load-balancer-sku standard \
-                --enable-managed-identity \
-                --node-count 3 \
-                --node-vm-size Standard_B4ms \
-                --node-osdisk-size 30 \
-                --generate-ssh-keys \
-                --outbound-type loadbalancer \
-                --kubernetes-version $PLATFORM_VER \
-                --tags team=cloud delete-cluster-after-hours=6 creation-time=\$(date -u +%s) \
-                -l $location
-            az aks get-credentials --subscription eng-cloud-dev --resource-group percona-operators --name $CLUSTER_NAME-$CLUSTER_SUFFIX --overwrite-existing
-        """
-    }
+    def libraries = load('cloud/common/libraries.groovy').loadLibraries()
+    libraries.azure.createCluster([
+        clusterName    : CLUSTER_NAME,
+        clusterSuffix  : CLUSTER_SUFFIX,
+        platformVersion: PLATFORM_VER,
+        region         : location
+    ])
 }
 
 void runTest(Integer TEST_ID) {
@@ -247,7 +225,7 @@ void runTest(Integer TEST_ID) {
 BASH
                 """
             }
-            pushArtifactFile("$GIT_BRANCH-$GIT_SHORT_COMMIT-$testName-$PLATFORM_VER-$DB_TAG-CW_$CLUSTER_WIDE-$PARAMS_HASH")
+            testsLib.pushArtifactFile("$GIT_BRANCH-$GIT_SHORT_COMMIT-$testName-$PLATFORM_VER-$DB_TAG-CW_$CLUSTER_WIDE-$PARAMS_HASH", GIT_SHORT_COMMIT)
             tests[TEST_ID]["result"] = "passed"
             return true
         }
@@ -273,51 +251,13 @@ BASH
     }
 }
 
-void pushArtifactFile(String FILE_NAME) {
-    echo "Push $FILE_NAME file to S3!"
-
-    withCredentials([aws(credentialsId: 'AMI/OVF', accessKeyVariable: 'AWS_ACCESS_KEY_ID', secretKeyVariable: 'AWS_SECRET_ACCESS_KEY')]) {
-        sh """
-            touch $FILE_NAME
-            S3_PATH=s3://percona-jenkins-artifactory/\$JOB_NAME/$GIT_SHORT_COMMIT
-            aws s3 ls \$S3_PATH/$FILE_NAME || :
-            aws s3 cp --quiet $FILE_NAME \$S3_PATH/$FILE_NAME || :
-        """
-    }
-}
-
-void makeReport() {
-    def libraries = load('cloud/common/libraries.groovy').loadLibraries()
-    libraries.tests.makeReport(tests, [
-        job_name         : JOB_NAME,
-        git_branch       : GIT_BRANCH,
-        git_short_commit : GIT_SHORT_COMMIT,
-        platform_version : PLATFORM_VER,
-        cluster_wide     : CLUSTER_WIDE,
-        images: [
-            IMAGE_OPERATOR    : IMAGE_OPERATOR,
-            IMAGE_MONGOD      : IMAGE_MONGOD,
-            IMAGE_BACKUP      : IMAGE_BACKUP,
-            IMAGE_PMM_CLIENT  : IMAGE_PMM_CLIENT,
-            IMAGE_PMM_SERVER  : IMAGE_PMM_SERVER,
-            IMAGE_PMM3_CLIENT : IMAGE_PMM3_CLIENT,
-            IMAGE_PMM3_SERVER : IMAGE_PMM3_SERVER,
-            IMAGE_LOGCOLLECTOR: IMAGE_LOGCOLLECTOR,
-            IMAGE_SEARCH      : IMAGE_SEARCH
-        ]
-    ])
-}
-
 void shutdownCluster(String CLUSTER_SUFFIX) {
-    timeout(time: 30, unit: 'MINUTES') {
-        withCredentials([azureServicePrincipal('PERCONA-OPERATORS-SP')]) {
-            def libraries = load('cloud/common/libraries.groovy').loadLibraries()
-            libraries.tools.kubernetesCleanupCluster("/tmp/${CLUSTER_NAME}-${CLUSTER_SUFFIX}")
-            sh """
-                az aks delete --name $CLUSTER_NAME-$CLUSTER_SUFFIX --resource-group percona-operators --subscription eng-cloud-dev --yes || true
-            """
-        }
-    }
+    def libraries = load('cloud/common/libraries.groovy').loadLibraries()
+    libraries.tools.kubernetesCleanupCluster("/tmp/${CLUSTER_NAME}-${CLUSTER_SUFFIX}")
+    libraries.azure.shutdownCluster([
+        clusterName  : CLUSTER_NAME,
+        clusterSuffix: CLUSTER_SUFFIX
+    ])
 }
 
 pipeline {
@@ -364,7 +304,14 @@ pipeline {
         }
         stage('Docker Build and Push') {
             steps {
-                dockerBuildPush()
+                script {
+                    def libraries = load('cloud/common/libraries.groovy').loadLibraries()
+                    libraries.tools.dockerBuildAndPush(
+                        operatorImage: 'perconalab/percona-server-mongodb-operator',
+                        branch       : GIT_BRANCH,
+                        platform     : 'linux/amd64,linux/arm64'
+                    )
+                }
             }
         }
         stage('Init Tests') {
@@ -392,9 +339,11 @@ pipeline {
     post {
         always {
             echo "CLUSTER ASSIGNMENTS\n" + tests.toString().replace("], ","]\n").replace("]]","]").replaceFirst("\\[","")
-            makeReport()
 
             script {
+                def libraries = load('cloud/common/libraries.groovy').loadLibraries()
+                libraries.tests.makeReport(tests, testVariables)
+
                 try {
                     def sendJobSlack = load "cloud/common/sendJobSlackNotification.groovy"
                     sendJobSlack.call(
@@ -412,7 +361,6 @@ pipeline {
 
                 clusters.each { shutdownCluster(it) }
 
-                def libraries = load('cloud/common/libraries.groovy').loadLibraries()
                 libraries.tools.dockerCleanupVolumes()
             }
 

--- a/cloud/jenkins/psmdbo_eks.groovy
+++ b/cloud/jenkins/psmdbo_eks.groovy
@@ -4,18 +4,7 @@ import groovy.transform.Field
 @Field def tests = []
 @Field def clusters = []
 @Field def release_versions = "source/e2e-tests/release_versions"
-
-String getParam(String paramName, String keyName = null) {
-    keyName = keyName ?: paramName
-
-    def param = sh(script: "grep -iE '^\\s*$keyName=' $release_versions | cut -d = -f 2 | tr -d \'\"\'| tail -1", returnStdout: true).trim()
-    if ("$param") {
-        echo "$paramName=$param (from params file)"
-    } else {
-        error("$keyName not found in params file $release_versions")
-    }
-    return param
-}
+@Field Map testVariables = [:]
 
 void prepareNode() {
     checkout(scm)
@@ -25,24 +14,6 @@ void prepareNode() {
         branch: GIT_BRANCH,
         repo: 'https://github.com/percona/percona-server-mongodb-operator'
     )
-
-    if ("$PILLAR_VERSION" != "none") {
-        echo "=========================[ Getting parameters for release test ]========================="
-        IMAGE_OPERATOR = IMAGE_OPERATOR ?: getParam("IMAGE_OPERATOR")
-        IMAGE_MONGOD = IMAGE_MONGOD ?: getParam("IMAGE_MONGOD", "IMAGE_MONGOD${PILLAR_VERSION}")
-        IMAGE_BACKUP = IMAGE_BACKUP ?: getParam("IMAGE_BACKUP")
-        IMAGE_PMM_CLIENT = IMAGE_PMM_CLIENT ?: getParam("IMAGE_PMM_CLIENT")
-        IMAGE_PMM_SERVER = IMAGE_PMM_SERVER ?: getParam("IMAGE_PMM_SERVER")
-        IMAGE_PMM3_CLIENT = IMAGE_PMM3_CLIENT ?: getParam("IMAGE_PMM3_CLIENT")
-        IMAGE_PMM3_SERVER = IMAGE_PMM3_SERVER ?: getParam("IMAGE_PMM3_SERVER")
-        IMAGE_LOGCOLLECTOR = IMAGE_LOGCOLLECTOR ?: getParam("IMAGE_LOGCOLLECTOR")
-        IMAGE_SEARCH = IMAGE_SEARCH ?: getParam("IMAGE_SEARCH")
-        if ("$PLATFORM_VER".toLowerCase() == "min" || "$PLATFORM_VER".toLowerCase() == "max") {
-            PLATFORM_VER = getParam("PLATFORM_VER", "EKS_${PLATFORM_VER}")
-        }
-    } else {
-        echo "=========================[ Not a release run. Using job params only! ]========================="
-    }
 
     echo "=========================[ Installing tools on the Jenkins executor ]========================="
     libraries.dependencies.install()
@@ -56,41 +27,58 @@ void prepareNode() {
         curl -sL https://github.com/eksctl-io/eksctl/releases/latest/download/eksctl_\$(uname -s)_amd64.tar.gz | sudo tar -C /usr/local/bin -xzf - && sudo chmod +x /usr/local/bin/eksctl
     """
 
-    if ("$PLATFORM_VER" == "latest") {
-        withCredentials([aws(credentialsId: 'AMI/OVF', accessKeyVariable: 'AWS_ACCESS_KEY_ID', secretKeyVariable: 'AWS_SECRET_ACCESS_KEY')]) {
-            PLATFORM_VER = sh(script: "aws eks describe-addon-versions --query 'addons[].addonVersions[].compatibilities[].clusterVersion' --output json | jq -r 'flatten | unique | sort | reverse | .[0]'", , returnStdout: true).trim()
-        }
+    def platformVersion = "$PLATFORM_VER"
+    if ("$PILLAR_VERSION" != "none" && (platformVersion.toLowerCase() in ["min", "max"])) {
+        platformVersion = libraries.tests.getReleaseVersionsParam(release_versions, "PLATFORM_VER", "EKS_${platformVersion.toUpperCase()}")
     }
+
+    testVariables = libraries.tests.prepareVersions([
+        libraries             : libraries,
+        release_versions      : release_versions,
+        operator              : 'psmdb-operator',
+        platform              : 'eks',
+        platform_provider     : 'eks',
+        platform_version      : platformVersion,
+        region                : EKS_REGION,
+        cluster_wide          : CLUSTER_WIDE,
+        pillar_version        : PILLAR_VERSION,
+        git_branch            : GIT_BRANCH,
+        job_name              : JOB_NAME,
+        db_tag                : DB_TAG,
+        debug_tests           : DEBUG_TESTS,
+        test_executor_type    : 'make',
+        default_operator_image: "perconalab/percona-server-mongodb-operator:${GIT_BRANCH}",
+        images: [
+            IMAGE_OPERATOR    : IMAGE_OPERATOR,
+            IMAGE_MONGOD      : IMAGE_MONGOD,
+            IMAGE_BACKUP      : IMAGE_BACKUP,
+            IMAGE_PMM_CLIENT  : IMAGE_PMM_CLIENT,
+            IMAGE_PMM_SERVER  : IMAGE_PMM_SERVER,
+            IMAGE_PMM3_CLIENT : IMAGE_PMM3_CLIENT,
+            IMAGE_PMM3_SERVER : IMAGE_PMM3_SERVER,
+            IMAGE_LOGCOLLECTOR: IMAGE_LOGCOLLECTOR,
+            IMAGE_SEARCH      : IMAGE_SEARCH
+        ]
+    ])
+
+    PLATFORM_VER = testVariables.platform_version
+    IMAGE_OPERATOR = testVariables.images.IMAGE_OPERATOR
+    IMAGE_MONGOD = testVariables.images.IMAGE_MONGOD
+    IMAGE_BACKUP = testVariables.images.IMAGE_BACKUP
+    IMAGE_PMM_CLIENT = testVariables.images.IMAGE_PMM_CLIENT
+    IMAGE_PMM_SERVER = testVariables.images.IMAGE_PMM_SERVER
+    IMAGE_PMM3_CLIENT = testVariables.images.IMAGE_PMM3_CLIENT
+    IMAGE_PMM3_SERVER = testVariables.images.IMAGE_PMM3_SERVER
+    IMAGE_LOGCOLLECTOR = testVariables.images.IMAGE_LOGCOLLECTOR
+    IMAGE_SEARCH = testVariables.images.IMAGE_SEARCH
+    GIT_SHORT_COMMIT = testVariables.git_short_commit
+    CLUSTER_NAME = testVariables.cluster_name
+    PARAMS_HASH = testVariables.params_hash
 
     if ("$IMAGE_MONGOD") {
         cw = ("$CLUSTER_WIDE" == "YES") ? "CW" : "NON-CW"
         currentBuild.displayName = "#" + currentBuild.number + " $GIT_BRANCH"
         currentBuild.description = "$PLATFORM_VER " + "$IMAGE_MONGOD".split(":")[1] + " $cw"
-    }
-
-    GIT_SHORT_COMMIT = sh(script: 'git -C source rev-parse --short HEAD', returnStdout: true).trim()
-    CLUSTER_NAME = sh(script: "echo jenkins-$JOB_NAME-$GIT_SHORT_COMMIT | tr '[:upper:]' '[:lower:]'", returnStdout: true).trim()
-    PARAMS_HASH = sh(script: "echo $GIT_BRANCH-$GIT_SHORT_COMMIT-$PLATFORM_VER-$CLUSTER_WIDE-$IMAGE_OPERATOR-$IMAGE_MONGOD-$IMAGE_BACKUP-$IMAGE_PMM_CLIENT-$IMAGE_PMM_SERVER-$IMAGE_PMM3_CLIENT-$IMAGE_PMM3_SERVER-$IMAGE_LOGCOLLECTOR-$IMAGE_SEARCH | md5sum | cut -d' ' -f1", returnStdout: true).trim()
-}
-
-void dockerBuildPush() {
-    echo "=========================[ Building and Pushing the operator Docker image ]========================="
-    withCredentials([usernamePassword(credentialsId: 'hub.docker.com', passwordVariable: 'PASS', usernameVariable: 'USER')]) {
-        sh '''
-            if [[ "$IMAGE_OPERATOR" ]]; then
-                echo "SKIP: Build is not needed, operator image was set!"
-            else
-                cd source
-                sg docker -c '
-                    docker buildx create --use
-                    echo "$PASS" | docker login -u "$USER" --password-stdin
-                    export IMAGE=perconalab/percona-server-mongodb-operator:$GIT_BRANCH
-                    DOCKER_DEFAULT_PLATFORM=linux/amd64,linux/arm64 e2e-tests/build
-                    docker logout
-                '
-                sudo rm -rf build
-            fi
-        '''
     }
 }
 
@@ -173,106 +161,17 @@ void clusterRunner(String cluster) {
     }
 }
 
-void verifyVolumeSnapshotResources(String CLUSTER_SUFFIX) {
-    def clusterName = "$CLUSTER_NAME-$CLUSTER_SUFFIX"
-
-    withCredentials([aws(accessKeyVariable: 'AWS_ACCESS_KEY_ID', credentialsId: 'eks-cicd', secretKeyVariable: 'AWS_SECRET_ACCESS_KEY')]) {
-        sh """
-            export KUBECONFIG=/tmp/${clusterName}
-            export PATH=/home/ec2-user/.local/bin:$PATH
-
-            wait_for_deployment() {
-                local deployment_name="\$1"
-
-                for i in \$(seq 1 60); do
-                    if kubectl get deployment "\$deployment_name" -n kube-system >/dev/null 2>&1; then
-                        kubectl wait --for=condition=Available deployment/"\$deployment_name" -n kube-system --timeout=10m
-                        return 0
-                    fi
-                    sleep 10
-                done
-
-                kubectl get deployment -n kube-system
-                return 1
-            }
-
-            wait_for_deployment ebs-csi-controller
-            wait_for_deployment snapshot-controller
-
-            kubectl get crd volumesnapshots.snapshot.storage.k8s.io volumesnapshotcontents.snapshot.storage.k8s.io volumesnapshotclasses.snapshot.storage.k8s.io
-            kubectl api-resources --api-group=snapshot.storage.k8s.io
-        """
-    }
-}
-
 void createCluster(String CLUSTER_SUFFIX) {
     clusters.add("$CLUSTER_SUFFIX")
 
-    timeout(time: 30, unit: 'MINUTES') {
-        sh """
-            timestamp="\$(date +%s)"
-tee cluster-${CLUSTER_SUFFIX}.yaml << EOF
-apiVersion: eksctl.io/v1alpha5
-kind: ClusterConfig
-metadata:
-  name: $CLUSTER_NAME-$CLUSTER_SUFFIX
-  region: ${EKS_REGION}
-  version: "$PLATFORM_VER"
-  tags:
-    'delete-cluster-after-hours': '6'
-    'creation-time': '\$timestamp'
-    'team': 'cloud'
-iam:
-  withOIDC: true
-addons:
-- name: aws-ebs-csi-driver
-  wellKnownPolicies:
-    ebsCSIController: true
-- name: snapshot-controller
-nodeGroups:
-- name: ng-1
-  minSize: 3
-  maxSize: 4
-  iam:
-    attachPolicyARNs:
-    - arn:aws:iam::aws:policy/AmazonEKSWorkerNodePolicy
-    - arn:aws:iam::aws:policy/AmazonEKS_CNI_Policy
-    - arn:aws:iam::aws:policy/AmazonEC2ContainerRegistryReadOnly
-    - arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore
-  instancesDistribution:
-    instanceTypes: ["m5.xlarge", "m5.2xlarge"] # At least two instance types should be specified
-  tags:
-    'iit-billing-tag': 'jenkins-eks'
-    'delete-cluster-after-hours': '6'
-    'team': 'cloud'
-    'product': 'psmdb-operator'
-EOF
-        """
-
-        withCredentials([aws(credentialsId: 'eks-cicd', accessKeyVariable: 'AWS_ACCESS_KEY_ID', secretKeyVariable: 'AWS_SECRET_ACCESS_KEY')]) {
-            sh """
-                export KUBECONFIG=/tmp/${CLUSTER_NAME}-${CLUSTER_SUFFIX}
-
-                eksctl create cluster -f cluster-${CLUSTER_SUFFIX}.yaml
-                
-                # Use GP3 storage class as default, recommended by the provider
-                kubectl apply -f cloud/common/files/eks-storage-gp3.yaml
-
-                # Remove GP2 storage class default label, for old clusters
-                kubectl annotate storageclass gp2 \
-                    storageclass.kubernetes.io/is-default-class- \
-                    --overwrite 2>/dev/null || true
-
-                kubectl create clusterrolebinding cluster-admin-binding1 \
-                    --clusterrole=cluster-admin \
-                    --user="\$(aws sts get-caller-identity|jq -r '.Arn')"
-
-                kubectl get storageclass
-            """
-        }
-    }
-
-    verifyVolumeSnapshotResources(CLUSTER_SUFFIX)
+    def libraries = load('cloud/common/libraries.groovy').loadLibraries()
+    libraries.eks.createCluster([
+        clusterName    : CLUSTER_NAME,
+        clusterSuffix  : CLUSTER_SUFFIX,
+        platformVersion: PLATFORM_VER,
+        region         : EKS_REGION,
+        product        : 'psmdb-operator'
+    ])
 }
 
 void runTest(Integer TEST_ID) {
@@ -322,7 +221,7 @@ BASH
                     """
                 }
             }
-            pushArtifactFile("$GIT_BRANCH-$GIT_SHORT_COMMIT-$testName-$PLATFORM_VER-$DB_TAG-CW_$CLUSTER_WIDE-$PARAMS_HASH")
+            testsLib.pushArtifactFile("$GIT_BRANCH-$GIT_SHORT_COMMIT-$testName-$PLATFORM_VER-$DB_TAG-CW_$CLUSTER_WIDE-$PARAMS_HASH", GIT_SHORT_COMMIT)
             tests[TEST_ID]["result"] = "passed"
             return true
         }
@@ -348,76 +247,14 @@ BASH
     }
 }
 
-void pushArtifactFile(String FILE_NAME) {
-    echo "Push $FILE_NAME file to S3!"
-
-    withCredentials([aws(credentialsId: 'AMI/OVF', accessKeyVariable: 'AWS_ACCESS_KEY_ID', secretKeyVariable: 'AWS_SECRET_ACCESS_KEY')]) {
-        sh """
-            touch $FILE_NAME
-            S3_PATH=s3://percona-jenkins-artifactory/\$JOB_NAME/$GIT_SHORT_COMMIT
-            aws s3 ls \$S3_PATH/$FILE_NAME || :
-            aws s3 cp --quiet $FILE_NAME \$S3_PATH/$FILE_NAME || :
-        """
-    }
-}
-
-void makeReport() {
-    def libraries = load('cloud/common/libraries.groovy').loadLibraries()
-    libraries.tests.makeReport(tests, [
-        job_name         : JOB_NAME,
-        git_branch       : GIT_BRANCH,
-        git_short_commit : GIT_SHORT_COMMIT,
-        platform_version : PLATFORM_VER,
-        cluster_wide     : CLUSTER_WIDE,
-        images: [
-            IMAGE_OPERATOR    : IMAGE_OPERATOR,
-            IMAGE_MONGOD      : IMAGE_MONGOD,
-            IMAGE_BACKUP      : IMAGE_BACKUP,
-            IMAGE_PMM_CLIENT  : IMAGE_PMM_CLIENT,
-            IMAGE_PMM_SERVER  : IMAGE_PMM_SERVER,
-            IMAGE_PMM3_CLIENT : IMAGE_PMM3_CLIENT,
-            IMAGE_PMM3_SERVER : IMAGE_PMM3_SERVER,
-            IMAGE_LOGCOLLECTOR: IMAGE_LOGCOLLECTOR,
-            IMAGE_SEARCH      : IMAGE_SEARCH
-        ]
-    ])
-}
-
 void shutdownCluster(String CLUSTER_SUFFIX) {
-    timeout(time: 30, unit: 'MINUTES') {
-        withCredentials([aws(credentialsId: 'eks-cicd', accessKeyVariable: 'AWS_ACCESS_KEY_ID', secretKeyVariable: 'AWS_SECRET_ACCESS_KEY')]) {
-            def libraries = load('cloud/common/libraries.groovy').loadLibraries()
-            libraries.tools.kubernetesCleanupCluster("/tmp/${CLUSTER_NAME}-${CLUSTER_SUFFIX}")
-            sh """
-                VPC_ID=\$(eksctl get cluster --name $CLUSTER_NAME-$CLUSTER_SUFFIX --region ${EKS_REGION} -ojson | jq --raw-output '.[0].ResourcesVpcConfig.VpcId' || true)
-                if [ -n "\$VPC_ID" ]; then
-                    LOADBALS=\$(aws elb describe-load-balancers --region ${EKS_REGION} --output json | jq --raw-output '.LoadBalancerDescriptions[] | select(.VPCId == "'\$VPC_ID'").LoadBalancerName')
-                    for loadbal in \$LOADBALS; do
-                        aws elb delete-load-balancer --load-balancer-name \$loadbal --region ${EKS_REGION}
-                    done
-                    eksctl delete cluster -f cluster-${CLUSTER_SUFFIX}.yaml --wait --force --disable-nodegroup-eviction || true
-
-                    VPC_DESC=\$(aws ec2 describe-vpcs --vpc-id \$VPC_ID --region ${EKS_REGION} || true)
-                    if [ -n "\$VPC_DESC" ]; then
-                        aws ec2 delete-vpc --vpc-id \$VPC_ID --region ${EKS_REGION} || true
-                    fi
-                    VPC_DESC=\$(aws ec2 describe-vpcs --vpc-id \$VPC_ID --region ${EKS_REGION} || true)
-                    if [ -n "\$VPC_DESC" ]; then
-                        for secgroup in \$(aws ec2 describe-security-groups --filters Name=vpc-id,Values=\$VPC_ID --query 'SecurityGroups[*].GroupId' --output text --region ${EKS_REGION}); do
-                            aws ec2 delete-security-group --group-id \$secgroup --region ${EKS_REGION} || true
-                        done
-
-                        aws ec2 delete-vpc --vpc-id \$VPC_ID --region ${EKS_REGION} || true
-                    fi
-                fi
-                aws cloudformation delete-stack --stack-name eksctl-$CLUSTER_NAME-$CLUSTER_SUFFIX-cluster --region ${EKS_REGION} || true
-                aws cloudformation wait stack-delete-complete --stack-name eksctl-$CLUSTER_NAME-$CLUSTER_SUFFIX-cluster --region ${EKS_REGION} || true
-
-                eksctl get cluster --name $CLUSTER_NAME-$CLUSTER_SUFFIX --region ${EKS_REGION} || true
-                aws cloudformation list-stacks --region ${EKS_REGION} | jq '.StackSummaries[] | select(.StackName | startswith("'eksctl-$CLUSTER_NAME-$CLUSTER_SUFFIX-cluster'"))' || true
-            """
-        }
-    }
+    def libraries = load('cloud/common/libraries.groovy').loadLibraries()
+    libraries.tools.kubernetesCleanupCluster("/tmp/${CLUSTER_NAME}-${CLUSTER_SUFFIX}")
+    libraries.eks.shutdownCluster([
+        clusterName  : CLUSTER_NAME,
+        clusterSuffix: CLUSTER_SUFFIX,
+        region       : EKS_REGION
+    ])
 }
 
 pipeline {
@@ -464,7 +301,14 @@ pipeline {
         }
         stage('Docker Build and Push') {
             steps {
-                dockerBuildPush()
+                script {
+                    def libraries = load('cloud/common/libraries.groovy').loadLibraries()
+                    libraries.tools.dockerBuildAndPush(
+                        operatorImage: 'perconalab/percona-server-mongodb-operator',
+                        branch       : GIT_BRANCH,
+                        platform     : 'linux/amd64,linux/arm64'
+                    )
+                }
             }
         }
         stage('Init Tests') {
@@ -492,9 +336,11 @@ pipeline {
     post {
         always {
             echo "CLUSTER ASSIGNMENTS\n" + tests.toString().replace("], ","]\n").replace("]]","]").replaceFirst("\\[","")
-            makeReport()
 
             script {
+                def libraries = load('cloud/common/libraries.groovy').loadLibraries()
+                libraries.tests.makeReport(tests, testVariables)
+
                 try {
                     def sendJobSlack = load "cloud/common/sendJobSlackNotification.groovy"
                     sendJobSlack.call(
@@ -512,7 +358,6 @@ pipeline {
 
                 clusters.each { shutdownCluster(it) }
 
-                def libraries = load('cloud/common/libraries.groovy').loadLibraries()
                 libraries.tools.dockerCleanupVolumes()
             }
 

--- a/cloud/jenkins/psmdbo_eks.groovy
+++ b/cloud/jenkins/psmdbo_eks.groovy
@@ -17,30 +17,6 @@ String getParam(String paramName, String keyName = null) {
     return param
 }
 
-void downloadKubectl() {
-    sh """
-        KUBECTL_VERSION="\$(curl -L -s https://api.github.com/repos/kubernetes/kubernetes/releases/latest | jq -r .tag_name)"
-        for i in {1..5}; do
-          if [ -f /usr/local/bin/kubectl ]; then
-              break
-          fi
-          echo "Attempt \$i: downloading kubectl..."
-          sudo curl -s -L -o /usr/local/bin/kubectl "https://dl.k8s.io/release/\${KUBECTL_VERSION}/bin/linux/amd64/kubectl"
-          sudo curl -s -L -o /tmp/kubectl.sha256 "https://dl.k8s.io/release/\${KUBECTL_VERSION}/bin/linux/amd64/kubectl.sha256"
-          if echo "\$(cat /tmp/kubectl.sha256) /usr/local/bin/kubectl" | sha256sum --check --status; then
-            echo 'Download passed checksum'
-            sudo chmod +x /usr/local/bin/kubectl
-            kubectl version --client --output=yaml
-            break
-          else
-            echo 'Checksum failed, retrying...'
-            sudo rm -f /usr/local/bin/kubectl /tmp/kubectl.sha256
-            sleep 5
-          fi
-        done
-    """
-}
-
 void prepareNode() {
     echo "=========================[ Cloning the sources ]========================="
     checkout(scm)
@@ -73,36 +49,17 @@ void prepareNode() {
     }
 
     echo "=========================[ Installing tools on the Jenkins executor ]========================="
+    def libraries = load('cloud/common/libraries.groovy').loadLibraries()
+    libraries.dependencies.install()
+    libraries.dependencies.installGoogleCLI()
+    libraries.dependencies.installAzureCLI()
+    libraries.dependencies.installUv()
+    libraries.dependencies.syncPythonDeps()
+    libraries.azure.auth()
+
     sh """
-        sudo curl -fsSL https://github.com/mikefarah/yq/releases/download/v4.44.1/yq_linux_amd64 -o /usr/local/bin/yq && sudo chmod +x /usr/local/bin/yq
-        sudo curl -fsSL https://github.com/jqlang/jq/releases/download/jq-1.7.1/jq-linux64 -o /usr/local/bin/jq && sudo chmod +x /usr/local/bin/jq
-    """
-    downloadKubectl()
-    sh """
-        curl -fsSL https://get.helm.sh/helm-v3.20.0-linux-amd64.tar.gz | sudo tar -C /usr/local/bin --strip-components 1 -xzf - linux-amd64/helm
         curl -sL https://github.com/eksctl-io/eksctl/releases/latest/download/eksctl_\$(uname -s)_amd64.tar.gz | sudo tar -C /usr/local/bin -xzf - && sudo chmod +x /usr/local/bin/eksctl
     """
-
-    sh '''
-        if ! command -v gsutil &>/dev/null; then
-            echo "gsutil not found, installing google-cloud-cli..."
-            sudo tee /etc/yum.repos.d/google-cloud-sdk.repo << EOF
-[google-cloud-cli]
-name=Google Cloud CLI
-baseurl=https://packages.cloud.google.com/yum/repos/cloud-sdk-el7-x86_64
-enabled=1
-gpgcheck=1
-repo_gpgcheck=0
-gpgkey=https://packages.cloud.google.com/yum/doc/rpm-package-key.gpg
-EOF
-            sudo yum install -y google-cloud-cli
-        fi
-        command -v gsutil
-        gsutil version -l | head -n1
-    '''
-
-    installAzureCLI()
-    azureAuth()
 
     if ("$PLATFORM_VER" == "latest") {
         withCredentials([aws(credentialsId: 'AMI/OVF', accessKeyVariable: 'AWS_ACCESS_KEY_ID', secretKeyVariable: 'AWS_SECRET_ACCESS_KEY')]) {
@@ -118,7 +75,7 @@ EOF
 
     GIT_SHORT_COMMIT = sh(script: 'git -C source rev-parse --short HEAD', returnStdout: true).trim()
     CLUSTER_NAME = sh(script: "echo jenkins-$JOB_NAME-$GIT_SHORT_COMMIT | tr '[:upper:]' '[:lower:]'", returnStdout: true).trim()
-    PARAMS_HASH = sh(script: "echo $GIT_BRANCH-$GIT_SHORT_COMMIT-$PLATFORM_VER-$CLUSTER_WIDE-$IMAGE_OPERATOR-$IMAGE_MONGOD-$IMAGE_BACKUP-$IMAGE_PMM_CLIENT-$IMAGE_PMM_SERVER-$IMAGE_PMM3_CLIENT-$IMAGE_PMM3_SERVER-$IMAGE_LOGCOLLECTOR-$IMAGE_SEARCH  | md5sum | cut -d' ' -f1", returnStdout: true).trim()
+    PARAMS_HASH = sh(script: "echo $GIT_BRANCH-$GIT_SHORT_COMMIT-$PLATFORM_VER-$CLUSTER_WIDE-$IMAGE_OPERATOR-$IMAGE_MONGOD-$IMAGE_BACKUP-$IMAGE_PMM_CLIENT-$IMAGE_PMM_SERVER-$IMAGE_PMM3_CLIENT-$IMAGE_PMM3_SERVER-$IMAGE_LOGCOLLECTOR-$IMAGE_SEARCH | md5sum | cut -d' ' -f1", returnStdout: true).trim()
 }
 
 void dockerBuildPush() {
@@ -297,12 +254,7 @@ nodeGroups:
 EOF
         """
 
-        withCredentials([[
-            $class: 'AmazonWebServicesCredentialsBinding',
-            accessKeyVariable: 'AWS_ACCESS_KEY_ID',
-            credentialsId: 'eks-cicd',
-            secretKeyVariable: 'AWS_SECRET_ACCESS_KEY'
-        ]]) {
+        withCredentials([aws(credentialsId: 'eks-cicd', accessKeyVariable: 'AWS_ACCESS_KEY_ID', secretKeyVariable: 'AWS_SECRET_ACCESS_KEY')]) {
             sh """
                 export KUBECONFIG=/tmp/${CLUSTER_NAME}-${CLUSTER_SUFFIX}
 
@@ -341,23 +293,32 @@ void runTest(Integer TEST_ID) {
 
             timeout(time: 90, unit: 'MINUTES') {
                 withCredentials([aws(credentialsId: 'eks-cicd', accessKeyVariable: 'AWS_ACCESS_KEY_ID'), file(credentialsId: 'eks-conf-file', variable: 'EKS_CONF_FILE')]) {
+                    def testsLib = load('cloud/common/vars/tests.groovy')
+                    def testVars = testsLib.buildPsmdbTestVariables(
+                        cluster_name: CLUSTER_NAME,
+                        debug_tests: DEBUG_TESTS,
+                        cluster_wide: CLUSTER_WIDE,
+                        default_operator_image: "perconalab/percona-server-mongodb-operator:${GIT_BRANCH}",
+                        images: [
+                            IMAGE_OPERATOR    : IMAGE_OPERATOR,
+                            IMAGE_MONGOD      : IMAGE_MONGOD,
+                            IMAGE_BACKUP      : IMAGE_BACKUP,
+                            IMAGE_PMM_CLIENT  : IMAGE_PMM_CLIENT,
+                            IMAGE_PMM_SERVER  : IMAGE_PMM_SERVER,
+                            IMAGE_PMM3_CLIENT : IMAGE_PMM3_CLIENT,
+                            IMAGE_PMM3_SERVER : IMAGE_PMM3_SERVER,
+                            IMAGE_LOGCOLLECTOR: IMAGE_LOGCOLLECTOR,
+                            IMAGE_SEARCH      : IMAGE_SEARCH
+                        ]
+                    )
+                    def exports = testsLib.getExportedVariablesForTests(testVars, clusterSuffix)
+                    def testCmd = testsLib.defineTestCommand(testVars, testName)
                     sh """
                         cd source
 
-                        [[ "$DEBUG_TESTS" == "YES" ]] && export DEBUG_TESTS=1
-                        [[ "$CLUSTER_WIDE" == "YES" ]] && export OPERATOR_NS=psmdb-operator
-                        [[ "$IMAGE_OPERATOR" ]] && export IMAGE=$IMAGE_OPERATOR || export IMAGE=perconalab/percona-server-mongodb-operator:$GIT_BRANCH
-                        export IMAGE_MONGOD=$IMAGE_MONGOD
-                        export IMAGE_BACKUP=$IMAGE_BACKUP
-                        export IMAGE_PMM_CLIENT=$IMAGE_PMM_CLIENT
-                        export IMAGE_PMM_SERVER=$IMAGE_PMM_SERVER
-                        export IMAGE_PMM3_CLIENT=$IMAGE_PMM3_CLIENT
-                        export IMAGE_PMM3_SERVER=$IMAGE_PMM3_SERVER
-                        export IMAGE_LOGCOLLECTOR=$IMAGE_LOGCOLLECTOR
-                        export IMAGE_SEARCH=$IMAGE_SEARCH
-                        export KUBECONFIG=/tmp/$CLUSTER_NAME-$clusterSuffix
+                        ${exports}
 
-                        e2e-tests/$testName/run
+                        ${testCmd}
                     """
                 }
             }
@@ -472,39 +433,6 @@ void shutdownCluster(String CLUSTER_SUFFIX) {
             """
         }
     }
-}
-
-void azureAuth() {
-    withCredentials([azureServicePrincipal('PERCONA-OPERATORS-SP')]) {
-        sh '''
-            az login --service-principal -u "$AZURE_CLIENT_ID" -p "$AZURE_CLIENT_SECRET" -t "$AZURE_TENANT_ID"  --allow-no-subscriptions
-            az account set -s "$AZURE_SUBSCRIPTION_ID"
-        '''
-    }
-}
-
-void installAzureCLI() {
-    sh """
-        if ! command -v az &>/dev/null; then
-            if [ "\$JENKINS_AGENT" = "AWS" ]; then
-                curl -s -L https://azurecliprod.blob.core.windows.net/install.py -o install.py
-                printf "/usr/azure-cli\\n/usr/bin" | sudo python3 install.py
-                sudo /usr/azure-cli/bin/python -m pip install "urllib3<2.0.0" > /dev/null
-            else
-                echo "Installing Azure CLI for Hetzner instances..."
-                sudo rpm --import https://packages.microsoft.com/keys/microsoft.asc
-                cat <<EOF | sudo tee /etc/yum.repos.d/azure-cli.repo
-[azure-cli]
-name=Azure CLI
-baseurl=https://packages.microsoft.com/yumrepos/azure-cli
-enabled=1
-gpgcheck=1
-gpgkey=https://packages.microsoft.com/keys/microsoft.asc
-EOF
-                sudo dnf install azure-cli -y
-            fi
-        fi
-    """
 }
 
 pipeline {

--- a/cloud/jenkins/psmdbo_eks.groovy
+++ b/cloud/jenkins/psmdbo_eks.groovy
@@ -71,6 +71,7 @@ void prepareNode() {
     IMAGE_PMM3_SERVER = testVariables.images.IMAGE_PMM3_SERVER
     IMAGE_LOGCOLLECTOR = testVariables.images.IMAGE_LOGCOLLECTOR
     IMAGE_SEARCH = testVariables.images.IMAGE_SEARCH
+    DB_TAG = testVariables.db_tag
     GIT_SHORT_COMMIT = testVariables.git_short_commit
     CLUSTER_NAME = testVariables.cluster_name
     PARAMS_HASH = testVariables.params_hash

--- a/cloud/jenkins/psmdbo_eks.groovy
+++ b/cloud/jenkins/psmdbo_eks.groovy
@@ -287,13 +287,13 @@ void runTest(Integer TEST_ID) {
 
     waitUntil {
         def timeStart = new Date().getTime()
+        def testsLib = load('cloud/common/vars/tests.groovy')
         try {
             echo "The $testName test was started on cluster $CLUSTER_NAME-$clusterSuffix !"
             tests[TEST_ID]["result"] = "failure"
 
             timeout(time: 90, unit: 'MINUTES') {
                 withCredentials([aws(credentialsId: 'eks-cicd', accessKeyVariable: 'AWS_ACCESS_KEY_ID'), file(credentialsId: 'eks-conf-file', variable: 'EKS_CONF_FILE')]) {
-                    def testsLib = load('cloud/common/vars/tests.groovy')
                     def testVars = testsLib.buildPsmdbTestVariables(
                         cluster_name: CLUSTER_NAME,
                         debug_tests: DEBUG_TESTS,
@@ -318,7 +318,12 @@ void runTest(Integer TEST_ID) {
 
                         ${exports}
 
-                        ${testCmd}
+                        mkdir -p e2e-tests/logs e2e-tests/reports
+                        bash -o pipefail <<BASH
+                        {
+                            ${testCmd}
+                        } 2>&1 | tee e2e-tests/logs/${testName}.log
+BASH
                     """
                 }
             }
@@ -338,6 +343,11 @@ void runTest(Integer TEST_ID) {
             def timeStop = new Date().getTime()
             def durationSec = (timeStop - timeStart) / 1000
             tests[TEST_ID]["time"] = durationSec
+            try {
+                testsLib.pushLogFile(testName, [gitShortCommit: GIT_SHORT_COMMIT])
+            } catch (logErr) {
+                echo "Warning: failed to push log for $testName: ${logErr}"
+            }
             echo "The $testName test was finished!"
         }
     }
@@ -357,15 +367,8 @@ void pushArtifactFile(String FILE_NAME) {
 }
 
 void makeReport() {
-    echo "=========================[ Generating Test Report ]========================="
-    testsReport = "<testsuite name=\"$JOB_NAME\">\n"
-    for (int i = 0; i < tests.size(); i ++) {
-        testsReport += '<testcase name="' + tests[i]["name"] + '" time="' + tests[i]["time"] + '"><'+ tests[i]["result"] +'/></testcase>\n'
-    }
-    testsReport += '</testsuite>\n'
-
     echo "=========================[ Generating Parameters Report ]========================="
-    pipelineParameters = """
+    def pipelineParameters = """
 testsuite name=$JOB_NAME
 IMAGE_OPERATOR=${IMAGE_OPERATOR ?: 'e2e_defaults'}
 IMAGE_MONGOD=${IMAGE_MONGOD ?: 'e2e_defaults'}
@@ -378,11 +381,13 @@ IMAGE_LOGCOLLECTOR=${IMAGE_LOGCOLLECTOR ?: 'e2e_defaults'}
 IMAGE_SEARCH=${IMAGE_SEARCH ?: 'e2e_defaults'}
 PLATFORM_VER=$PLATFORM_VER"""
 
-    writeFile file: "TestsReport.xml", text: testsReport
-    writeFile file: 'PipelineParameters.txt', text: pipelineParameters
-
-    addSummary(icon: 'symbol-aperture-outline plugin-ionicons-api',
-        text: "<pre>${pipelineParameters}</pre>"
+    def testsLib = load('cloud/common/vars/tests.groovy')
+    testsLib.writePipelineParameters(pipelineParameters)
+    testsLib.publishPytestReports(
+        tests         : tests,
+        gitShortCommit: GIT_SHORT_COMMIT,
+        gitBranch     : GIT_BRANCH,
+        title         : "PSMDB e2e tests - ${GIT_BRANCH} (${GIT_SHORT_COMMIT})"
     )
 }
 
@@ -508,8 +513,6 @@ pipeline {
         always {
             echo "CLUSTER ASSIGNMENTS\n" + tests.toString().replace("], ","]\n").replace("]]","]").replaceFirst("\\[","")
             makeReport()
-            junit testResults: '*.xml', healthScaleFactor: 1.0
-            archiveArtifacts '*.xml,*.txt'
 
             script {
                 try {

--- a/cloud/jenkins/psmdbo_eks.groovy
+++ b/cloud/jenkins/psmdbo_eks.groovy
@@ -18,17 +18,13 @@ String getParam(String paramName, String keyName = null) {
 }
 
 void prepareNode() {
-    echo "=========================[ Cloning the sources ]========================="
     checkout(scm)
-    sh """
-        # sudo is needed for better node recovery after compilation failure
-        # if building failed on compilation stage directory will have files owned by docker user
-        sudo git config --global --add safe.directory '*'
-        sudo git reset --hard
-        sudo git clean -xdf
-        sudo rm -rf source
-        git clone -b $GIT_BRANCH https://github.com/percona/percona-server-mongodb-operator source
-    """
+    def libraries = load('cloud/common/libraries.groovy').loadLibraries()
+    libraries.tools.gitResetWorkspace()
+    libraries.tools.gitClone(
+        branch: GIT_BRANCH,
+        repo: 'https://github.com/percona/percona-server-mongodb-operator'
+    )
 
     if ("$PILLAR_VERSION" != "none") {
         echo "=========================[ Getting parameters for release test ]========================="
@@ -49,7 +45,6 @@ void prepareNode() {
     }
 
     echo "=========================[ Installing tools on the Jenkins executor ]========================="
-    def libraries = load('cloud/common/libraries.groovy').loadLibraries()
     libraries.dependencies.install()
     libraries.dependencies.installGoogleCLI()
     libraries.dependencies.installAzureCLI()
@@ -367,48 +362,33 @@ void pushArtifactFile(String FILE_NAME) {
 }
 
 void makeReport() {
-    echo "=========================[ Generating Parameters Report ]========================="
-    def pipelineParameters = """
-testsuite name=$JOB_NAME
-IMAGE_OPERATOR=${IMAGE_OPERATOR ?: 'e2e_defaults'}
-IMAGE_MONGOD=${IMAGE_MONGOD ?: 'e2e_defaults'}
-IMAGE_BACKUP=${IMAGE_BACKUP ?: 'e2e_defaults'}
-IMAGE_PMM_CLIENT=${IMAGE_PMM_CLIENT ?: 'e2e_defaults'}
-IMAGE_PMM_SERVER=${IMAGE_PMM_SERVER ?: 'e2e_defaults'}
-IMAGE_PMM3_CLIENT=${IMAGE_PMM3_CLIENT ?: 'e2e_defaults'}
-IMAGE_PMM3_SERVER=${IMAGE_PMM3_SERVER ?: 'e2e_defaults'}
-IMAGE_LOGCOLLECTOR=${IMAGE_LOGCOLLECTOR ?: 'e2e_defaults'}
-IMAGE_SEARCH=${IMAGE_SEARCH ?: 'e2e_defaults'}
-PLATFORM_VER=$PLATFORM_VER"""
-
-    def testsLib = load('cloud/common/vars/tests.groovy')
-    testsLib.writePipelineParameters(pipelineParameters)
-    testsLib.publishPytestReports(
-        tests         : tests,
-        gitShortCommit: GIT_SHORT_COMMIT,
-        gitBranch     : GIT_BRANCH,
-        title         : "PSMDB e2e tests - ${GIT_BRANCH} (${GIT_SHORT_COMMIT})"
-    )
+    def libraries = load('cloud/common/libraries.groovy').loadLibraries()
+    libraries.tests.makeReport(tests, [
+        job_name         : JOB_NAME,
+        git_branch       : GIT_BRANCH,
+        git_short_commit : GIT_SHORT_COMMIT,
+        platform_version : PLATFORM_VER,
+        cluster_wide     : CLUSTER_WIDE,
+        images: [
+            IMAGE_OPERATOR    : IMAGE_OPERATOR,
+            IMAGE_MONGOD      : IMAGE_MONGOD,
+            IMAGE_BACKUP      : IMAGE_BACKUP,
+            IMAGE_PMM_CLIENT  : IMAGE_PMM_CLIENT,
+            IMAGE_PMM_SERVER  : IMAGE_PMM_SERVER,
+            IMAGE_PMM3_CLIENT : IMAGE_PMM3_CLIENT,
+            IMAGE_PMM3_SERVER : IMAGE_PMM3_SERVER,
+            IMAGE_LOGCOLLECTOR: IMAGE_LOGCOLLECTOR,
+            IMAGE_SEARCH      : IMAGE_SEARCH
+        ]
+    ])
 }
 
 void shutdownCluster(String CLUSTER_SUFFIX) {
     timeout(time: 30, unit: 'MINUTES') {
         withCredentials([aws(credentialsId: 'eks-cicd', accessKeyVariable: 'AWS_ACCESS_KEY_ID', secretKeyVariable: 'AWS_SECRET_ACCESS_KEY')]) {
+            def libraries = load('cloud/common/libraries.groovy').loadLibraries()
+            libraries.tools.kubernetesCleanupCluster("/tmp/${CLUSTER_NAME}-${CLUSTER_SUFFIX}")
             sh """
-                export KUBECONFIG=/tmp/$CLUSTER_NAME-$CLUSTER_SUFFIX
-                if [ -s "\$KUBECONFIG" ] && kubectl get --raw='/healthz' --request-timeout=5s >/dev/null 2>&1; then
-                    for namespace in \$(kubectl get namespaces --request-timeout=5s --no-headers | awk '{print \$1}' | grep -vE "^kube-" | sed '/-operator/ s/^/1-/' | sort | sed 's/^1-//'); do
-                        kubectl delete deployments --all -n \$namespace --force --grace-period=0 --request-timeout=10s || true
-                        kubectl delete sts --all -n \$namespace --force --grace-period=0 --request-timeout=10s || true
-                        kubectl delete replicasets --all -n \$namespace --force --grace-period=0 --request-timeout=10s || true
-                        kubectl delete poddisruptionbudget --all -n \$namespace --force --grace-period=0 --request-timeout=10s || true
-                        kubectl delete services --all -n \$namespace --force --grace-period=0 --request-timeout=10s || true
-                        kubectl delete pods --all -n \$namespace --force --grace-period=0 --request-timeout=10s || true
-                    done
-                else
-                    echo "Skipping namespace cleanup: Kubernetes API is not reachable for $CLUSTER_NAME-$CLUSTER_SUFFIX"
-                fi
-
                 VPC_ID=\$(eksctl get cluster --name $CLUSTER_NAME-$CLUSTER_SUFFIX --region ${EKS_REGION} -ojson | jq --raw-output '.[0].ResourcesVpcConfig.VpcId' || true)
                 if [ -n "\$VPC_ID" ]; then
                     LOADBALS=\$(aws elb describe-load-balancers --region ${EKS_REGION} --output json | jq --raw-output '.LoadBalancerDescriptions[] | select(.VPCId == "'\$VPC_ID'").LoadBalancerName')
@@ -531,11 +511,11 @@ pipeline {
                 }
 
                 clusters.each { shutdownCluster(it) }
+
+                def libraries = load('cloud/common/libraries.groovy').loadLibraries()
+                libraries.tools.dockerCleanupVolumes()
             }
 
-            sh """
-                sudo docker system prune --volumes -af
-            """
             deleteDir()
         }
     }

--- a/cloud/jenkins/psmdbo_gke.groovy
+++ b/cloud/jenkins/psmdbo_gke.groovy
@@ -78,6 +78,7 @@ void prepareNode() {
     IMAGE_LOGCOLLECTOR = testVariables.images.IMAGE_LOGCOLLECTOR
     IMAGE_SEARCH = testVariables.images.IMAGE_SEARCH
     MACHINE_TYPE = testVariables.machine_type
+    DB_TAG = testVariables.db_tag
     GIT_SHORT_COMMIT = testVariables.git_short_commit
     CLUSTER_NAME = testVariables.cluster_name
     PARAMS_HASH = testVariables.params_hash

--- a/cloud/jenkins/psmdbo_gke.groovy
+++ b/cloud/jenkins/psmdbo_gke.groovy
@@ -18,17 +18,13 @@ String getParam(String paramName, String keyName = null) {
 }
 
 void prepareNode() {
-    echo "=========================[ Cloning the sources ]========================="
     checkout(scm)
-    sh """
-        # sudo is needed for better node recovery after compilation failure
-        # if building failed on compilation stage directory will have files owned by docker user
-        sudo git config --global --add safe.directory '*'
-        sudo git reset --hard
-        sudo git clean -xdf
-        sudo rm -rf source
-        git clone -b $GIT_BRANCH https://github.com/percona/percona-server-mongodb-operator source
-    """
+    def libraries = load('cloud/common/libraries.groovy').loadLibraries()
+    libraries.tools.gitResetWorkspace()
+    libraries.tools.gitClone(
+        branch: GIT_BRANCH,
+        repo: 'https://github.com/percona/percona-server-mongodb-operator'
+    )
 
     if ("$PILLAR_VERSION" != "none") {
         echo "=========================[ Getting parameters for release test ]========================="
@@ -52,7 +48,6 @@ void prepareNode() {
     }
 
     echo "=========================[ Installing tools on the Jenkins executor ]========================="
-    def libraries = load('cloud/common/libraries.groovy').loadLibraries()
     libraries.dependencies.install()
     libraries.dependencies.installGoogleCLI()
     libraries.dependencies.installAzureCLI()
@@ -335,29 +330,27 @@ void pushArtifactFile(String FILE_NAME) {
 }
 
 void makeReport() {
-    echo "=========================[ Generating Parameters Report ]========================="
-    def pipelineParameters = """
-testsuite name=$JOB_NAME
-IMAGE_OPERATOR=${IMAGE_OPERATOR ?: 'e2e_defaults'}
-IMAGE_MONGOD=${IMAGE_MONGOD ?: 'e2e_defaults'}
-IMAGE_BACKUP=${IMAGE_BACKUP ?: 'e2e_defaults'}
-IMAGE_PMM_CLIENT=${IMAGE_PMM_CLIENT ?: 'e2e_defaults'}
-IMAGE_PMM_SERVER=${IMAGE_PMM_SERVER ?: 'e2e_defaults'}
-IMAGE_PMM3_CLIENT=${IMAGE_PMM3_CLIENT ?: 'e2e_defaults'}
-IMAGE_PMM3_SERVER=${IMAGE_PMM3_SERVER ?: 'e2e_defaults'}
-IMAGE_LOGCOLLECTOR=${IMAGE_LOGCOLLECTOR ?: 'e2e_defaults'}
-IMAGE_SEARCH=${IMAGE_SEARCH ?: 'e2e_defaults'}
-PLATFORM_VER=$PLATFORM_VER
-GKE_RELEASE_CHANNEL=$GKE_RELEASE_CHANNEL"""
-
-    def testsLib = load('cloud/common/vars/tests.groovy')
-    testsLib.writePipelineParameters(pipelineParameters)
-    testsLib.publishPytestReports(
-        tests         : tests,
-        gitShortCommit: GIT_SHORT_COMMIT,
-        gitBranch     : GIT_BRANCH,
-        title         : "PSMDB e2e tests - ${GIT_BRANCH} (${GIT_SHORT_COMMIT})"
-    )
+    def libraries = load('cloud/common/libraries.groovy').loadLibraries()
+    libraries.tests.makeReport(tests, [
+        job_name         : JOB_NAME,
+        git_branch       : GIT_BRANCH,
+        git_short_commit : GIT_SHORT_COMMIT,
+        platform_version : PLATFORM_VER,
+        platform_channel : GKE_RELEASE_CHANNEL,
+        platform_arch    : ARCH,
+        cluster_wide     : CLUSTER_WIDE,
+        images: [
+            IMAGE_OPERATOR    : IMAGE_OPERATOR,
+            IMAGE_MONGOD      : IMAGE_MONGOD,
+            IMAGE_BACKUP      : IMAGE_BACKUP,
+            IMAGE_PMM_CLIENT  : IMAGE_PMM_CLIENT,
+            IMAGE_PMM_SERVER  : IMAGE_PMM_SERVER,
+            IMAGE_PMM3_CLIENT : IMAGE_PMM3_CLIENT,
+            IMAGE_PMM3_SERVER : IMAGE_PMM3_SERVER,
+            IMAGE_LOGCOLLECTOR: IMAGE_LOGCOLLECTOR,
+            IMAGE_SEARCH      : IMAGE_SEARCH
+        ]
+    ])
 }
 
 void shutdownCluster(String CLUSTER_SUFFIX) {
@@ -368,20 +361,9 @@ void shutdownCluster(String CLUSTER_SUFFIX) {
                 "CLUSTER_NAME=${CLUSTER_NAME}",
                 "GKE_REGION=${GKE_REGION}"
             ]) {
+                def libraries = load('cloud/common/libraries.groovy').loadLibraries()
+                libraries.tools.kubernetesCleanupCluster("/tmp/${CLUSTER_NAME}-${CLUSTER_SUFFIX}")
                 sh '''
-                    export KUBECONFIG=/tmp/$CLUSTER_NAME-$CLUSTER_SUFFIX
-                    if [ -s "$KUBECONFIG" ] && kubectl get --raw='/healthz' --request-timeout=5s >/dev/null 2>&1; then
-                        for namespace in $(kubectl get namespaces --request-timeout=5s --no-headers | awk '{print $1}' | grep -vE "^kube-|^gke-" | sed '/-operator/ s/^/1-/' | sort | sed 's/^1-//'); do
-                            kubectl delete deployments --all -n $namespace --force --grace-period=0 --request-timeout=10s || true
-                            kubectl delete sts --all -n $namespace --force --grace-period=0 --request-timeout=10s || true
-                            kubectl delete replicasets --all -n $namespace --force --grace-period=0 --request-timeout=10s || true
-                            kubectl delete poddisruptionbudget --all -n $namespace --force --grace-period=0 --request-timeout=10s || true
-                            kubectl delete services --all -n $namespace --force --grace-period=0 --request-timeout=10s || true
-                            kubectl delete pods --all -n $namespace --force --grace-period=0 --request-timeout=10s || true
-                        done
-                    else
-                        echo "Skipping namespace cleanup: Kubernetes API is not reachable for $CLUSTER_NAME-$CLUSTER_SUFFIX"
-                    fi
                     gcloud container clusters delete --async --zone $GKE_REGION $CLUSTER_NAME-$CLUSTER_SUFFIX --quiet || true
                 '''
             }
@@ -483,11 +465,11 @@ pipeline {
                 }
 
                 clusters.each { shutdownCluster(it) }
+
+                def libraries = load('cloud/common/libraries.groovy').loadLibraries()
+                libraries.tools.dockerCleanupVolumes()
             }
 
-            sh """
-                sudo docker system prune --volumes -af
-            """
             deleteDir()
         }
     }

--- a/cloud/jenkins/psmdbo_gke.groovy
+++ b/cloud/jenkins/psmdbo_gke.groovy
@@ -17,30 +17,6 @@ String getParam(String paramName, String keyName = null) {
     return param
 }
 
-void downloadKubectl() {
-    sh """
-        KUBECTL_VERSION="\$(curl -L -s https://api.github.com/repos/kubernetes/kubernetes/releases/latest | jq -r .tag_name)"
-        for i in {1..5}; do
-          if [ -f /usr/local/bin/kubectl ]; then
-              break
-          fi
-          echo "Attempt \$i: downloading kubectl..."
-          sudo curl -s -L -o /usr/local/bin/kubectl "https://dl.k8s.io/release/\${KUBECTL_VERSION}/bin/linux/amd64/kubectl"
-          sudo curl -s -L -o /tmp/kubectl.sha256 "https://dl.k8s.io/release/\${KUBECTL_VERSION}/bin/linux/amd64/kubectl.sha256"
-          if echo "\$(cat /tmp/kubectl.sha256) /usr/local/bin/kubectl" | sha256sum --check --status; then
-            echo 'Download passed checksum'
-            sudo chmod +x /usr/local/bin/kubectl
-            kubectl version --client --output=yaml
-            break
-          else
-            echo 'Checksum failed, retrying...'
-            sudo rm -f /usr/local/bin/kubectl /tmp/kubectl.sha256
-            sleep 5
-          fi
-        done
-    """
-}
-
 void prepareNode() {
     echo "=========================[ Cloning the sources ]========================="
     checkout(scm)
@@ -76,36 +52,16 @@ void prepareNode() {
     }
 
     echo "=========================[ Installing tools on the Jenkins executor ]========================="
-    sh """
-        sudo curl -fsSL https://github.com/mikefarah/yq/releases/download/v4.44.1/yq_linux_amd64 -o /usr/local/bin/yq && sudo chmod +x /usr/local/bin/yq
-        sudo curl -fsSL https://github.com/jqlang/jq/releases/download/jq-1.7.1/jq-linux64 -o /usr/local/bin/jq && sudo chmod +x /usr/local/bin/jq
-    """
-    downloadKubectl()
-    sh """
-        curl -fsSL https://get.helm.sh/helm-v3.20.0-linux-amd64.tar.gz | sudo tar -C /usr/local/bin --strip-components 1 -xzf - linux-amd64/helm
-
-        sudo tee /etc/yum.repos.d/google-cloud-sdk.repo << EOF
-[google-cloud-cli]
-name=Google Cloud CLI
-baseurl=https://packages.cloud.google.com/yum/repos/cloud-sdk-el7-x86_64
-enabled=1
-gpgcheck=1
-repo_gpgcheck=0
-gpgkey=https://packages.cloud.google.com/yum/doc/rpm-package-key.gpg
-EOF
-        sudo yum install -y google-cloud-cli google-cloud-cli-gke-gcloud-auth-plugin
-    """
-
-    installAzureCLI()
-    azureAuth()
+    def libraries = load('cloud/common/libraries.groovy').loadLibraries()
+    libraries.dependencies.install()
+    libraries.dependencies.installGoogleCLI()
+    libraries.dependencies.installAzureCLI()
+    libraries.dependencies.installUv()
+    libraries.dependencies.syncPythonDeps()
+    libraries.azure.auth()
 
     echo "=========================[ Logging in the Kubernetes provider ]========================="
-    withCredentials([string(credentialsId: 'GCP_PROJECT_ID', variable: 'GCP_PROJECT'), file(credentialsId: 'gcloud-key-file', variable: 'CLIENT_SECRET_FILE')]) {
-        sh '''
-            gcloud auth activate-service-account --key-file $CLIENT_SECRET_FILE
-            gcloud config set project $GCP_PROJECT
-        '''
-    }
+    libraries.gcloud.auth()
 
     if ("$PLATFORM_VER" == "latest") {
         PLATFORM_VER = sh(script: "gcloud container get-server-config --region=${GKE_REGION} --flatten=channels --filter='channels.channel=$GKE_RELEASE_CHANNEL' --format='value(channels.validVersions)' | cut -d- -f1", returnStdout: true).trim()
@@ -303,24 +259,34 @@ void runTest(Integer TEST_ID) {
 
             timeout(time: 90, unit: 'MINUTES') {
                 withCredentials([string(credentialsId: 'GCP_PROJECT_ID', variable: 'GCP_PROJECT')]) {
+                    def testsLib = load('cloud/common/vars/tests.groovy')
+                    def testVars = testsLib.buildPsmdbTestVariables(
+                        cluster_name: CLUSTER_NAME,
+                        debug_tests: DEBUG_TESTS,
+                        cluster_wide: CLUSTER_WIDE,
+                        default_operator_image: "perconalab/percona-server-mongodb-operator:${GIT_BRANCH}",
+                        images: [
+                            IMAGE_OPERATOR    : IMAGE_OPERATOR,
+                            IMAGE_MONGOD      : IMAGE_MONGOD,
+                            IMAGE_BACKUP      : IMAGE_BACKUP,
+                            IMAGE_PMM_CLIENT  : IMAGE_PMM_CLIENT,
+                            IMAGE_PMM_SERVER  : IMAGE_PMM_SERVER,
+                            IMAGE_PMM3_CLIENT : IMAGE_PMM3_CLIENT,
+                            IMAGE_PMM3_SERVER : IMAGE_PMM3_SERVER,
+                            IMAGE_LOGCOLLECTOR: IMAGE_LOGCOLLECTOR,
+                            IMAGE_SEARCH      : IMAGE_SEARCH
+                        ]
+                    )
+                    def exports = testsLib.getExportedVariablesForTests(testVars, clusterSuffix)
+                    def testCmd = testsLib.defineTestCommand(testVars, testName)
                     sh """
                         cd source
 
-                        [[ "$DEBUG_TESTS" == "YES" ]] && export DEBUG_TESTS=1
-                        [[ "$CLUSTER_WIDE" == "YES" ]] && export OPERATOR_NS=psmdb-operator
-                        [[ "$IMAGE_OPERATOR" ]] && export IMAGE=$IMAGE_OPERATOR || export IMAGE=perconalab/percona-server-mongodb-operator:$GIT_BRANCH
-                        export IMAGE_MONGOD=$IMAGE_MONGOD
-                        export IMAGE_BACKUP=$IMAGE_BACKUP
-                        export IMAGE_PMM_CLIENT=$IMAGE_PMM_CLIENT
-                        export IMAGE_PMM_SERVER=$IMAGE_PMM_SERVER
-                        export IMAGE_PMM3_CLIENT=$IMAGE_PMM3_CLIENT
-                        export IMAGE_PMM3_SERVER=$IMAGE_PMM3_SERVER
-                        export IMAGE_LOGCOLLECTOR=$IMAGE_LOGCOLLECTOR
-                        export KUBECONFIG=/tmp/$CLUSTER_NAME-$clusterSuffix
+                        ${exports}
                         export GCP_PROJECT=\$GCP_PROJECT
                         export GCS_WI_SERVICE_ACCOUNT=percona-psmdb-operator-wi@\$GCP_PROJECT.iam.gserviceaccount.com
 
-                        e2e-tests/$testName/run
+                        ${testCmd}
                     """
                 }
             }
@@ -416,39 +382,6 @@ void shutdownCluster(String CLUSTER_SUFFIX) {
             }
         }
     }
-}
-
-void azureAuth() {
-    withCredentials([azureServicePrincipal('PERCONA-OPERATORS-SP')]) {
-        sh '''
-            az login --service-principal -u "$AZURE_CLIENT_ID" -p "$AZURE_CLIENT_SECRET" -t "$AZURE_TENANT_ID"  --allow-no-subscriptions
-            az account set -s "$AZURE_SUBSCRIPTION_ID"
-        '''
-    }
-}
-
-void installAzureCLI() {
-    sh """
-        if ! command -v az &>/dev/null; then
-            if [ "\$JENKINS_AGENT" = "AWS" ]; then
-                curl -s -L https://azurecliprod.blob.core.windows.net/install.py -o install.py
-                printf "/usr/azure-cli\\n/usr/bin" | sudo python3 install.py
-                sudo /usr/azure-cli/bin/python -m pip install "urllib3<2.0.0" > /dev/null
-            else
-                echo "Installing Azure CLI for Hetzner instances..."
-                sudo rpm --import https://packages.microsoft.com/keys/microsoft.asc
-                cat <<EOF | sudo tee /etc/yum.repos.d/azure-cli.repo
-[azure-cli]
-name=Azure CLI
-baseurl=https://packages.microsoft.com/yumrepos/azure-cli
-enabled=1
-gpgcheck=1
-gpgkey=https://packages.microsoft.com/keys/microsoft.asc
-EOF
-                sudo dnf install azure-cli -y
-            fi
-        fi
-    """
 }
 
 pipeline {

--- a/cloud/jenkins/psmdbo_gke.groovy
+++ b/cloud/jenkins/psmdbo_gke.groovy
@@ -4,18 +4,7 @@ import groovy.transform.Field
 @Field def tests = []
 @Field def clusters = []
 @Field def release_versions = "source/e2e-tests/release_versions"
-
-String getParam(String paramName, String keyName = null) {
-    keyName = keyName ?: paramName
-
-    def param = sh(script: "grep -iE '^\\s*$keyName=' $release_versions | cut -d = -f 2 | tr -d \'\"\'| tail -1", returnStdout: true).trim()
-    if ("$param") {
-        echo "$paramName=$param (from params file)"
-    } else {
-        error("$keyName not found in params file $release_versions")
-    }
-    return param
-}
+@Field Map testVariables = [:]
 
 void prepareNode() {
     checkout(scm)
@@ -25,27 +14,6 @@ void prepareNode() {
         branch: GIT_BRANCH,
         repo: 'https://github.com/percona/percona-server-mongodb-operator'
     )
-
-    if ("$PILLAR_VERSION" != "none") {
-        echo "=========================[ Getting parameters for release test ]========================="
-        GKE_RELEASE_CHANNEL = "stable"
-        echo "Forcing GKE_RELEASE_CHANNEL=stable, because it's a release run!"
-
-        IMAGE_OPERATOR = IMAGE_OPERATOR ?: getParam("IMAGE_OPERATOR")
-        IMAGE_MONGOD = IMAGE_MONGOD ?: getParam("IMAGE_MONGOD", "IMAGE_MONGOD${PILLAR_VERSION}")
-        IMAGE_BACKUP = IMAGE_BACKUP ?: getParam("IMAGE_BACKUP")
-        IMAGE_PMM_CLIENT = IMAGE_PMM_CLIENT ?: getParam("IMAGE_PMM_CLIENT")
-        IMAGE_PMM_SERVER = IMAGE_PMM_SERVER ?: getParam("IMAGE_PMM_SERVER")
-        IMAGE_PMM3_CLIENT = IMAGE_PMM3_CLIENT ?: getParam("IMAGE_PMM3_CLIENT")
-        IMAGE_PMM3_SERVER = IMAGE_PMM3_SERVER ?: getParam("IMAGE_PMM3_SERVER")
-        IMAGE_LOGCOLLECTOR = IMAGE_LOGCOLLECTOR ?: getParam("IMAGE_LOGCOLLECTOR")
-        IMAGE_SEARCH = IMAGE_SEARCH ?: getParam("IMAGE_SEARCH")
-        if ("$PLATFORM_VER".toLowerCase() == "min" || "$PLATFORM_VER".toLowerCase() == "max") {
-            PLATFORM_VER = getParam("PLATFORM_VER", "GKE_${PLATFORM_VER}")
-        }
-    } else {
-        echo "=========================[ Not a release run. Using job params only! ]========================="
-    }
 
     echo "=========================[ Installing tools on the Jenkins executor ]========================="
     libraries.dependencies.install()
@@ -58,47 +26,66 @@ void prepareNode() {
     echo "=========================[ Logging in the Kubernetes provider ]========================="
     libraries.gcloud.auth()
 
-    if ("$PLATFORM_VER" == "latest") {
-        PLATFORM_VER = sh(script: "gcloud container get-server-config --region=${GKE_REGION} --flatten=channels --filter='channels.channel=$GKE_RELEASE_CHANNEL' --format='value(channels.validVersions)' | cut -d- -f1", returnStdout: true).trim()
+    if ("$PILLAR_VERSION" != "none") {
+        GKE_RELEASE_CHANNEL = "stable"
+        echo "Forcing GKE_RELEASE_CHANNEL=stable, because it's a release run!"
     }
 
-    if ("$ARCH" == "amd64") {
-        MACHINE_TYPE="n1-standard-4"
-    } else if ("$ARCH" == "arm64") {
-        MACHINE_TYPE="t2a-standard-4"
-    } else {
-        error("Unknown architecture $ARCH")
+    def platformVersion = "$PLATFORM_VER"
+    if ("$PILLAR_VERSION" != "none" && (platformVersion.toLowerCase() in ["min", "max"])) {
+        platformVersion = libraries.tests.getReleaseVersionsParam(release_versions, "PLATFORM_VER", "GKE_${platformVersion.toUpperCase()}")
     }
+
+    testVariables = libraries.tests.prepareVersions([
+        libraries             : libraries,
+        release_versions      : release_versions,
+        operator              : 'psmdb-operator',
+        platform              : 'gke',
+        platform_provider     : 'gcloud',
+        platform_channel      : GKE_RELEASE_CHANNEL,
+        platform_version      : platformVersion,
+        platform_arch         : ARCH,
+        zone                  : GKE_REGION,
+        cluster_wide          : CLUSTER_WIDE,
+        pillar_version        : PILLAR_VERSION,
+        git_branch            : GIT_BRANCH,
+        job_name              : JOB_NAME,
+        db_tag                : DB_TAG,
+        debug_tests           : DEBUG_TESTS,
+        test_executor_type    : 'make',
+        default_operator_image: "perconalab/percona-server-mongodb-operator:${GIT_BRANCH}",
+        images: [
+            IMAGE_OPERATOR    : IMAGE_OPERATOR,
+            IMAGE_MONGOD      : IMAGE_MONGOD,
+            IMAGE_BACKUP      : IMAGE_BACKUP,
+            IMAGE_PMM_CLIENT  : IMAGE_PMM_CLIENT,
+            IMAGE_PMM_SERVER  : IMAGE_PMM_SERVER,
+            IMAGE_PMM3_CLIENT : IMAGE_PMM3_CLIENT,
+            IMAGE_PMM3_SERVER : IMAGE_PMM3_SERVER,
+            IMAGE_LOGCOLLECTOR: IMAGE_LOGCOLLECTOR,
+            IMAGE_SEARCH      : IMAGE_SEARCH
+        ]
+    ])
+
+    PLATFORM_VER = testVariables.platform_version
+    IMAGE_OPERATOR = testVariables.images.IMAGE_OPERATOR
+    IMAGE_MONGOD = testVariables.images.IMAGE_MONGOD
+    IMAGE_BACKUP = testVariables.images.IMAGE_BACKUP
+    IMAGE_PMM_CLIENT = testVariables.images.IMAGE_PMM_CLIENT
+    IMAGE_PMM_SERVER = testVariables.images.IMAGE_PMM_SERVER
+    IMAGE_PMM3_CLIENT = testVariables.images.IMAGE_PMM3_CLIENT
+    IMAGE_PMM3_SERVER = testVariables.images.IMAGE_PMM3_SERVER
+    IMAGE_LOGCOLLECTOR = testVariables.images.IMAGE_LOGCOLLECTOR
+    IMAGE_SEARCH = testVariables.images.IMAGE_SEARCH
+    MACHINE_TYPE = testVariables.machine_type
+    GIT_SHORT_COMMIT = testVariables.git_short_commit
+    CLUSTER_NAME = testVariables.cluster_name
+    PARAMS_HASH = testVariables.params_hash
 
     if ("$IMAGE_MONGOD") {
         cw = ("$CLUSTER_WIDE" == "YES") ? "CW" : "NON-CW"
         currentBuild.displayName = "#" + currentBuild.number + " $GIT_BRANCH"
         currentBuild.description = "$PLATFORM_VER-$GKE_RELEASE_CHANNEL $ARCH " + "$IMAGE_MONGOD".split(":")[1] + " $cw"
-    }
-
-    GIT_SHORT_COMMIT = sh(script: 'git -C source rev-parse --short HEAD', returnStdout: true).trim()
-    CLUSTER_NAME = sh(script: "echo jenkins-$JOB_NAME-$GIT_SHORT_COMMIT | tr '[:upper:]' '[:lower:]'", returnStdout: true).trim()
-    PARAMS_HASH = sh(script: "echo $GIT_BRANCH-$GIT_SHORT_COMMIT-$GKE_RELEASE_CHANNEL-$ARCH-$PLATFORM_VER-$CLUSTER_WIDE-$IMAGE_OPERATOR-$IMAGE_MONGOD-$IMAGE_BACKUP-$IMAGE_PMM_CLIENT-$IMAGE_PMM_SERVER-$IMAGE_PMM3_CLIENT-$IMAGE_PMM3_SERVER-$IMAGE_LOGCOLLECTOR-$IMAGE_SEARCH | md5sum | cut -d' ' -f1", returnStdout: true).trim()
-}
-
-void dockerBuildPush() {
-    echo "=========================[ Building and Pushing the operator Docker image ]========================="
-    withCredentials([usernamePassword(credentialsId: 'hub.docker.com', passwordVariable: 'PASS', usernameVariable: 'USER')]) {
-        sh '''
-            if [[ "$IMAGE_OPERATOR" ]]; then
-                echo "SKIP: Build is not needed, operator image was set!"
-            else
-                cd source
-                sg docker -c '
-                    docker buildx create --use
-                    echo "$PASS" | docker login -u "$USER" --password-stdin
-                    export IMAGE=perconalab/percona-server-mongodb-operator:$GIT_BRANCH
-                    DOCKER_DEFAULT_PLATFORM=linux/amd64,linux/arm64 e2e-tests/build
-                    docker logout
-                '
-                sudo rm -rf build
-            fi
-        '''
     }
 }
 
@@ -184,61 +171,15 @@ void clusterRunner(String cluster) {
 void createCluster(String CLUSTER_SUFFIX) {
     clusters.add("$CLUSTER_SUFFIX")
 
-    timeout(time: 30, unit: 'MINUTES') {
-        withCredentials([string(credentialsId: 'GCP_PROJECT_ID', variable: 'GCP_PROJECT'), file(credentialsId: 'gcloud-key-file', variable: 'CLIENT_SECRET_FILE')]) {
-            withEnv([
-                "CLUSTER_SUFFIX=${CLUSTER_SUFFIX}",
-                "CLUSTER_NAME=${CLUSTER_NAME}",
-                "GKE_RELEASE_CHANNEL=${GKE_RELEASE_CHANNEL}",
-                "GKE_REGION=${GKE_REGION}",
-                "PLATFORM_VER=${PLATFORM_VER}",
-                "MACHINE_TYPE=${MACHINE_TYPE}"
-            ]) {
-                sh '''
-                    export KUBECONFIG=/tmp/$CLUSTER_NAME-$CLUSTER_SUFFIX
-                    maxRetries=15
-                    exitCode=1
-
-                    while [[ $exitCode != 0 && $maxRetries > 0 ]]; do
-                        gcloud container clusters create $CLUSTER_NAME-$CLUSTER_SUFFIX \
-                            --release-channel $GKE_RELEASE_CHANNEL \
-                            --zone $GKE_REGION \
-                            --cluster-version $PLATFORM_VER \
-                            --preemptible \
-                            --disk-size 30 \
-                            --machine-type $MACHINE_TYPE \
-                            --num-nodes=3 \
-                            --network=jenkins-vpc \
-                            --subnetwork=jenkins-$CLUSTER_SUFFIX \
-                            --cluster-ipv4-cidr=/21 \
-                            --labels delete-cluster-after-hours=6 \
-                            --enable-ip-alias \
-                            --monitoring=NONE \
-                            --logging=NONE \
-                            --no-enable-managed-prometheus \
-                            --workload-pool=cloud-dev-112233.svc.id.goog \
-                            --quiet &&\
-                        kubectl create clusterrolebinding cluster-admin-binding1 --clusterrole=cluster-admin --user=$(gcloud config get-value core/account)
-                        exitCode=$?
-                        if [[ $exitCode == 0 ]]; then break; fi
-                        (( maxRetries -- ))
-                        sleep 1
-                    done
-                    if [[ $exitCode != 0 ]]; then exit $exitCode; fi
-
-                    CURRENT_TIME=$(date --rfc-3339=seconds)
-                    FUTURE_TIME=$(date -d '6 hours' --rfc-3339=seconds)
-
-                    gcloud container clusters update $CLUSTER_NAME-$CLUSTER_SUFFIX \
-                        --zone $GKE_REGION \
-                        --add-maintenance-exclusion-start "$CURRENT_TIME" \
-                        --add-maintenance-exclusion-end "$FUTURE_TIME"
-
-                    kubectl get nodes -o custom-columns="NAME:.metadata.name,TAINTS:.spec.taints,AGE:.metadata.creationTimestamp"
-                '''
-            }
-        }
-    }
+    def libraries = load('cloud/common/libraries.groovy').loadLibraries()
+    libraries.gcloud.createCluster([
+        clusterName    : CLUSTER_NAME,
+        clusterSuffix  : CLUSTER_SUFFIX,
+        platformChannel: GKE_RELEASE_CHANNEL,
+        platformVersion: PLATFORM_VER,
+        machineType    : MACHINE_TYPE,
+        zone           : GKE_REGION
+    ])
 }
 
 void runTest(Integer TEST_ID) {
@@ -290,7 +231,7 @@ BASH
                     """
                 }
             }
-            pushArtifactFile("$GIT_BRANCH-$GIT_SHORT_COMMIT-$testName-$PLATFORM_VER-$DB_TAG-CW_$CLUSTER_WIDE-$PARAMS_HASH")
+            testsLib.pushArtifactFile("$GIT_BRANCH-$GIT_SHORT_COMMIT-$testName-$PLATFORM_VER-$DB_TAG-CW_$CLUSTER_WIDE-$PARAMS_HASH", GIT_SHORT_COMMIT)
             tests[TEST_ID]["result"] = "passed"
             return true
         }
@@ -316,59 +257,14 @@ BASH
     }
 }
 
-void pushArtifactFile(String FILE_NAME) {
-    echo "Push $FILE_NAME file to S3!"
-
-    withCredentials([aws(credentialsId: 'AMI/OVF', accessKeyVariable: 'AWS_ACCESS_KEY_ID', secretKeyVariable: 'AWS_SECRET_ACCESS_KEY')]) {
-        sh """
-            touch $FILE_NAME
-            S3_PATH=s3://percona-jenkins-artifactory/\$JOB_NAME/$GIT_SHORT_COMMIT
-            aws s3 ls \$S3_PATH/$FILE_NAME || :
-            aws s3 cp --quiet $FILE_NAME \$S3_PATH/$FILE_NAME || :
-        """
-    }
-}
-
-void makeReport() {
-    def libraries = load('cloud/common/libraries.groovy').loadLibraries()
-    libraries.tests.makeReport(tests, [
-        job_name         : JOB_NAME,
-        git_branch       : GIT_BRANCH,
-        git_short_commit : GIT_SHORT_COMMIT,
-        platform_version : PLATFORM_VER,
-        platform_channel : GKE_RELEASE_CHANNEL,
-        platform_arch    : ARCH,
-        cluster_wide     : CLUSTER_WIDE,
-        images: [
-            IMAGE_OPERATOR    : IMAGE_OPERATOR,
-            IMAGE_MONGOD      : IMAGE_MONGOD,
-            IMAGE_BACKUP      : IMAGE_BACKUP,
-            IMAGE_PMM_CLIENT  : IMAGE_PMM_CLIENT,
-            IMAGE_PMM_SERVER  : IMAGE_PMM_SERVER,
-            IMAGE_PMM3_CLIENT : IMAGE_PMM3_CLIENT,
-            IMAGE_PMM3_SERVER : IMAGE_PMM3_SERVER,
-            IMAGE_LOGCOLLECTOR: IMAGE_LOGCOLLECTOR,
-            IMAGE_SEARCH      : IMAGE_SEARCH
-        ]
-    ])
-}
-
 void shutdownCluster(String CLUSTER_SUFFIX) {
-    timeout(time: 30, unit: 'MINUTES') {
-        withCredentials([string(credentialsId: 'GCP_PROJECT_ID', variable: 'GCP_PROJECT'), file(credentialsId: 'gcloud-key-file', variable: 'CLIENT_SECRET_FILE')]) {
-            withEnv([
-                "CLUSTER_SUFFIX=${CLUSTER_SUFFIX}",
-                "CLUSTER_NAME=${CLUSTER_NAME}",
-                "GKE_REGION=${GKE_REGION}"
-            ]) {
-                def libraries = load('cloud/common/libraries.groovy').loadLibraries()
-                libraries.tools.kubernetesCleanupCluster("/tmp/${CLUSTER_NAME}-${CLUSTER_SUFFIX}")
-                sh '''
-                    gcloud container clusters delete --async --zone $GKE_REGION $CLUSTER_NAME-$CLUSTER_SUFFIX --quiet || true
-                '''
-            }
-        }
-    }
+    def libraries = load('cloud/common/libraries.groovy').loadLibraries()
+    libraries.tools.kubernetesCleanupCluster("/tmp/${CLUSTER_NAME}-${CLUSTER_SUFFIX}")
+    libraries.gcloud.shutdownCluster([
+        clusterName  : CLUSTER_NAME,
+        clusterSuffix: CLUSTER_SUFFIX,
+        zone         : GKE_REGION
+    ])
 }
 
 pipeline {
@@ -417,7 +313,14 @@ pipeline {
         }
         stage('Docker Build and Push') {
             steps {
-                dockerBuildPush()
+                script {
+                    def libraries = load('cloud/common/libraries.groovy').loadLibraries()
+                    libraries.tools.dockerBuildAndPush(
+                        operatorImage: 'perconalab/percona-server-mongodb-operator',
+                        branch       : GIT_BRANCH,
+                        platform     : 'linux/amd64,linux/arm64'
+                    )
+                }
             }
         }
         stage('Init Tests') {
@@ -445,9 +348,11 @@ pipeline {
     post {
         always {
             echo "CLUSTER ASSIGNMENTS\n" + tests.toString().replace("], ","]\n").replace("]]","]").replaceFirst("\\[","")
-            makeReport()
 
             script {
+                def libraries = load('cloud/common/libraries.groovy').loadLibraries()
+                libraries.tests.makeReport(tests, testVariables)
+
                 try {
                     def sendJobSlack = load "cloud/common/sendJobSlackNotification.groovy"
                     sendJobSlack.call(
@@ -466,7 +371,6 @@ pipeline {
 
                 clusters.each { shutdownCluster(it) }
 
-                def libraries = load('cloud/common/libraries.groovy').loadLibraries()
                 libraries.tools.dockerCleanupVolumes()
             }
 

--- a/cloud/jenkins/psmdbo_gke.groovy
+++ b/cloud/jenkins/psmdbo_gke.groovy
@@ -253,13 +253,13 @@ void runTest(Integer TEST_ID) {
 
     waitUntil {
         def timeStart = new Date().getTime()
+        def testsLib = load('cloud/common/vars/tests.groovy')
         try {
             echo "The $testName test was started on cluster $CLUSTER_NAME-$clusterSuffix !"
             tests[TEST_ID]["result"] = "failure"
 
             timeout(time: 90, unit: 'MINUTES') {
                 withCredentials([string(credentialsId: 'GCP_PROJECT_ID', variable: 'GCP_PROJECT')]) {
-                    def testsLib = load('cloud/common/vars/tests.groovy')
                     def testVars = testsLib.buildPsmdbTestVariables(
                         cluster_name: CLUSTER_NAME,
                         debug_tests: DEBUG_TESTS,
@@ -286,7 +286,12 @@ void runTest(Integer TEST_ID) {
                         export GCP_PROJECT=\$GCP_PROJECT
                         export GCS_WI_SERVICE_ACCOUNT=percona-psmdb-operator-wi@\$GCP_PROJECT.iam.gserviceaccount.com
 
-                        ${testCmd}
+                        mkdir -p e2e-tests/logs e2e-tests/reports
+                        bash -o pipefail <<BASH
+                        {
+                            ${testCmd}
+                        } 2>&1 | tee e2e-tests/logs/${testName}.log
+BASH
                     """
                 }
             }
@@ -306,6 +311,11 @@ void runTest(Integer TEST_ID) {
             def timeStop = new Date().getTime()
             def durationSec = (timeStop - timeStart) / 1000
             tests[TEST_ID]["time"] = durationSec
+            try {
+                testsLib.pushLogFile(testName, [gitShortCommit: GIT_SHORT_COMMIT])
+            } catch (logErr) {
+                echo "Warning: failed to push log for $testName: ${logErr}"
+            }
             echo "The $testName test was finished!"
         }
     }
@@ -325,15 +335,8 @@ void pushArtifactFile(String FILE_NAME) {
 }
 
 void makeReport() {
-    echo "=========================[ Generating Test Report ]========================="
-    testsReport = "<testsuite name=\"$JOB_NAME\">\n"
-    for (int i = 0; i < tests.size(); i ++) {
-        testsReport += '<testcase name="' + tests[i]["name"] + '" time="' + tests[i]["time"] + '"><'+ tests[i]["result"] +'/></testcase>\n'
-    }
-    testsReport += '</testsuite>\n'
-
     echo "=========================[ Generating Parameters Report ]========================="
-    pipelineParameters = """
+    def pipelineParameters = """
 testsuite name=$JOB_NAME
 IMAGE_OPERATOR=${IMAGE_OPERATOR ?: 'e2e_defaults'}
 IMAGE_MONGOD=${IMAGE_MONGOD ?: 'e2e_defaults'}
@@ -347,11 +350,13 @@ IMAGE_SEARCH=${IMAGE_SEARCH ?: 'e2e_defaults'}
 PLATFORM_VER=$PLATFORM_VER
 GKE_RELEASE_CHANNEL=$GKE_RELEASE_CHANNEL"""
 
-    writeFile file: "TestsReport.xml", text: testsReport
-    writeFile file: 'PipelineParameters.txt', text: pipelineParameters
-
-    addSummary(icon: 'symbol-aperture-outline plugin-ionicons-api',
-        text: "<pre>${pipelineParameters}</pre>"
+    def testsLib = load('cloud/common/vars/tests.groovy')
+    testsLib.writePipelineParameters(pipelineParameters)
+    testsLib.publishPytestReports(
+        tests         : tests,
+        gitShortCommit: GIT_SHORT_COMMIT,
+        gitBranch     : GIT_BRANCH,
+        title         : "PSMDB e2e tests - ${GIT_BRANCH} (${GIT_SHORT_COMMIT})"
     )
 }
 
@@ -459,8 +464,6 @@ pipeline {
         always {
             echo "CLUSTER ASSIGNMENTS\n" + tests.toString().replace("], ","]\n").replace("]]","]").replaceFirst("\\[","")
             makeReport()
-            junit testResults: '*.xml', healthScaleFactor: 1.0
-            archiveArtifacts '*.xml,*.txt'
 
             script {
                 try {

--- a/cloud/jenkins/psmdbo_minikube.groovy
+++ b/cloud/jenkins/psmdbo_minikube.groovy
@@ -162,12 +162,12 @@ void runTest(Integer TEST_ID) {
 
     waitUntil {
         def timeStart = new Date().getTime()
+        def testsLib = load('cloud/common/vars/tests.groovy')
         try {
             echo "The $testName test was started !"
             tests[TEST_ID]["result"] = "failure"
 
             timeout(time: 90, unit: 'MINUTES') {
-                def testsLib = load('cloud/common/vars/tests.groovy')
                 def testVars = testsLib.buildPsmdbTestVariables(
                     cluster_name: 'minikube',
                     skip_kubeconfig: true,
@@ -194,7 +194,12 @@ void runTest(Integer TEST_ID) {
                     ${exports}
 
                     sudo rm -rf /tmp/hostpath-provisioner/*
-                    ${testCmd}
+                    mkdir -p e2e-tests/logs e2e-tests/reports
+                    bash -o pipefail <<BASH
+                    {
+                        ${testCmd}
+                    } 2>&1 | tee e2e-tests/logs/${testName}.log
+BASH
                 """
             }
             pushArtifactFile("$GIT_BRANCH-$GIT_SHORT_COMMIT-$testName-$PLATFORM_VER-$DB_TAG-CW_$CLUSTER_WIDE-$PARAMS_HASH")
@@ -213,6 +218,11 @@ void runTest(Integer TEST_ID) {
             def timeStop = new Date().getTime()
             def durationSec = (timeStop - timeStart) / 1000
             tests[TEST_ID]["time"] = durationSec
+            try {
+                testsLib.pushLogFile(testName, [gitShortCommit: GIT_SHORT_COMMIT])
+            } catch (logErr) {
+                echo "Warning: failed to push log for $testName: ${logErr}"
+            }
             echo "The $testName test was finished!"
         }
     }
@@ -232,15 +242,8 @@ void pushArtifactFile(String FILE_NAME) {
 }
 
 void makeReport() {
-    echo "=========================[ Generating Test Report ]========================="
-    testsReport = "<testsuite name=\"$JOB_NAME\">\n"
-    for (int i = 0; i < tests.size(); i ++) {
-        testsReport += '<testcase name="' + tests[i]["name"] + '" time="' + tests[i]["time"] + '"><'+ tests[i]["result"] +'/></testcase>\n'
-    }
-    testsReport += '</testsuite>\n'
-
     echo "=========================[ Generating Parameters Report ]========================="
-    pipelineParameters = """
+    def pipelineParameters = """
 testsuite name=$JOB_NAME
 IMAGE_OPERATOR=${IMAGE_OPERATOR ?: 'e2e_defaults'}
 IMAGE_MONGOD=${IMAGE_MONGOD ?: 'e2e_defaults'}
@@ -253,11 +256,13 @@ IMAGE_LOGCOLLECTOR=${IMAGE_LOGCOLLECTOR ?: 'e2e_defaults'}
 IMAGE_SEARCH=${IMAGE_SEARCH ?: 'e2e_defaults'}
 PLATFORM_VER=$PLATFORM_VER"""
 
-    writeFile file: "TestsReport.xml", text: testsReport
-    writeFile file: 'PipelineParameters.txt', text: pipelineParameters
-
-    addSummary(icon: 'symbol-aperture-outline plugin-ionicons-api',
-        text: "<pre>${pipelineParameters}</pre>"
+    def testsLib = load('cloud/common/vars/tests.groovy')
+    testsLib.writePipelineParameters(pipelineParameters)
+    testsLib.publishPytestReports(
+        tests         : tests,
+        gitShortCommit: GIT_SHORT_COMMIT,
+        gitBranch     : GIT_BRANCH,
+        title         : "PSMDB e2e tests - ${GIT_BRANCH} (${GIT_SHORT_COMMIT})"
     )
 }
 
@@ -325,8 +330,6 @@ pipeline {
         always {
             echo "CLUSTER ASSIGNMENTS\n" + tests.toString().replace("], ","]\n").replace("]]","]").replaceFirst("\\[","")
             makeReport()
-            junit testResults: '*.xml', healthScaleFactor: 1.0
-            archiveArtifacts '*.xml,*.txt'
 
             script {
                 try {

--- a/cloud/jenkins/psmdbo_minikube.groovy
+++ b/cloud/jenkins/psmdbo_minikube.groovy
@@ -67,6 +67,7 @@ void prepareNode() {
     IMAGE_PMM3_SERVER = testVariables.images.IMAGE_PMM3_SERVER
     IMAGE_LOGCOLLECTOR = testVariables.images.IMAGE_LOGCOLLECTOR
     IMAGE_SEARCH = testVariables.images.IMAGE_SEARCH
+    DB_TAG = testVariables.db_tag
     GIT_SHORT_COMMIT = testVariables.git_short_commit
     PARAMS_HASH = testVariables.params_hash
 

--- a/cloud/jenkins/psmdbo_minikube.groovy
+++ b/cloud/jenkins/psmdbo_minikube.groovy
@@ -16,17 +16,13 @@ String getParam(String paramName, String keyName = null) {
 }
 
 void prepareNode() {
-    echo "=========================[ Cloning the sources ]========================="
     checkout(scm)
-    sh """
-        # sudo is needed for better node recovery after compilation failure
-        # if building failed on compilation stage directory will have files owned by docker user
-        sudo git config --global --add safe.directory '*'
-        sudo git reset --hard
-        sudo git clean -xdf
-        sudo rm -rf source
-        git clone -b $GIT_BRANCH https://github.com/percona/percona-server-mongodb-operator source
-    """
+    def libraries = load('cloud/common/libraries.groovy').loadLibraries()
+    libraries.tools.gitResetWorkspace()
+    libraries.tools.gitClone(
+        branch: GIT_BRANCH,
+        repo: 'https://github.com/percona/percona-server-mongodb-operator'
+    )
 
     if ("$PILLAR_VERSION" != "none") {
         echo "=========================[ Getting parameters for release test ]========================="
@@ -47,7 +43,6 @@ void prepareNode() {
     }
 
     echo "=========================[ Installing tools on the Jenkins executor ]========================="
-    def libraries = load('cloud/common/libraries.groovy').loadLibraries()
     libraries.dependencies.install()
     libraries.dependencies.installAzureCLI()
     libraries.dependencies.installUv()
@@ -242,28 +237,25 @@ void pushArtifactFile(String FILE_NAME) {
 }
 
 void makeReport() {
-    echo "=========================[ Generating Parameters Report ]========================="
-    def pipelineParameters = """
-testsuite name=$JOB_NAME
-IMAGE_OPERATOR=${IMAGE_OPERATOR ?: 'e2e_defaults'}
-IMAGE_MONGOD=${IMAGE_MONGOD ?: 'e2e_defaults'}
-IMAGE_BACKUP=${IMAGE_BACKUP ?: 'e2e_defaults'}
-IMAGE_PMM_CLIENT=${IMAGE_PMM_CLIENT ?: 'e2e_defaults'}
-IMAGE_PMM_SERVER=${IMAGE_PMM_SERVER ?: 'e2e_defaults'}
-IMAGE_PMM3_CLIENT=${IMAGE_PMM3_CLIENT ?: 'e2e_defaults'}
-IMAGE_PMM3_SERVER=${IMAGE_PMM3_SERVER ?: 'e2e_defaults'}
-IMAGE_LOGCOLLECTOR=${IMAGE_LOGCOLLECTOR ?: 'e2e_defaults'}
-IMAGE_SEARCH=${IMAGE_SEARCH ?: 'e2e_defaults'}
-PLATFORM_VER=$PLATFORM_VER"""
-
-    def testsLib = load('cloud/common/vars/tests.groovy')
-    testsLib.writePipelineParameters(pipelineParameters)
-    testsLib.publishPytestReports(
-        tests         : tests,
-        gitShortCommit: GIT_SHORT_COMMIT,
-        gitBranch     : GIT_BRANCH,
-        title         : "PSMDB e2e tests - ${GIT_BRANCH} (${GIT_SHORT_COMMIT})"
-    )
+    def libraries = load('cloud/common/libraries.groovy').loadLibraries()
+    libraries.tests.makeReport(tests, [
+        job_name         : JOB_NAME,
+        git_branch       : GIT_BRANCH,
+        git_short_commit : GIT_SHORT_COMMIT,
+        platform_version : PLATFORM_VER,
+        cluster_wide     : CLUSTER_WIDE,
+        images: [
+            IMAGE_OPERATOR    : IMAGE_OPERATOR,
+            IMAGE_MONGOD      : IMAGE_MONGOD,
+            IMAGE_BACKUP      : IMAGE_BACKUP,
+            IMAGE_PMM_CLIENT  : IMAGE_PMM_CLIENT,
+            IMAGE_PMM_SERVER  : IMAGE_PMM_SERVER,
+            IMAGE_PMM3_CLIENT : IMAGE_PMM3_CLIENT,
+            IMAGE_PMM3_SERVER : IMAGE_PMM3_SERVER,
+            IMAGE_LOGCOLLECTOR: IMAGE_LOGCOLLECTOR,
+            IMAGE_SEARCH      : IMAGE_SEARCH
+        ]
+    ])
 }
 
 pipeline {

--- a/cloud/jenkins/psmdbo_minikube.groovy
+++ b/cloud/jenkins/psmdbo_minikube.groovy
@@ -2,18 +2,7 @@ import groovy.transform.Field
 
 @Field def tests = []
 @Field def release_versions = "source/e2e-tests/release_versions"
-
-String getParam(String paramName, String keyName = null) {
-    keyName = keyName ?: paramName
-
-    def param = sh(script: "grep -iE '^\\s*$keyName=' $release_versions | cut -d = -f 2 | tr -d \'\"\'| tail -1", returnStdout: true).trim()
-    if ("$param") {
-        echo "$paramName=$param (from params file)"
-    } else {
-        error("$keyName not found in params file $release_versions")
-    }
-    return param
-}
+@Field Map testVariables = [:]
 
 void prepareNode() {
     checkout(scm)
@@ -23,24 +12,6 @@ void prepareNode() {
         branch: GIT_BRANCH,
         repo: 'https://github.com/percona/percona-server-mongodb-operator'
     )
-
-    if ("$PILLAR_VERSION" != "none") {
-        echo "=========================[ Getting parameters for release test ]========================="
-        IMAGE_OPERATOR = IMAGE_OPERATOR ?: getParam("IMAGE_OPERATOR")
-        IMAGE_MONGOD = IMAGE_MONGOD ?: getParam("IMAGE_MONGOD", "IMAGE_MONGOD${PILLAR_VERSION}")
-        IMAGE_BACKUP = IMAGE_BACKUP ?: getParam("IMAGE_BACKUP")
-        IMAGE_PMM_CLIENT = IMAGE_PMM_CLIENT ?: getParam("IMAGE_PMM_CLIENT")
-        IMAGE_PMM_SERVER = IMAGE_PMM_SERVER ?: getParam("IMAGE_PMM_SERVER")
-        IMAGE_PMM3_CLIENT = IMAGE_PMM3_CLIENT ?: getParam("IMAGE_PMM3_CLIENT")
-        IMAGE_PMM3_SERVER = IMAGE_PMM3_SERVER ?: getParam("IMAGE_PMM3_SERVER")
-        IMAGE_LOGCOLLECTOR = IMAGE_LOGCOLLECTOR ?: getParam("IMAGE_LOGCOLLECTOR")
-        IMAGE_SEARCH = IMAGE_SEARCH ?: getParam("IMAGE_SEARCH")
-        if ("$PLATFORM_VER".toLowerCase() == "rel") {
-            PLATFORM_VER = getParam("PLATFORM_VER", "MINIKUBE_${PLATFORM_VER}")
-        }
-    } else {
-        echo "=========================[ Not a release run. Using job params only! ]========================="
-    }
 
     echo "=========================[ Installing tools on the Jenkins executor ]========================="
     libraries.dependencies.install()
@@ -53,34 +24,56 @@ void prepareNode() {
         sudo curl -sLo /usr/local/bin/minikube https://storage.googleapis.com/minikube/releases/latest/minikube-linux-amd64 && sudo chmod +x /usr/local/bin/minikube
     """
 
+    def platformVersion = "$PLATFORM_VER"
+    if ("$PILLAR_VERSION" != "none" && platformVersion.toLowerCase() == "rel") {
+        platformVersion = libraries.tests.getReleaseVersionsParam(release_versions, "PLATFORM_VER", "MINIKUBE_REL")
+    }
+
+    testVariables = libraries.tests.prepareVersions([
+        libraries             : libraries,
+        release_versions      : release_versions,
+        operator              : 'psmdb-operator',
+        platform              : 'minikube',
+        platform_provider     : 'minikube',
+        platform_version      : platformVersion,
+        cluster_wide          : CLUSTER_WIDE,
+        pillar_version        : PILLAR_VERSION,
+        git_branch            : GIT_BRANCH,
+        job_name              : JOB_NAME,
+        db_tag                : DB_TAG,
+        debug_tests           : DEBUG_TESTS,
+        test_executor_type    : 'make',
+        default_operator_image: "perconalab/percona-server-mongodb-operator:${GIT_BRANCH}",
+        images: [
+            IMAGE_OPERATOR    : IMAGE_OPERATOR,
+            IMAGE_MONGOD      : IMAGE_MONGOD,
+            IMAGE_BACKUP      : IMAGE_BACKUP,
+            IMAGE_PMM_CLIENT  : IMAGE_PMM_CLIENT,
+            IMAGE_PMM_SERVER  : IMAGE_PMM_SERVER,
+            IMAGE_PMM3_CLIENT : IMAGE_PMM3_CLIENT,
+            IMAGE_PMM3_SERVER : IMAGE_PMM3_SERVER,
+            IMAGE_LOGCOLLECTOR: IMAGE_LOGCOLLECTOR,
+            IMAGE_SEARCH      : IMAGE_SEARCH
+        ]
+    ])
+
+    PLATFORM_VER = testVariables.platform_version
+    IMAGE_OPERATOR = testVariables.images.IMAGE_OPERATOR
+    IMAGE_MONGOD = testVariables.images.IMAGE_MONGOD
+    IMAGE_BACKUP = testVariables.images.IMAGE_BACKUP
+    IMAGE_PMM_CLIENT = testVariables.images.IMAGE_PMM_CLIENT
+    IMAGE_PMM_SERVER = testVariables.images.IMAGE_PMM_SERVER
+    IMAGE_PMM3_CLIENT = testVariables.images.IMAGE_PMM3_CLIENT
+    IMAGE_PMM3_SERVER = testVariables.images.IMAGE_PMM3_SERVER
+    IMAGE_LOGCOLLECTOR = testVariables.images.IMAGE_LOGCOLLECTOR
+    IMAGE_SEARCH = testVariables.images.IMAGE_SEARCH
+    GIT_SHORT_COMMIT = testVariables.git_short_commit
+    PARAMS_HASH = testVariables.params_hash
+
     if ("$IMAGE_MONGOD") {
         cw = ("$CLUSTER_WIDE" == "YES") ? "CW" : "NON-CW"
         currentBuild.displayName = "#" + currentBuild.number + " $GIT_BRANCH"
         currentBuild.description = "$PLATFORM_VER " + "$IMAGE_MONGOD".split(":")[1] + " $cw"
-    }
-
-    GIT_SHORT_COMMIT = sh(script: 'git -C source rev-parse --short HEAD', returnStdout: true).trim()
-    PARAMS_HASH = sh(script: "echo $GIT_BRANCH-$GIT_SHORT_COMMIT-$PLATFORM_VER-$CLUSTER_WIDE-$IMAGE_OPERATOR-$IMAGE_MONGOD-$IMAGE_BACKUP-$IMAGE_PMM_CLIENT-$IMAGE_PMM_SERVER-$IMAGE_PMM3_CLIENT-$IMAGE_PMM3_SERVER-$IMAGE_LOGCOLLECTOR-$IMAGE_SEARCH | md5sum | cut -d' ' -f1", returnStdout: true).trim()
-}
-
-void dockerBuildPush() {
-    echo "=========================[ Building and Pushing the operator Docker image ]========================="
-    withCredentials([usernamePassword(credentialsId: 'hub.docker.com', passwordVariable: 'PASS', usernameVariable: 'USER')]) {
-        sh '''
-            if [[ "$IMAGE_OPERATOR" ]]; then
-                echo "SKIP: Build is not needed, operator image was set!"
-            else
-                cd source
-                sg docker -c '
-                    docker buildx create --use
-                    echo "$PASS" | docker login -u "$USER" --password-stdin
-                    export IMAGE=perconalab/percona-server-mongodb-operator:$GIT_BRANCH
-                    DOCKER_DEFAULT_PLATFORM=linux/amd64,linux/arm64 e2e-tests/build
-                    docker logout
-                '
-                sudo rm -rf build
-            fi
-        '''
     }
 }
 
@@ -137,10 +130,8 @@ void initTests() {
 }
 
 void clusterRunner(String cluster) {
-    sh """
-        export CHANGE_MINIKUBE_NONE_USER=true
-        minikube start --kubernetes-version $PLATFORM_VER --cpus=6 --memory=28G --force
-    """
+    def libraries = load('cloud/common/libraries.groovy').loadLibraries()
+    libraries.minikube.createCluster([platformVersion: PLATFORM_VER])
 
     for (int i=0; i<tests.size(); i++) {
         if (tests[i]["result"] == "skipped") {
@@ -197,7 +188,7 @@ void runTest(Integer TEST_ID) {
 BASH
                 """
             }
-            pushArtifactFile("$GIT_BRANCH-$GIT_SHORT_COMMIT-$testName-$PLATFORM_VER-$DB_TAG-CW_$CLUSTER_WIDE-$PARAMS_HASH")
+            testsLib.pushArtifactFile("$GIT_BRANCH-$GIT_SHORT_COMMIT-$testName-$PLATFORM_VER-$DB_TAG-CW_$CLUSTER_WIDE-$PARAMS_HASH", GIT_SHORT_COMMIT)
             tests[TEST_ID]["result"] = "passed"
             return true
         }
@@ -221,41 +212,6 @@ BASH
             echo "The $testName test was finished!"
         }
     }
-}
-
-void pushArtifactFile(String FILE_NAME) {
-    echo "Push $FILE_NAME file to S3!"
-
-    withCredentials([aws(credentialsId: 'AMI/OVF', accessKeyVariable: 'AWS_ACCESS_KEY_ID', secretKeyVariable: 'AWS_SECRET_ACCESS_KEY')]) {
-        sh """
-            touch $FILE_NAME
-            S3_PATH=s3://percona-jenkins-artifactory/\$JOB_NAME/$GIT_SHORT_COMMIT
-            aws s3 ls \$S3_PATH/$FILE_NAME || :
-            aws s3 cp --quiet $FILE_NAME \$S3_PATH/$FILE_NAME || :
-        """
-    }
-}
-
-void makeReport() {
-    def libraries = load('cloud/common/libraries.groovy').loadLibraries()
-    libraries.tests.makeReport(tests, [
-        job_name         : JOB_NAME,
-        git_branch       : GIT_BRANCH,
-        git_short_commit : GIT_SHORT_COMMIT,
-        platform_version : PLATFORM_VER,
-        cluster_wide     : CLUSTER_WIDE,
-        images: [
-            IMAGE_OPERATOR    : IMAGE_OPERATOR,
-            IMAGE_MONGOD      : IMAGE_MONGOD,
-            IMAGE_BACKUP      : IMAGE_BACKUP,
-            IMAGE_PMM_CLIENT  : IMAGE_PMM_CLIENT,
-            IMAGE_PMM_SERVER  : IMAGE_PMM_SERVER,
-            IMAGE_PMM3_CLIENT : IMAGE_PMM3_CLIENT,
-            IMAGE_PMM3_SERVER : IMAGE_PMM3_SERVER,
-            IMAGE_LOGCOLLECTOR: IMAGE_LOGCOLLECTOR,
-            IMAGE_SEARCH      : IMAGE_SEARCH
-        ]
-    ])
 }
 
 pipeline {
@@ -301,7 +257,14 @@ pipeline {
         }
         stage('Docker Build and Push') {
             steps {
-                dockerBuildPush()
+                script {
+                    def libraries = load('cloud/common/libraries.groovy').loadLibraries()
+                    libraries.tools.dockerBuildAndPush(
+                        operatorImage: 'perconalab/percona-server-mongodb-operator',
+                        branch       : GIT_BRANCH,
+                        platform     : 'linux/amd64,linux/arm64'
+                    )
+                }
             }
         }
         stage('Init Tests') {
@@ -321,9 +284,11 @@ pipeline {
     post {
         always {
             echo "CLUSTER ASSIGNMENTS\n" + tests.toString().replace("], ","]\n").replace("]]","]").replaceFirst("\\[","")
-            makeReport()
 
             script {
+                def libraries = load('cloud/common/libraries.groovy').loadLibraries()
+                libraries.tests.makeReport(tests, testVariables)
+
                 try {
                     def sendJobSlack = load "cloud/common/sendJobSlackNotification.groovy"
                     sendJobSlack.call(

--- a/cloud/jenkins/psmdbo_minikube.groovy
+++ b/cloud/jenkins/psmdbo_minikube.groovy
@@ -15,30 +15,6 @@ String getParam(String paramName, String keyName = null) {
     return param
 }
 
-void downloadKubectl() {
-    sh """
-        KUBECTL_VERSION="\$(curl -L -s https://api.github.com/repos/kubernetes/kubernetes/releases/latest | jq -r .tag_name)"
-        for i in {1..5}; do
-          if [ -f /usr/local/bin/kubectl ]; then
-              break
-          fi
-          echo "Attempt \$i: downloading kubectl..."
-          sudo curl -s -L -o /usr/local/bin/kubectl "https://dl.k8s.io/release/\${KUBECTL_VERSION}/bin/linux/amd64/kubectl"
-          sudo curl -s -L -o /tmp/kubectl.sha256 "https://dl.k8s.io/release/\${KUBECTL_VERSION}/bin/linux/amd64/kubectl.sha256"
-          if echo "\$(cat /tmp/kubectl.sha256) /usr/local/bin/kubectl" | sha256sum --check --status; then
-            echo 'Download passed checksum'
-            sudo chmod +x /usr/local/bin/kubectl
-            kubectl version --client --output=yaml
-            break
-          else
-            echo 'Checksum failed, retrying...'
-            sudo rm -f /usr/local/bin/kubectl /tmp/kubectl.sha256
-            sleep 5
-          fi
-        done
-    """
-}
-
 void prepareNode() {
     echo "=========================[ Cloning the sources ]========================="
     checkout(scm)
@@ -71,18 +47,16 @@ void prepareNode() {
     }
 
     echo "=========================[ Installing tools on the Jenkins executor ]========================="
+    def libraries = load('cloud/common/libraries.groovy').loadLibraries()
+    libraries.dependencies.install()
+    libraries.dependencies.installAzureCLI()
+    libraries.dependencies.installUv()
+    libraries.dependencies.syncPythonDeps()
+    libraries.azure.auth()
+
     sh """
-        sudo curl -fsSL https://github.com/mikefarah/yq/releases/download/v4.44.1/yq_linux_amd64 -o /usr/local/bin/yq && sudo chmod +x /usr/local/bin/yq
-        sudo curl -fsSL https://github.com/jqlang/jq/releases/download/jq-1.7.1/jq-linux64 -o /usr/local/bin/jq && sudo chmod +x /usr/local/bin/jq
-    """
-    downloadKubectl()
-    sh """
-        curl -fsSL https://get.helm.sh/helm-v3.20.0-linux-amd64.tar.gz | sudo tar -C /usr/local/bin --strip-components 1 -xzf - linux-amd64/helm
         sudo curl -sLo /usr/local/bin/minikube https://storage.googleapis.com/minikube/releases/latest/minikube-linux-amd64 && sudo chmod +x /usr/local/bin/minikube
     """
-
-    installAzureCLI()
-    azureAuth()
 
     if ("$IMAGE_MONGOD") {
         cw = ("$CLUSTER_WIDE" == "YES") ? "CW" : "NON-CW"
@@ -192,24 +166,37 @@ void runTest(Integer TEST_ID) {
             echo "The $testName test was started !"
             tests[TEST_ID]["result"] = "failure"
 
-            sh """
-                cd source
+            timeout(time: 90, unit: 'MINUTES') {
+                def testsLib = load('cloud/common/vars/tests.groovy')
+                def testVars = testsLib.buildPsmdbTestVariables(
+                    cluster_name: 'minikube',
+                    skip_kubeconfig: true,
+                    debug_tests: DEBUG_TESTS,
+                    cluster_wide: CLUSTER_WIDE,
+                    default_operator_image: "perconalab/percona-server-mongodb-operator:${GIT_BRANCH}",
+                    images: [
+                        IMAGE_OPERATOR    : IMAGE_OPERATOR,
+                        IMAGE_MONGOD      : IMAGE_MONGOD,
+                        IMAGE_BACKUP      : IMAGE_BACKUP,
+                        IMAGE_PMM_CLIENT  : IMAGE_PMM_CLIENT,
+                        IMAGE_PMM_SERVER  : IMAGE_PMM_SERVER,
+                        IMAGE_PMM3_CLIENT : IMAGE_PMM3_CLIENT,
+                        IMAGE_PMM3_SERVER : IMAGE_PMM3_SERVER,
+                        IMAGE_LOGCOLLECTOR: IMAGE_LOGCOLLECTOR,
+                        IMAGE_SEARCH      : IMAGE_SEARCH
+                    ]
+                )
+                def exports = testsLib.getExportedVariablesForTests(testVars, 'cluster1')
+                def testCmd = testsLib.defineTestCommand(testVars, testName)
+                sh """
+                    cd source
 
-                [[ "$DEBUG_TESTS" == "YES" ]] && export DEBUG_TESTS=1
-                [[ "$CLUSTER_WIDE" == "YES" ]] && export OPERATOR_NS=psmdb-operator
-                [[ "$IMAGE_OPERATOR" ]] && export IMAGE=$IMAGE_OPERATOR || export IMAGE=perconalab/percona-server-mongodb-operator:$GIT_BRANCH
-                export IMAGE_MONGOD=$IMAGE_MONGOD
-                export IMAGE_BACKUP=$IMAGE_BACKUP
-                export IMAGE_PMM_CLIENT=$IMAGE_PMM_CLIENT
-                export IMAGE_PMM_SERVER=$IMAGE_PMM_SERVER
-                export IMAGE_PMM3_CLIENT=$IMAGE_PMM3_CLIENT
-                export IMAGE_PMM3_SERVER=$IMAGE_PMM3_SERVER
-                export IMAGE_LOGCOLLECTOR=$IMAGE_LOGCOLLECTOR
-                export IMAGE_SEARCH=$IMAGE_SEARCH
+                    ${exports}
 
-                sudo rm -rf /tmp/hostpath-provisioner/*
-                e2e-tests/$testName/run
-            """
+                    sudo rm -rf /tmp/hostpath-provisioner/*
+                    ${testCmd}
+                """
+            }
             pushArtifactFile("$GIT_BRANCH-$GIT_SHORT_COMMIT-$testName-$PLATFORM_VER-$DB_TAG-CW_$CLUSTER_WIDE-$PARAMS_HASH")
             tests[TEST_ID]["result"] = "passed"
             return true
@@ -272,39 +259,6 @@ PLATFORM_VER=$PLATFORM_VER"""
     addSummary(icon: 'symbol-aperture-outline plugin-ionicons-api',
         text: "<pre>${pipelineParameters}</pre>"
     )
-}
-
-void azureAuth() {
-    withCredentials([azureServicePrincipal('PERCONA-OPERATORS-SP')]) {
-        sh '''
-            az login --service-principal -u "$AZURE_CLIENT_ID" -p "$AZURE_CLIENT_SECRET" -t "$AZURE_TENANT_ID"  --allow-no-subscriptions
-            az account set -s "$AZURE_SUBSCRIPTION_ID"
-        '''
-    }
-}
-
-void installAzureCLI() {
-    sh """
-        if ! command -v az &>/dev/null; then
-            if [ "\$JENKINS_AGENT" = "AWS" ]; then
-                curl -s -L https://azurecliprod.blob.core.windows.net/install.py -o install.py
-                printf "/usr/azure-cli\\n/usr/bin" | sudo python3 install.py
-                sudo /usr/azure-cli/bin/python -m pip install "urllib3<2.0.0" > /dev/null
-            else
-                echo "Installing Azure CLI for Hetzner instances..."
-                sudo rpm --import https://packages.microsoft.com/keys/microsoft.asc
-                cat <<EOF | sudo tee /etc/yum.repos.d/azure-cli.repo
-[azure-cli]
-name=Azure CLI
-baseurl=https://packages.microsoft.com/yumrepos/azure-cli
-enabled=1
-gpgcheck=1
-gpgkey=https://packages.microsoft.com/keys/microsoft.asc
-EOF
-                sudo dnf install azure-cli -y
-            fi
-        fi
-    """
 }
 
 pipeline {

--- a/cloud/jenkins/psmdbo_openshift.groovy
+++ b/cloud/jenkins/psmdbo_openshift.groovy
@@ -18,17 +18,13 @@ String getParam(String paramName, String keyName = null) {
 }
 
 void prepareNode() {
-    echo "=========================[ Cloning the sources ]========================="
     checkout(scm)
-    sh """
-        # sudo is needed for better node recovery after compilation failure
-        # if building failed on compilation stage directory will have files owned by docker user
-        sudo git config --global --add safe.directory '*'
-        sudo git reset --hard
-        sudo git clean -xdf
-        sudo rm -rf source
-        git clone -b $GIT_BRANCH https://github.com/percona/percona-server-mongodb-operator source
-    """
+    def libraries = load('cloud/common/libraries.groovy').loadLibraries()
+    libraries.tools.gitResetWorkspace()
+    libraries.tools.gitClone(
+        branch: GIT_BRANCH,
+        repo: 'https://github.com/percona/percona-server-mongodb-operator'
+    )
 
     if ("$PILLAR_VERSION" != "none") {
         echo "=========================[ Getting parameters for release test ]========================="
@@ -53,7 +49,6 @@ void prepareNode() {
     }
  
     echo "=========================[ Installing tools on the Jenkins executor ]========================="
-    def libraries = load('cloud/common/libraries.groovy').loadLibraries()
     libraries.dependencies.install()
     libraries.dependencies.installGoogleCLI()
     libraries.dependencies.installAzureCLI()
@@ -394,49 +389,34 @@ void pushArtifactFile(String FILE_NAME) {
 }
 
 void makeReport() {
-    echo "=========================[ Generating Parameters Report ]========================="
-    def pipelineParameters = """
-testsuite name=$JOB_NAME
-IMAGE_OPERATOR=${IMAGE_OPERATOR ?: 'e2e_defaults'}
-IMAGE_MONGOD=${IMAGE_MONGOD ?: 'e2e_defaults'}
-IMAGE_BACKUP=${IMAGE_BACKUP ?: 'e2e_defaults'}
-IMAGE_PMM_CLIENT=${IMAGE_PMM_CLIENT ?: 'e2e_defaults'}
-IMAGE_PMM_SERVER=${IMAGE_PMM_SERVER ?: 'e2e_defaults'}
-IMAGE_PMM3_CLIENT=${IMAGE_PMM3_CLIENT ?: 'e2e_defaults'}
-IMAGE_PMM3_SERVER=${IMAGE_PMM3_SERVER ?: 'e2e_defaults'}
-IMAGE_LOGCOLLECTOR=${IMAGE_LOGCOLLECTOR ?: 'e2e_defaults'}
-IMAGE_SEARCH=${IMAGE_SEARCH ?: 'e2e_defaults'}
-PLATFORM_VER=$PLATFORM_VER"""
-
-    def testsLib = load('cloud/common/vars/tests.groovy')
-    testsLib.writePipelineParameters(pipelineParameters)
-    testsLib.publishPytestReports(
-        tests         : tests,
-        gitShortCommit: GIT_SHORT_COMMIT,
-        gitBranch     : GIT_BRANCH,
-        title         : "PSMDB e2e tests - ${GIT_BRANCH} (${GIT_SHORT_COMMIT})"
-    )
+    def libraries = load('cloud/common/libraries.groovy').loadLibraries()
+    libraries.tests.makeReport(tests, [
+        job_name         : JOB_NAME,
+        git_branch       : GIT_BRANCH,
+        git_short_commit : GIT_SHORT_COMMIT,
+        platform_version : PLATFORM_VER,
+        cluster_wide     : CLUSTER_WIDE,
+        images: [
+            IMAGE_OPERATOR    : IMAGE_OPERATOR,
+            IMAGE_MONGOD      : IMAGE_MONGOD,
+            IMAGE_BACKUP      : IMAGE_BACKUP,
+            IMAGE_PMM_CLIENT  : IMAGE_PMM_CLIENT,
+            IMAGE_PMM_SERVER  : IMAGE_PMM_SERVER,
+            IMAGE_PMM3_CLIENT : IMAGE_PMM3_CLIENT,
+            IMAGE_PMM3_SERVER : IMAGE_PMM3_SERVER,
+            IMAGE_LOGCOLLECTOR: IMAGE_LOGCOLLECTOR,
+            IMAGE_SEARCH      : IMAGE_SEARCH
+        ]
+    ])
 }
 
 void shutdownCluster(String CLUSTER_SUFFIX) {
     timeout(time: 30, unit: 'MINUTES') {
         withCredentials([aws(credentialsId: 'openshift-cicd', accessKeyVariable: 'AWS_ACCESS_KEY_ID'), file(credentialsId: 'aws-openshift-41-key-pub', variable: 'AWS_NODES_KEY_PUB'), file(credentialsId: 'openshift-secret-file', variable: 'OPENSHIFT-CONF-FILE')]) {
             sshagent(['aws-openshift-41-key']) {
+                def libraries = load('cloud/common/libraries.groovy').loadLibraries()
+                libraries.tools.kubernetesCleanupCluster("${WORKSPACE}/openshift/${CLUSTER_SUFFIX}/auth/kubeconfig")
                 sh """
-                    export KUBECONFIG=$WORKSPACE/openshift/$CLUSTER_SUFFIX/auth/kubeconfig
-                    if [ -s "\$KUBECONFIG" ] && kubectl get --raw='/healthz' --request-timeout=5s >/dev/null 2>&1; then
-                        for namespace in \$(kubectl get namespaces --request-timeout=5s --no-headers | awk '{print \$1}' | grep -vE "^kube-|^openshift" | sed '/-operator/ s/^/1-/' | sort | sed 's/^1-//'); do
-                            kubectl delete deployments --all -n \$namespace --force --grace-period=0 --request-timeout=10s || true
-                            kubectl delete sts --all -n \$namespace --force --grace-period=0 --request-timeout=10s || true
-                            kubectl delete replicasets --all -n \$namespace --force --grace-period=0 --request-timeout=10s || true
-                            kubectl delete poddisruptionbudget --all -n \$namespace --force --grace-period=0 --request-timeout=10s || true
-                            kubectl delete services --all -n \$namespace --force --grace-period=0 --request-timeout=10s || true
-                            kubectl delete pods --all -n \$namespace --force --grace-period=0 --request-timeout=10s || true
-                        done
-                    else
-                        echo "Skipping namespace cleanup: Kubernetes API is not reachable for $CLUSTER_NAME-$CLUSTER_SUFFIX"
-                    fi
-
                     /usr/local/bin/openshift-install destroy cluster --dir=openshift/$CLUSTER_SUFFIX || true
                 """
             }
@@ -535,11 +515,11 @@ pipeline {
                 }
 
                 clusters.each { shutdownCluster(it) }
+
+                def libraries = load('cloud/common/libraries.groovy').loadLibraries()
+                libraries.tools.dockerCleanupVolumes()
             }
 
-            sh """
-                sudo docker system prune --volumes -af
-            """
             deleteDir()
         }
     }

--- a/cloud/jenkins/psmdbo_openshift.groovy
+++ b/cloud/jenkins/psmdbo_openshift.groovy
@@ -67,6 +67,7 @@ void prepareNode() {
     IMAGE_PMM3_SERVER = testVariables.images.IMAGE_PMM3_SERVER
     IMAGE_LOGCOLLECTOR = testVariables.images.IMAGE_LOGCOLLECTOR
     IMAGE_SEARCH = testVariables.images.IMAGE_SEARCH
+    DB_TAG = testVariables.db_tag
     GIT_SHORT_COMMIT = testVariables.git_short_commit
     CLUSTER_NAME = "psmdbo-${GIT_SHORT_COMMIT.take(6)}".toLowerCase()
     env.CLUSTER_NAME = CLUSTER_NAME

--- a/cloud/jenkins/psmdbo_openshift.groovy
+++ b/cloud/jenkins/psmdbo_openshift.groovy
@@ -17,30 +17,6 @@ String getParam(String paramName, String keyName = null) {
     return param
 }
 
-void downloadKubectl() {
-    sh """
-        KUBECTL_VERSION="\$(curl -L -s https://api.github.com/repos/kubernetes/kubernetes/releases/latest | jq -r .tag_name)"
-        for i in {1..5}; do
-          if [ -f /usr/local/bin/kubectl ]; then
-              break
-          fi
-          echo "Attempt \$i: downloading kubectl..."
-          sudo curl -s -L -o /usr/local/bin/kubectl "https://dl.k8s.io/release/\${KUBECTL_VERSION}/bin/linux/amd64/kubectl"
-          sudo curl -s -L -o /tmp/kubectl.sha256 "https://dl.k8s.io/release/\${KUBECTL_VERSION}/bin/linux/amd64/kubectl.sha256"
-          if echo "\$(cat /tmp/kubectl.sha256) /usr/local/bin/kubectl" | sha256sum --check --status; then
-            echo 'Download passed checksum'
-            sudo chmod +x /usr/local/bin/kubectl
-            kubectl version --client --output=yaml
-            break
-          else
-            echo 'Checksum failed, retrying...'
-            sudo rm -f /usr/local/bin/kubectl /tmp/kubectl.sha256
-            sleep 5
-          fi
-        done
-    """
-}
-
 void prepareNode() {
     echo "=========================[ Cloning the sources ]========================="
     checkout(scm)
@@ -77,38 +53,18 @@ void prepareNode() {
     }
  
     echo "=========================[ Installing tools on the Jenkins executor ]========================="
-    sh """
-        sudo curl -fsSL https://github.com/mikefarah/yq/releases/download/v4.44.1/yq_linux_amd64 -o /usr/local/bin/yq && sudo chmod +x /usr/local/bin/yq
-        sudo curl -fsSL https://github.com/jqlang/jq/releases/download/jq-1.7.1/jq-linux64 -o /usr/local/bin/jq && sudo chmod +x /usr/local/bin/jq
-    """
-    downloadKubectl()
-    sh """
-        curl -fsSL https://get.helm.sh/helm-v3.20.0-linux-amd64.tar.gz | sudo tar -C /usr/local/bin --strip-components 1 -xzf - linux-amd64/helm
+    def libraries = load('cloud/common/libraries.groovy').loadLibraries()
+    libraries.dependencies.install()
+    libraries.dependencies.installGoogleCLI()
+    libraries.dependencies.installAzureCLI()
+    libraries.dependencies.installUv()
+    libraries.dependencies.syncPythonDeps()
+    libraries.azure.auth()
 
+    sh """
         curl -s -L https://mirror.openshift.com/pub/openshift-v4/clients/ocp/$PLATFORM_VER/openshift-client-linux.tar.gz | sudo tar -C /usr/local/bin -xzf - oc
         curl -s -L https://mirror.openshift.com/pub/openshift-v4/clients/ocp/$PLATFORM_VER/openshift-install-linux.tar.gz | sudo tar -C /usr/local/bin -xzf - openshift-install
     """
-
-    sh '''
-        if ! command -v gsutil &>/dev/null; then
-            echo "gsutil not found, installing google-cloud-cli..."
-            sudo tee /etc/yum.repos.d/google-cloud-sdk.repo << EOF
-[google-cloud-cli]
-name=Google Cloud CLI
-baseurl=https://packages.cloud.google.com/yum/repos/cloud-sdk-el7-x86_64
-enabled=1
-gpgcheck=1
-repo_gpgcheck=0
-gpgkey=https://packages.cloud.google.com/yum/doc/rpm-package-key.gpg
-EOF
-            sudo yum install -y google-cloud-cli
-        fi
-        command -v gsutil
-        gsutil version -l | head -n1
-    '''
-
-    installAzureCLI()
-    azureAuth()
 
     if ("$IMAGE_MONGOD") {
         cw = ("$CLUSTER_WIDE" == "YES") ? "CW" : "NON-CW"
@@ -278,7 +234,7 @@ void createCluster(String CLUSTER_SUFFIX) {
     clusters.add("$CLUSTER_SUFFIX")
 
     timeout(time: 60, unit: 'MINUTES') {
-        withCredentials([[$class: 'AmazonWebServicesCredentialsBinding', accessKeyVariable: 'AWS_ACCESS_KEY_ID', credentialsId: 'openshift-cicd'], file(credentialsId: 'aws-openshift-41-key-pub', variable: 'AWS_NODES_KEY_PUB'), file(credentialsId: 'openshift4-secrets', variable: 'OPENSHIFT_CONF_FILE'), usernamePassword(credentialsId: 'docker.io', passwordVariable: 'DOCKER_READ_PASS', usernameVariable: 'DOCKER_READ_USER')]) {
+        withCredentials([aws(credentialsId: 'openshift-cicd', accessKeyVariable: 'AWS_ACCESS_KEY_ID', secretKeyVariable: 'AWS_SECRET_ACCESS_KEY'), file(credentialsId: 'aws-openshift-41-key-pub', variable: 'AWS_NODES_KEY_PUB'), file(credentialsId: 'openshift4-secrets', variable: 'OPENSHIFT_CONF_FILE'), usernamePassword(credentialsId: 'docker.io', passwordVariable: 'DOCKER_READ_PASS', usernameVariable: 'DOCKER_READ_USER')]) {
             withEnv(["CLUSTER_SUFFIX=${CLUSTER_SUFFIX}", "CLUSTER_NAME=${CLUSTER_NAME}"]) {
                 sh """
                     mkdir -p openshift/\$CLUSTER_SUFFIX
@@ -362,25 +318,35 @@ void runTest(Integer TEST_ID) {
             tests[TEST_ID]["result"] = "failure"
 
             timeout(time: 90, unit: 'MINUTES') {
+                def testsLib = load('cloud/common/vars/tests.groovy')
+                def testVars = testsLib.buildPsmdbTestVariables(
+                    cluster_name: CLUSTER_NAME,
+                    kubeconfig: "$WORKSPACE/openshift/${clusterSuffix}/auth/kubeconfig",
+                    debug_tests: DEBUG_TESTS,
+                    cluster_wide: CLUSTER_WIDE,
+                    default_operator_image: "perconalab/percona-server-mongodb-operator:${GIT_BRANCH}",
+                    images: [
+                        IMAGE_OPERATOR    : IMAGE_OPERATOR,
+                        IMAGE_MONGOD      : IMAGE_MONGOD,
+                        IMAGE_BACKUP      : IMAGE_BACKUP,
+                        IMAGE_PMM_CLIENT  : IMAGE_PMM_CLIENT,
+                        IMAGE_PMM_SERVER  : IMAGE_PMM_SERVER,
+                        IMAGE_PMM3_CLIENT : IMAGE_PMM3_CLIENT,
+                        IMAGE_PMM3_SERVER : IMAGE_PMM3_SERVER,
+                        IMAGE_LOGCOLLECTOR: IMAGE_LOGCOLLECTOR,
+                        IMAGE_SEARCH      : IMAGE_SEARCH
+                    ]
+                )
+                def exports = testsLib.getExportedVariablesForTests(testVars, clusterSuffix)
+                def testCmd = testsLib.defineTestCommand(testVars, testName)
                 sh """
                     cd source
 
-                    [[ "$DEBUG_TESTS" == "YES" ]] && export DEBUG_TESTS=1
-                    [[ "$CLUSTER_WIDE" == "YES" ]] && export OPERATOR_NS=psmdb-operator
-                    [[ "$IMAGE_OPERATOR" ]] && export IMAGE=$IMAGE_OPERATOR || export IMAGE=perconalab/percona-server-mongodb-operator:$GIT_BRANCH
-                    export IMAGE_MONGOD=$IMAGE_MONGOD
-                    export IMAGE_BACKUP=$IMAGE_BACKUP
-                    export IMAGE_PMM_CLIENT=$IMAGE_PMM_CLIENT
-                    export IMAGE_PMM_SERVER=$IMAGE_PMM_SERVER
-                    export IMAGE_PMM3_CLIENT=$IMAGE_PMM3_CLIENT
-                    export IMAGE_PMM3_SERVER=$IMAGE_PMM3_SERVER
-                    export IMAGE_LOGCOLLECTOR=$IMAGE_LOGCOLLECTOR
-                    export IMAGE_SEARCH=$IMAGE_SEARCH
-                    export KUBECONFIG=$WORKSPACE/openshift/$clusterSuffix/auth/kubeconfig
+                    ${exports}
 
                     oc whoami
 
-                    e2e-tests/$testName/run
+                    ${testCmd}
                 """
             }
             pushArtifactFile("$GIT_BRANCH-$GIT_SHORT_COMMIT-$testName-$PLATFORM_VER-$DB_TAG-CW_$CLUSTER_WIDE-$PARAMS_HASH")
@@ -471,39 +437,6 @@ void shutdownCluster(String CLUSTER_SUFFIX) {
             }
         }
     }
-}
-
-void azureAuth() {
-    withCredentials([azureServicePrincipal('PERCONA-OPERATORS-SP')]) {
-        sh '''
-            az login --service-principal -u "$AZURE_CLIENT_ID" -p "$AZURE_CLIENT_SECRET" -t "$AZURE_TENANT_ID"  --allow-no-subscriptions
-            az account set -s "$AZURE_SUBSCRIPTION_ID"
-        '''
-    }
-}
-
-void installAzureCLI() {
-    sh """
-        if ! command -v az &>/dev/null; then
-            if [ "\$JENKINS_AGENT" = "AWS" ]; then
-                curl -s -L https://azurecliprod.blob.core.windows.net/install.py -o install.py
-                printf "/usr/azure-cli\\n/usr/bin" | sudo python3 install.py
-                sudo /usr/azure-cli/bin/python -m pip install "urllib3<2.0.0" > /dev/null
-            else
-                echo "Installing Azure CLI for Hetzner instances..."
-                sudo rpm --import https://packages.microsoft.com/keys/microsoft.asc
-                cat <<EOF | sudo tee /etc/yum.repos.d/azure-cli.repo
-[azure-cli]
-name=Azure CLI
-baseurl=https://packages.microsoft.com/yumrepos/azure-cli
-enabled=1
-gpgcheck=1
-gpgkey=https://packages.microsoft.com/keys/microsoft.asc
-EOF
-                sudo dnf install azure-cli -y
-            fi
-        fi
-    """
 }
 
 pipeline {

--- a/cloud/jenkins/psmdbo_openshift.groovy
+++ b/cloud/jenkins/psmdbo_openshift.groovy
@@ -313,12 +313,12 @@ void runTest(Integer TEST_ID) {
 
     waitUntil {
         def timeStart = new Date().getTime()
+        def testsLib = load('cloud/common/vars/tests.groovy')
         try {
             echo "The $testName test was started on cluster $CLUSTER_NAME-$clusterSuffix !"
             tests[TEST_ID]["result"] = "failure"
 
             timeout(time: 90, unit: 'MINUTES') {
-                def testsLib = load('cloud/common/vars/tests.groovy')
                 def testVars = testsLib.buildPsmdbTestVariables(
                     cluster_name: CLUSTER_NAME,
                     kubeconfig: "$WORKSPACE/openshift/${clusterSuffix}/auth/kubeconfig",
@@ -346,7 +346,12 @@ void runTest(Integer TEST_ID) {
 
                     oc whoami
 
-                    ${testCmd}
+                    mkdir -p e2e-tests/logs e2e-tests/reports
+                    bash -o pipefail <<BASH
+                    {
+                        ${testCmd}
+                    } 2>&1 | tee e2e-tests/logs/${testName}.log
+BASH
                 """
             }
             pushArtifactFile("$GIT_BRANCH-$GIT_SHORT_COMMIT-$testName-$PLATFORM_VER-$DB_TAG-CW_$CLUSTER_WIDE-$PARAMS_HASH")
@@ -365,6 +370,11 @@ void runTest(Integer TEST_ID) {
             def timeStop = new Date().getTime()
             def durationSec = (timeStop - timeStart) / 1000
             tests[TEST_ID]["time"] = durationSec
+            try {
+                testsLib.pushLogFile(testName, [gitShortCommit: GIT_SHORT_COMMIT])
+            } catch (logErr) {
+                echo "Warning: failed to push log for $testName: ${logErr}"
+            }
             echo "The $testName test was finished!"
         }
     }
@@ -384,15 +394,8 @@ void pushArtifactFile(String FILE_NAME) {
 }
 
 void makeReport() {
-    echo "=========================[ Generating Test Report ]========================="
-    testsReport = "<testsuite name=\"$JOB_NAME\">\n"
-    for (int i = 0; i < tests.size(); i ++) {
-        testsReport += '<testcase name="' + tests[i]["name"] + '" time="' + tests[i]["time"] + '"><'+ tests[i]["result"] +'/></testcase>\n'
-    }
-    testsReport += '</testsuite>\n'
-
     echo "=========================[ Generating Parameters Report ]========================="
-    pipelineParameters = """
+    def pipelineParameters = """
 testsuite name=$JOB_NAME
 IMAGE_OPERATOR=${IMAGE_OPERATOR ?: 'e2e_defaults'}
 IMAGE_MONGOD=${IMAGE_MONGOD ?: 'e2e_defaults'}
@@ -405,11 +408,13 @@ IMAGE_LOGCOLLECTOR=${IMAGE_LOGCOLLECTOR ?: 'e2e_defaults'}
 IMAGE_SEARCH=${IMAGE_SEARCH ?: 'e2e_defaults'}
 PLATFORM_VER=$PLATFORM_VER"""
 
-    writeFile file: "TestsReport.xml", text: testsReport
-    writeFile file: 'PipelineParameters.txt', text: pipelineParameters
-
-    addSummary(icon: 'symbol-aperture-outline plugin-ionicons-api',
-        text: "<pre>${pipelineParameters}</pre>"
+    def testsLib = load('cloud/common/vars/tests.groovy')
+    testsLib.writePipelineParameters(pipelineParameters)
+    testsLib.publishPytestReports(
+        tests         : tests,
+        gitShortCommit: GIT_SHORT_COMMIT,
+        gitBranch     : GIT_BRANCH,
+        title         : "PSMDB e2e tests - ${GIT_BRANCH} (${GIT_SHORT_COMMIT})"
     )
 }
 
@@ -512,8 +517,6 @@ pipeline {
         always {
             echo "CLUSTER ASSIGNMENTS\n" + tests.toString().replace("], ","]\n").replace("]]","]").replaceFirst("\\[","")
             makeReport()
-            junit testResults: '*.xml', healthScaleFactor: 1.0
-            archiveArtifacts '*.xml,*.txt'
 
             script {
                 try {

--- a/cloud/jenkins/psmdbo_openshift.groovy
+++ b/cloud/jenkins/psmdbo_openshift.groovy
@@ -4,18 +4,7 @@ import groovy.transform.Field
 @Field def tests = []
 @Field def clusters = []
 @Field def release_versions = "source/e2e-tests/release_versions"
-
-String getParam(String paramName, String keyName = null) {
-    keyName = keyName ?: paramName
-
-    def param = sh(script: "grep -iE '^\\s*$keyName=' $release_versions | cut -d = -f 2 | tr -d \'\"\'| tail -1", returnStdout: true).trim()
-    if ("$param") {
-        echo "$paramName=$param (from params file)"
-    } else {
-        error("$keyName not found in params file $release_versions")
-    }
-    return param
-}
+@Field Map testVariables = [:]
 
 void prepareNode() {
     checkout(scm)
@@ -26,28 +15,6 @@ void prepareNode() {
         repo: 'https://github.com/percona/percona-server-mongodb-operator'
     )
 
-    if ("$PILLAR_VERSION" != "none") {
-        echo "=========================[ Getting parameters for release test ]========================="
-        IMAGE_OPERATOR = IMAGE_OPERATOR ?: getParam("IMAGE_OPERATOR")
-        IMAGE_MONGOD = IMAGE_MONGOD ?: getParam("IMAGE_MONGOD", "IMAGE_MONGOD${PILLAR_VERSION}")
-        IMAGE_BACKUP = IMAGE_BACKUP ?: getParam("IMAGE_BACKUP")
-        IMAGE_PMM_CLIENT = IMAGE_PMM_CLIENT ?: getParam("IMAGE_PMM_CLIENT")
-        IMAGE_PMM_SERVER = IMAGE_PMM_SERVER ?: getParam("IMAGE_PMM_SERVER")
-        IMAGE_PMM3_CLIENT = IMAGE_PMM3_CLIENT ?: getParam("IMAGE_PMM3_CLIENT")
-        IMAGE_PMM3_SERVER = IMAGE_PMM3_SERVER ?: getParam("IMAGE_PMM3_SERVER")
-        IMAGE_LOGCOLLECTOR = IMAGE_LOGCOLLECTOR ?: getParam("IMAGE_LOGCOLLECTOR")
-        IMAGE_SEARCH = IMAGE_SEARCH ?: getParam("IMAGE_SEARCH")
-        if ("$PLATFORM_VER".toLowerCase() == "min" || "$PLATFORM_VER".toLowerCase() == "max") {
-            PLATFORM_VER = getParam("PLATFORM_VER", "OPENSHIFT_${PLATFORM_VER}")
-        }
-    } else {
-        echo "=========================[ Not a release run. Using job params only! ]========================="
-    }
-
-    if ("$PLATFORM_VER" == "latest") {
-        PLATFORM_VER = sh(script: "curl -s https://mirror.openshift.com/pub/openshift-v4/x86_64/clients/ocp/$PLATFORM_VER/release.txt | sed -n 's/^\\s*Version:\\s\\+\\(\\S\\+\\)\\s*\$/\\1/p'", returnStdout: true).trim()
-    }
- 
     echo "=========================[ Installing tools on the Jenkins executor ]========================="
     libraries.dependencies.install()
     libraries.dependencies.installGoogleCLI()
@@ -55,6 +22,56 @@ void prepareNode() {
     libraries.dependencies.installUv()
     libraries.dependencies.syncPythonDeps()
     libraries.azure.auth()
+
+    def platformVersion = "$PLATFORM_VER"
+    if ("$PILLAR_VERSION" != "none" && (platformVersion.toLowerCase() in ["min", "max"])) {
+        platformVersion = libraries.tests.getReleaseVersionsParam(release_versions, "PLATFORM_VER", "OPENSHIFT_${platformVersion.toUpperCase()}")
+    }
+
+    testVariables = libraries.tests.prepareVersions([
+        libraries             : libraries,
+        release_versions      : release_versions,
+        operator              : 'psmdb-operator',
+        platform              : 'openshift',
+        platform_provider     : 'openshift',
+        platform_version      : platformVersion,
+        region                : AWS_REGION,
+        cluster_wide          : CLUSTER_WIDE,
+        pillar_version        : PILLAR_VERSION,
+        git_branch            : GIT_BRANCH,
+        job_name              : JOB_NAME,
+        db_tag                : DB_TAG,
+        debug_tests           : DEBUG_TESTS,
+        test_executor_type    : 'make',
+        default_operator_image: "perconalab/percona-server-mongodb-operator:${GIT_BRANCH}",
+        images: [
+            IMAGE_OPERATOR    : IMAGE_OPERATOR,
+            IMAGE_MONGOD      : IMAGE_MONGOD,
+            IMAGE_BACKUP      : IMAGE_BACKUP,
+            IMAGE_PMM_CLIENT  : IMAGE_PMM_CLIENT,
+            IMAGE_PMM_SERVER  : IMAGE_PMM_SERVER,
+            IMAGE_PMM3_CLIENT : IMAGE_PMM3_CLIENT,
+            IMAGE_PMM3_SERVER : IMAGE_PMM3_SERVER,
+            IMAGE_LOGCOLLECTOR: IMAGE_LOGCOLLECTOR,
+            IMAGE_SEARCH      : IMAGE_SEARCH
+        ]
+    ])
+
+    PLATFORM_VER = testVariables.platform_version
+    IMAGE_OPERATOR = testVariables.images.IMAGE_OPERATOR
+    IMAGE_MONGOD = testVariables.images.IMAGE_MONGOD
+    IMAGE_BACKUP = testVariables.images.IMAGE_BACKUP
+    IMAGE_PMM_CLIENT = testVariables.images.IMAGE_PMM_CLIENT
+    IMAGE_PMM_SERVER = testVariables.images.IMAGE_PMM_SERVER
+    IMAGE_PMM3_CLIENT = testVariables.images.IMAGE_PMM3_CLIENT
+    IMAGE_PMM3_SERVER = testVariables.images.IMAGE_PMM3_SERVER
+    IMAGE_LOGCOLLECTOR = testVariables.images.IMAGE_LOGCOLLECTOR
+    IMAGE_SEARCH = testVariables.images.IMAGE_SEARCH
+    GIT_SHORT_COMMIT = testVariables.git_short_commit
+    CLUSTER_NAME = "psmdbo-${GIT_SHORT_COMMIT.take(6)}".toLowerCase()
+    env.CLUSTER_NAME = CLUSTER_NAME
+    testVariables.cluster_name = CLUSTER_NAME
+    PARAMS_HASH = testVariables.params_hash
 
     sh """
         curl -s -L https://mirror.openshift.com/pub/openshift-v4/clients/ocp/$PLATFORM_VER/openshift-client-linux.tar.gz | sudo tar -C /usr/local/bin -xzf - oc
@@ -65,32 +82,6 @@ void prepareNode() {
         cw = ("$CLUSTER_WIDE" == "YES") ? "CW" : "NON-CW"
         currentBuild.displayName = "#" + currentBuild.number + " $GIT_BRANCH"
         currentBuild.description = "$PLATFORM_VER " + "$IMAGE_MONGOD".split(":")[1] + " $cw"
-    }
-
-    GIT_SHORT_COMMIT = sh(script: 'git -C source rev-parse --short HEAD', returnStdout: true).trim()
-    CLUSTER_NAME = "psmdbo-${GIT_SHORT_COMMIT.take(6)}".toLowerCase()
-    env.CLUSTER_NAME = CLUSTER_NAME
-    PARAMS_HASH = sh(script: "echo $GIT_BRANCH-$GIT_SHORT_COMMIT-$PLATFORM_VER-$CLUSTER_WIDE-$IMAGE_OPERATOR-$IMAGE_MONGOD-$IMAGE_BACKUP-$IMAGE_PMM_CLIENT-$IMAGE_PMM_SERVER-$IMAGE_PMM3_CLIENT-$IMAGE_PMM3_SERVER-$IMAGE_LOGCOLLECTOR-$IMAGE_SEARCH | md5sum | cut -d' ' -f1", returnStdout: true).trim()
-}
-
-void dockerBuildPush() {
-    echo "=========================[ Building and Pushing the operator Docker image ]========================="
-    withCredentials([usernamePassword(credentialsId: 'hub.docker.com', passwordVariable: 'PASS', usernameVariable: 'USER')]) {
-        sh '''
-            if [[ "$IMAGE_OPERATOR" ]]; then
-                echo "SKIP: Build is not needed, operator image was set!"
-            else
-                cd source
-                sg docker -c '
-                    docker buildx create --use
-                    echo "$PASS" | docker login -u "$USER" --password-stdin
-                    export IMAGE=perconalab/percona-server-mongodb-operator:$GIT_BRANCH
-                    DOCKER_DEFAULT_PLATFORM=linux/amd64,linux/arm64 e2e-tests/build
-                    docker logout
-                '
-                sudo rm -rf build
-            fi
-        '''
     }
 }
 
@@ -173,132 +164,16 @@ void clusterRunner(String cluster) {
     }
 }
 
-void enableVolumeSnapshotResources(String CLUSTER_SUFFIX) {
-    sh """
-        export KUBECONFIG=$WORKSPACE/openshift/$CLUSTER_SUFFIX/auth/kubeconfig
-
-        for i in \$(seq 1 60); do
-            if kubectl get crd csisnapshotcontrollers.operator.openshift.io >/dev/null 2>&1; then
-                break
-            fi
-            sleep 10
-        done
-
-        cat <<EOF | kubectl apply -f -
-apiVersion: operator.openshift.io/v1
-kind: CSISnapshotController
-metadata:
-  name: cluster
-spec:
-  managementState: Managed
-EOF
-
-        kubectl get csisnapshotcontroller cluster -o yaml
-    """
-}
-
-void verifyVolumeSnapshotResources(String CLUSTER_SUFFIX) {
-    sh """
-        export KUBECONFIG=$WORKSPACE/openshift/$CLUSTER_SUFFIX/auth/kubeconfig
-
-        wait_for_deployment() {
-            local deployment_name="\$1"
-            local namespace="\$2"
-
-            for i in \$(seq 1 60); do
-                if kubectl get deployment "\$deployment_name" -n "\$namespace" >/dev/null 2>&1; then
-                    kubectl wait --for=condition=Available deployment/"\$deployment_name" -n "\$namespace" --timeout=10m
-                    return 0
-                fi
-                sleep 10
-            done
-
-            kubectl get deployment -n "\$namespace" || true
-            return 1
-        }
-
-        wait_for_deployment csi-snapshot-controller-operator openshift-cluster-storage-operator
-        wait_for_deployment csi-snapshot-controller openshift-cluster-storage-operator
-
-        kubectl get crd volumesnapshots.snapshot.storage.k8s.io volumesnapshotcontents.snapshot.storage.k8s.io volumesnapshotclasses.snapshot.storage.k8s.io
-        kubectl api-resources --api-group=snapshot.storage.k8s.io
-    """
-}
-
 void createCluster(String CLUSTER_SUFFIX) {
     clusters.add("$CLUSTER_SUFFIX")
 
-    timeout(time: 60, unit: 'MINUTES') {
-        withCredentials([aws(credentialsId: 'openshift-cicd', accessKeyVariable: 'AWS_ACCESS_KEY_ID', secretKeyVariable: 'AWS_SECRET_ACCESS_KEY'), file(credentialsId: 'aws-openshift-41-key-pub', variable: 'AWS_NODES_KEY_PUB'), file(credentialsId: 'openshift4-secrets', variable: 'OPENSHIFT_CONF_FILE'), usernamePassword(credentialsId: 'docker.io', passwordVariable: 'DOCKER_READ_PASS', usernameVariable: 'DOCKER_READ_USER')]) {
-            withEnv(["CLUSTER_SUFFIX=${CLUSTER_SUFFIX}", "CLUSTER_NAME=${CLUSTER_NAME}"]) {
-                sh """
-                    mkdir -p openshift/\$CLUSTER_SUFFIX
-                    timestamp="\$(date +%s)"
-tee openshift/\$CLUSTER_SUFFIX/install-config.yaml << EOF
-additionalTrustBundlePolicy: Proxyonly
-credentialsMode: Mint
-apiVersion: v1
-baseDomain: cd.percona.com
-compute:
-- architecture: amd64
-  hyperthreading: Enabled
-  name: worker
-  platform:
-    aws:
-      type: m5.xlarge
-  replicas: 3
-controlPlane:
-  architecture: amd64
-  hyperthreading: Enabled
-  name: master
-  platform: {}
-  replicas: 1
-metadata:
-  creationTimestamp: null
-  name: \$CLUSTER_NAME-\$CLUSTER_SUFFIX
-networking:
-  clusterNetwork:
-  - cidr: 10.128.0.0/14
-    hostPrefix: 23
-  machineNetwork:
-  - cidr: 10.0.0.0/16
-  networkType: OVNKubernetes
-  serviceNetwork:
-  - 172.30.0.0/16
-platform:
-  aws:
-    region: ${AWS_REGION}
-    userTags:
-      iit-billing-tag: openshift
-      delete-cluster-after-hours: 7
-      team: cloud
-      product: psmdb-operator
-      creation-time: \$timestamp
-
-publish: External
-EOF
-                    cat $OPENSHIFT_CONF_FILE >> openshift/\$CLUSTER_SUFFIX/install-config.yaml
-                """
-                sshagent(['aws-openshift-41-key']) {
-                    sh '''
-                        /usr/local/bin/openshift-install create cluster --dir=openshift/$CLUSTER_SUFFIX --log-level=debug || {
-                            /usr/local/bin/openshift-install gather bootstrap --dir=openshift/$CLUSTER_SUFFIX || true
-                            exit 1
-                        }
-                        export KUBECONFIG=openshift/$CLUSTER_SUFFIX/auth/kubeconfig
-                        TMP=$(mktemp)
-                        oc get secret/pull-secret -n openshift-config --template='{{index .data ".dockerconfigjson" | base64decode}}' > $TMP
-                        oc registry login --registry='docker.io' --auth-basic="$DOCKER_READ_USER:$DOCKER_READ_PASS" --to=$TMP
-                        oc set data secret/pull-secret -n openshift-config --from-file=.dockerconfigjson=$TMP
-                        rm -rf $TMP
-                    '''
-                }
-            }
-        }
-    }
-
-    enableVolumeSnapshotResources(CLUSTER_SUFFIX)
-    verifyVolumeSnapshotResources(CLUSTER_SUFFIX)
+    def libraries = load('cloud/common/libraries.groovy').loadLibraries()
+    libraries.openshift.createCluster([
+        clusterName  : CLUSTER_NAME,
+        clusterSuffix: CLUSTER_SUFFIX,
+        region       : AWS_REGION,
+        product      : 'psmdb-operator'
+    ])
 }
 
 void runTest(Integer TEST_ID) {
@@ -349,7 +224,7 @@ void runTest(Integer TEST_ID) {
 BASH
                 """
             }
-            pushArtifactFile("$GIT_BRANCH-$GIT_SHORT_COMMIT-$testName-$PLATFORM_VER-$DB_TAG-CW_$CLUSTER_WIDE-$PARAMS_HASH")
+            testsLib.pushArtifactFile("$GIT_BRANCH-$GIT_SHORT_COMMIT-$testName-$PLATFORM_VER-$DB_TAG-CW_$CLUSTER_WIDE-$PARAMS_HASH", GIT_SHORT_COMMIT)
             tests[TEST_ID]["result"] = "passed"
             return true
         }
@@ -375,53 +250,12 @@ BASH
     }
 }
 
-void pushArtifactFile(String FILE_NAME) {
-    echo "Push $FILE_NAME file to S3!"
-
-    withCredentials([aws(credentialsId: 'AMI/OVF', accessKeyVariable: 'AWS_ACCESS_KEY_ID', secretKeyVariable: 'AWS_SECRET_ACCESS_KEY')]) {
-        sh """
-            touch $FILE_NAME
-            S3_PATH=s3://percona-jenkins-artifactory/\$JOB_NAME/$GIT_SHORT_COMMIT
-            aws s3 ls \$S3_PATH/$FILE_NAME || :
-            aws s3 cp --quiet $FILE_NAME \$S3_PATH/$FILE_NAME || :
-        """
-    }
-}
-
-void makeReport() {
-    def libraries = load('cloud/common/libraries.groovy').loadLibraries()
-    libraries.tests.makeReport(tests, [
-        job_name         : JOB_NAME,
-        git_branch       : GIT_BRANCH,
-        git_short_commit : GIT_SHORT_COMMIT,
-        platform_version : PLATFORM_VER,
-        cluster_wide     : CLUSTER_WIDE,
-        images: [
-            IMAGE_OPERATOR    : IMAGE_OPERATOR,
-            IMAGE_MONGOD      : IMAGE_MONGOD,
-            IMAGE_BACKUP      : IMAGE_BACKUP,
-            IMAGE_PMM_CLIENT  : IMAGE_PMM_CLIENT,
-            IMAGE_PMM_SERVER  : IMAGE_PMM_SERVER,
-            IMAGE_PMM3_CLIENT : IMAGE_PMM3_CLIENT,
-            IMAGE_PMM3_SERVER : IMAGE_PMM3_SERVER,
-            IMAGE_LOGCOLLECTOR: IMAGE_LOGCOLLECTOR,
-            IMAGE_SEARCH      : IMAGE_SEARCH
-        ]
-    ])
-}
-
 void shutdownCluster(String CLUSTER_SUFFIX) {
-    timeout(time: 30, unit: 'MINUTES') {
-        withCredentials([aws(credentialsId: 'openshift-cicd', accessKeyVariable: 'AWS_ACCESS_KEY_ID'), file(credentialsId: 'aws-openshift-41-key-pub', variable: 'AWS_NODES_KEY_PUB'), file(credentialsId: 'openshift-secret-file', variable: 'OPENSHIFT-CONF-FILE')]) {
-            sshagent(['aws-openshift-41-key']) {
-                def libraries = load('cloud/common/libraries.groovy').loadLibraries()
-                libraries.tools.kubernetesCleanupCluster("${WORKSPACE}/openshift/${CLUSTER_SUFFIX}/auth/kubeconfig")
-                sh """
-                    /usr/local/bin/openshift-install destroy cluster --dir=openshift/$CLUSTER_SUFFIX || true
-                """
-            }
-        }
-    }
+    def libraries = load('cloud/common/libraries.groovy').loadLibraries()
+    libraries.tools.kubernetesCleanupCluster("${WORKSPACE}/openshift/${CLUSTER_SUFFIX}/auth/kubeconfig")
+    libraries.openshift.shutdownCluster([
+        clusterSuffix: CLUSTER_SUFFIX
+    ])
 }
 
 pipeline {
@@ -468,7 +302,14 @@ pipeline {
         }
         stage('Docker Build and Push') {
             steps {
-                dockerBuildPush()
+                script {
+                    def libraries = load('cloud/common/libraries.groovy').loadLibraries()
+                    libraries.tools.dockerBuildAndPush(
+                        operatorImage: 'perconalab/percona-server-mongodb-operator',
+                        branch       : GIT_BRANCH,
+                        platform     : 'linux/amd64,linux/arm64'
+                    )
+                }
             }
         }
         stage('Init Tests') {
@@ -496,9 +337,11 @@ pipeline {
     post {
         always {
             echo "CLUSTER ASSIGNMENTS\n" + tests.toString().replace("], ","]\n").replace("]]","]").replaceFirst("\\[","")
-            makeReport()
 
             script {
+                def libraries = load('cloud/common/libraries.groovy').loadLibraries()
+                libraries.tests.makeReport(tests, testVariables)
+
                 try {
                     def sendJobSlack = load "cloud/common/sendJobSlackNotification.groovy"
                     sendJobSlack.call(
@@ -516,7 +359,6 @@ pipeline {
 
                 clusters.each { shutdownCluster(it) }
 
-                def libraries = load('cloud/common/libraries.groovy').loadLibraries()
                 libraries.tools.dockerCleanupVolumes()
             }
 

--- a/cloud/jenkins/psmdbo_rancher.groovy
+++ b/cloud/jenkins/psmdbo_rancher.groovy
@@ -235,8 +235,6 @@ pipeline {
                 libraries.tools.dockerCleanupVolumes()
             }
 
-            junit testResults: '*.xml', healthScaleFactor: 1.0, allowEmptyResults: true
-            archiveArtifacts artifacts: '*.xml,*.txt', allowEmptyArchive: true
             deleteDir()
         }
     }

--- a/cloud/jenkins/psmdbo_rancher.groovy
+++ b/cloud/jenkins/psmdbo_rancher.groovy
@@ -14,6 +14,7 @@ def getLibraries() {
 
 pipeline {
     environment {
+        CLEAN_NAMESPACE = 1
         DB_TAG = sh(
             script: '''[[ "$IMAGE_MONGOD" ]] && echo "$IMAGE_MONGOD" | awk -F':' '{print $2}' || echo main''',
             returnStdout: true
@@ -24,7 +25,7 @@ pipeline {
         choice(name: 'TEST_SUITE', choices: ['run-release.csv', 'run-distro.csv', 'run-backups.csv'], description: 'Choose test suite from file')
         text(name: 'TEST_LIST', defaultValue: '', description: 'List of tests to run separated by new line')
         choice(name: 'IGNORE_PREVIOUS_RUN', choices: ['NO', 'YES'], description: 'Ignore passed tests in previous run')
-        choice(name: 'PILLAR_VERSION', choices: ['none', '80', '70', '60'], description: 'Set to 60/70/80 for a release run. Release runs force PLATFORM_CHANNEL=stable and load images from source/e2e-tests/release_versions.')
+        choice(name: 'PILLAR_VERSION', choices: ['none', '80', '83', '70', '60'], description: 'Set to 60/70/80/83 for a release run. Release runs force PLATFORM_CHANNEL=stable and load images from source/e2e-tests/release_versions.')
         string(name: 'GIT_BRANCH', defaultValue: 'main', description: 'Tag/Branch')
         choice(name: 'PLATFORM_CHANNEL', choices: ['stable', 'latest', 'testing'], description: 'Used when PLATFORM_VERSION=latest. Release runs override this to stable.')
         string(name: 'PLATFORM_VERSION', defaultValue: 'latest', description:  'RKE2/Kubernetes version. Use latest to resolve from PLATFORM_CHANNEL, min to use RKE2_MIN from release_versions, max to use RKE2_MAX from release_versions, or pass an explicit version.')
@@ -33,15 +34,15 @@ pipeline {
         string(name: 'RANCHER_ZONE', defaultValue: 'us-central1-a', description: 'Google zone to schedule Rancher instances')
         choice(name: 'CLUSTER_WIDE', choices: ['YES', 'NO'], description: 'Run tests in cluster-wide mode')
 
-        string(name: 'IMAGE_OPERATOR', defaultValue: '', description: 'Example: perconalab/percona-server-mongodb-operator:main')
-        string(name: 'IMAGE_MONGOD', defaultValue: '', description: 'Example: perconalab/percona-server-mongodb-operator:main-mongod8.0')
-        string(name: 'IMAGE_BACKUP', defaultValue: '', description: 'Example: perconalab/percona-server-mongodb-operator:main-backup')
-        string(name: 'IMAGE_PMM_CLIENT', defaultValue: '', description: 'Example: perconalab/percona-server-mongodb-operator:main-pmm')
-        string(name: 'IMAGE_PMM_SERVER', defaultValue: '', description: 'Example: perconalab/percona-server-mongodb-operator:main-pmm-server')
-        string(name: 'IMAGE_PMM3_CLIENT', defaultValue: '', description: 'Example: perconalab/percona-server-mongodb-operator:main-pmm3')
-        string(name: 'IMAGE_PMM3_SERVER', defaultValue: '', description: 'Example: perconalab/percona-server-mongodb-operator:main-pmm3-server')
-        string(name: 'IMAGE_LOGCOLLECTOR', defaultValue: '', description: 'Example: perconalab/fluentbit:main-logcollector')
-        string(name: 'IMAGE_SEARCH', defaultValue: '', description: 'Example: perconalab/percona-server-mongodb-operator:main-mongot')
+        string(name: 'IMAGE_OPERATOR', defaultValue: '', description: 'ex: perconalab/percona-server-mongodb-operator:main')
+        string(name: 'IMAGE_MONGOD', defaultValue: '', description: 'ex: perconalab/percona-server-mongodb-operator:main-mongod8.0')
+        string(name: 'IMAGE_BACKUP', defaultValue: '', description: 'ex: perconalab/percona-server-mongodb-operator:main-backup')
+        string(name: 'IMAGE_PMM_CLIENT', defaultValue: '', description: 'ex: perconalab/pmm-client:dev-latest')
+        string(name: 'IMAGE_PMM_SERVER', defaultValue: '', description: 'ex: perconalab/pmm-server:dev-latest')
+        string(name: 'IMAGE_PMM3_CLIENT', defaultValue: '', description: 'ex: perconalab/pmm-client:3-dev-latest')
+        string(name: 'IMAGE_PMM3_SERVER', defaultValue: '', description: 'ex: perconalab/pmm-server:3-dev-latest')
+        string(name: 'IMAGE_LOGCOLLECTOR', defaultValue: '', description: 'ex: perconalab/fluentbit:main-logcollector')
+        string(name: 'IMAGE_SEARCH', defaultValue: '', description: 'ex: perconalab/percona-server-mongodb-operator:main-mongot')
 
         choice(name: 'DEBUG_TESTS', choices: ['NO', 'YES'], description: 'Enable debug mode for tests')
         choice(name: 'JENKINS_AGENT', choices: ['Hetzner', 'AWS'], description: 'Jenkins agent provider')
@@ -61,6 +62,7 @@ pipeline {
         skipDefaultCheckout()
         disableConcurrentBuilds()
         timeout(time: 6, unit: 'HOURS')
+        copyArtifactPermission('psmdb-operator-latest-scheduler');
     }
 
     stages {
@@ -85,6 +87,8 @@ pipeline {
                     libraries.dependencies.install()
                     libraries.dependencies.installGoogleCLI()
                     libraries.dependencies.installAzureCLI()
+                    libraries.dependencies.installUv()
+                    libraries.dependencies.syncPythonDeps()
 
                     libraries.gcloud.auth()
                     libraries.azure.auth()
@@ -129,7 +133,7 @@ pipeline {
                         job_name              : JOB_NAME,
                         db_tag                : DB_TAG,
                         debug_tests           : DEBUG_TESTS,
-                        test_executor_type    : 'shell',
+                        test_executor_type    : 'make',
 
                         default_operator_image: "perconalab/percona-server-mongodb-operator:${GIT_BRANCH}",
 

--- a/cloud/jenkins/psmdbo_rancher.groovy
+++ b/cloud/jenkins/psmdbo_rancher.groovy
@@ -101,7 +101,8 @@ pipeline {
                 script {
                     libraries.tools.dockerBuildAndPush(
                         operatorImage: 'perconalab/percona-server-mongodb-operator',
-                        branch: GIT_BRANCH
+                        branch: GIT_BRANCH,
+                        platform: 'linux/amd64,linux/arm64'
                     )
                 }
             }


### PR DESCRIPTION
- Switch PSMDB e2e runs to make e2e-test TEST=<name> via shared defineTestCommand (make executor)
- Install uv and run uv sync --locked before tests
- Route test env setup through buildPsmdbTestVariables / getExportedVariablesForTests
- Reuse shared dependencies / azure / gcloud helpers for tool install (latest yq/jq/helm/kubectl, gcloud, az)
- Keep only platform-specific installs local (eksctl, oc/openshift-install, minikube)
- Align rancher with others: CLEAN_NAMESPACE, copyArtifactPermission, PILLAR 83, image param examples
- Fix GKE missing IMAGE_SEARCH export; EKS PARAMS_HASH typo
- Bump GCloud yum repo to el9; fix installUv PATH check