### PR TITLE
PKG-1433: Bake PPG package-test snapshots on Hetzner (Rocky, Alma, OL)

### DIFF
--- a/.github/actions/setup-hcloud/action.yml
+++ b/.github/actions/setup-hcloud/action.yml
@@ -1,0 +1,29 @@
+# Local composite action: install the hcloud CLI at ONE pinned version,
+# checksum-verified against the release manifest. Single source of the pin for
+# its three call sites (factory bake + prune, janitor sweep). Referenced by
+# path (uses: ./.github/actions/setup-hcloud), so no SHA pin applies.
+name: setup-hcloud
+description: Install the hcloud CLI (pinned, checksum-verified)
+inputs:
+  version:
+    description: hcloud CLI release to install (bump deliberately)
+    required: false
+    default: '1.67.0'
+runs:
+  using: composite
+  steps:
+    - name: Install hcloud CLI (pinned, checksum-verified)
+      shell: bash
+      # The input reaches the script as an env var, not inline ${{ }}, so it is
+      # data to the shell and cannot break out of the run block.
+      env:
+        HCLOUD_CLI_VERSION: ${{ inputs.version }}
+      run: |
+        set -euo pipefail
+        cd "$(mktemp -d)"
+        curl -fsSLO "https://github.com/hetznercloud/cli/releases/download/v${HCLOUD_CLI_VERSION}/hcloud-linux-amd64.tar.gz"
+        curl -fsSLO "https://github.com/hetznercloud/cli/releases/download/v${HCLOUD_CLI_VERSION}/checksums.txt"
+        grep ' hcloud-linux-amd64.tar.gz$' checksums.txt | sha256sum -c -
+        tar -xzf hcloud-linux-amd64.tar.gz hcloud
+        sudo install -m 0755 hcloud /usr/local/bin/hcloud
+        hcloud version

--- a/.github/workflows/ppg-hcloud-factory.yml
+++ b/.github/workflows/ppg-hcloud-factory.yml
@@ -1,0 +1,249 @@
+# EL package-test snapshot factory (Hetzner Cloud): Rocky Linux, AlmaLinux, and
+# Oracle Linux. Bakes package-test snapshots with Packer over plain SSH (Hetzner
+# injects the build key at server create, no static keys), authenticated by a
+# project-scoped API token, and promotes each via a fresh-boot smoke test. The
+# scheduled run then self-prunes retention (keep 4 promoted per combo).
+# Sibling of ppg-ami-factory.yml (AWS). Consumers select the newest
+# role=ppg-package-test snapshot by label (see ppg/packer-hetzner/README.md).
+# Lineage roots are seeded once per combo via dispatch (just ci-seed).
+#
+# Triggers: PR validate-only (pull_request -> check job, no token), recipe change
+# (code paths only, doc edits never bake), weekly security rebake (cron, offset
+# from the AWS factory's Mon 06:00 so the two factories never rebake in the same
+# window), manual.
+# Actions are pinned to commit SHAs. The trailing "# vX.Y.Z" records the tag.
+
+name: ppg-hcloud-factory
+run-name: ppg hcloud factory (${{ inputs.env || 'prod' }}, ${{ github.event_name }})
+
+on:
+  workflow_dispatch:
+    inputs:
+      combos:
+        description: 'JSON matrix include list, e.g. [{"os":"rocky","os_major":"9","arch":"x86_64","seed":true}]; os defaults to rocky, seed to false'
+        required: false
+        default: '[{"os":"rocky","os_major":"9","arch":"x86_64"}]'
+      env:
+        description: 'prod (real factory labels) or test (isolated labels, never consumed by production)'
+        required: false
+        default: 'prod'
+        type: choice
+        options: [prod, test]
+  # Code paths only (templates, scripts, justfile, bootstrap, this workflow,
+  # the local setup-hcloud action): a README-only edit must not trigger a bake.
+  push:
+    branches: [master]
+    paths:
+      - 'ppg/packer-hetzner/*.pkr.hcl'
+      - 'ppg/packer-hetzner/smoke/**'
+      - 'ppg/packer-hetzner/scripts/**'
+      - 'ppg/packer-hetzner/justfile'
+      - 'ppg/packer-hetzner/bootstrap/**'
+      - '.github/workflows/ppg-hcloud-factory.yml'
+      - '.github/actions/setup-hcloud/**'
+  pull_request:
+    paths:
+      - 'ppg/packer-hetzner/*.pkr.hcl'
+      - 'ppg/packer-hetzner/smoke/**'
+      - 'ppg/packer-hetzner/scripts/**'
+      - 'ppg/packer-hetzner/justfile'
+      - 'ppg/packer-hetzner/bootstrap/**'
+      - '.github/workflows/ppg-hcloud-factory.yml'
+      - '.github/actions/setup-hcloud/**'
+  schedule:
+    - cron: '0 8 * * 1' # weekly Mon 08:00 UTC - absorb EL errata, offset from the AWS factory
+
+permissions:
+  contents: read # workflow-level default: read-only
+
+concurrency:
+  # PR checks stay per-ref. Everything that can bake (push, schedule, manual
+  # dispatch) serializes per factory env ACROSS refs, so two prod bakes can
+  # never interleave their promote and prune steps.
+  group: ppg-hcloud-factory-${{ github.event_name == 'pull_request' && github.ref || (github.event.inputs.env || 'prod') }}
+  cancel-in-progress: false
+
+env:
+  FACTORY_ENV: ${{ github.event.inputs.env || 'prod' }}
+  # One location for bake AND smoke so the snapshot and its boot test share a
+  # placement family (parity with the justfile's location variable).
+  BAKE_LOCATION: fsn1
+
+jobs:
+  # No-token gate: a malformed template or bad combo fails HERE, before bake
+  # spins up any server. Runs scripts/check.sh, the SAME file `just check` runs,
+  # so the CI and local gates cannot drift. The factory token secret is never
+  # exposed to this job, so a PR can never reach the Hetzner project.
+  check:
+    name: Validate templates (no token)
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+
+      - name: Setup Packer
+        uses: hashicorp/setup-packer@3286471d6cc6756d056a0b199fea5e0becdbc189 # v3.3.0
+        with:
+          version: '1.15.4' # exact, matches the bake job
+
+      - name: fmt-check + validate (fail before any server spend)
+        working-directory: ppg/packer-hetzner
+        run: |
+          set -euo pipefail
+          bash scripts/check.sh
+
+  bake:
+    name: ${{ matrix.os || 'rocky' }} ${{ matrix.os_major }} ${{ matrix.arch }}
+    needs: check # no server launches until templates validate
+    if: github.event_name != 'pull_request' # PRs run the no-token check only
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    permissions:
+      contents: read
+    # The factory token secret lives in this environment, whose protected-branch
+    # deployment rule keeps a branch-ref dispatch from ever reading it.
+    environment: hcloud-factory
+    # Job-level so packer, the smoke, and the promote/delete steps all read the
+    # same project-scoped token without repeating the secret per step.
+    env:
+      HCLOUD_TOKEN: ${{ secrets.HCLOUD_TOKEN_PPG_FACTORY }}
+    strategy:
+      fail-fast: false
+      max-parallel: 12
+      # Default matrix: only combos with a promoted lineage today, so no leg is
+      # guaranteed red. arm64 rows return when CAX stock allows seeding (zero
+      # stock in fsn1/nbg1/hel1 since 2026-08-05). Uncomment the OL8/OL10 rows
+      # after their base bootstrap + seed land (bootstrap/bootstrap-base.sh,
+      # then `just seed <major> x86_64 prod oraclelinux`):
+      #   {"os":"oraclelinux","os_major":"8","arch":"x86_64"},
+      #   {"os":"oraclelinux","os_major":"10","arch":"x86_64"},
+      matrix:
+        include: ${{ fromJSON(github.event.inputs.combos || '[{"os":"rocky","os_major":"8","arch":"x86_64"},{"os":"rocky","os_major":"9","arch":"x86_64"},{"os":"rocky","os_major":"10","arch":"x86_64"},{"os":"almalinux","os_major":"8","arch":"x86_64"},{"os":"almalinux","os_major":"9","arch":"x86_64"},{"os":"almalinux","os_major":"10","arch":"x86_64"},{"os":"oraclelinux","os_major":"9","arch":"x86_64"}]') }}
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+
+      - name: Install hcloud CLI (pinned, checksum-verified)
+        uses: ./.github/actions/setup-hcloud
+
+      - name: Setup Packer
+        uses: hashicorp/setup-packer@3286471d6cc6756d056a0b199fea5e0becdbc189 # v3.3.0
+        with:
+          # Exact version, never a constraint: setup-packer uses this string verbatim
+          # as the tool-cache path segment, so a space/'>' in a constraint like
+          # ">= 1.12.0" breaks the post-install `packer version` check. Bump deliberately.
+          version: '1.15.4'
+
+      - name: Packer init
+        working-directory: ppg/packer-hetzner
+        run: packer init .
+
+      - name: Build candidate snapshot (${{ matrix.os || 'rocky' }} ${{ matrix.os_major }} ${{ matrix.arch }}, env=${{ env.FACTORY_ENV }})
+        id: build
+        working-directory: ppg/packer-hetzner
+        # Matrix values via env, not inline ${{ }}, so they reach packer as data
+        # (quoted shell vars) and cannot break out of the run shell.
+        env:
+          OS: ${{ matrix.os || 'rocky' }}
+          SEED: ${{ matrix.seed || false }}
+          OS_MAJOR: ${{ matrix.os_major }}
+          ARCH: ${{ matrix.arch }}
+        run: |
+          set -euo pipefail
+          rm -f manifest.json
+          packer build -color=false \
+            -var "os=${OS}" \
+            -var "seed=${SEED}" \
+            -var "os_major=${OS_MAJOR}" \
+            -var "arch=${ARCH}" \
+            -var "env=${FACTORY_ENV}" \
+            -var "location=${BAKE_LOCATION}" .
+          SNAPSHOT_ID=$(python3 -c "import json;print(json.load(open('manifest.json'))['builds'][-1]['artifact_id'])")
+          echo "snapshot_id=$SNAPSHOT_ID" >> "$GITHUB_OUTPUT"
+          echo "built candidate: $SNAPSHOT_ID"
+          {
+            echo "### ${OS} ${OS_MAJOR} ${ARCH}"
+            echo "- built: $SNAPSHOT_ID"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Smoke test (fresh boot + install)
+        working-directory: ppg/packer-hetzner
+        env:
+          SNAPSHOT_ID: ${{ steps.build.outputs.snapshot_id }}
+          OS: ${{ matrix.os || 'rocky' }}
+          OS_MAJOR: ${{ matrix.os_major }}
+          ARCH: ${{ matrix.arch }}
+        run: |
+          set -euo pipefail
+          # Same sentinel-gated script the justfile smoke recipe runs: delete
+          # the candidate only on a genuine post-SSH boot/install failure, keep
+          # it for retry on transient infrastructure failures.
+          bash scripts/smoke-run.sh "$SNAPSHOT_ID" "$OS_MAJOR" "$ARCH" "$FACTORY_ENV" "$OS" "$BAKE_LOCATION" \
+            || { echo "- smoke: FAIL (transient failures keep the candidate, see log)" >> "$GITHUB_STEP_SUMMARY"; exit 1; }
+          echo "- smoke: pass" >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Promote (env=${{ env.FACTORY_ENV }})
+        working-directory: ppg/packer-hetzner
+        env:
+          SNAPSHOT_ID: ${{ steps.build.outputs.snapshot_id }}
+        run: |
+          set -euo pipefail
+          # Promote via the SAME retried script the justfile uses: a transient
+          # label failure must NOT delete a smoke-passed snapshot.
+          bash scripts/promote.sh "$SNAPSHOT_ID" "$FACTORY_ENV" \
+            || { echo "- promote: FAILED ($SNAPSHOT_ID left for manual promote)" >> "$GITHUB_STEP_SUMMARY"; exit 1; }
+          promoted_role=ppg-package-test
+          if [ "$FACTORY_ENV" = "test" ]; then
+            promoted_role=ppg-test-package-test
+          fi
+          echo "- promote: $promoted_role" >> "$GITHUB_STEP_SUMMARY"
+
+  # Weekly rebakes self-prune retention (keep the newest 4 promoted snapshots
+  # per combo + drop stale candidates). Schedule-only on purpose: a manual
+  # dispatch (partial matrix, test env, seeding) must never trigger deletes.
+  prune:
+    name: Retention prune (keep 4 promoted per combo)
+    needs: bake
+    if: github.event_name == 'schedule' && success()
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      contents: read
+    # Same environment-scoped secret as bake (protected-branch deployment rule).
+    environment: hcloud-factory
+    env:
+      HCLOUD_TOKEN: ${{ secrets.HCLOUD_TOKEN_PPG_FACTORY }}
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+
+      - name: Install hcloud CLI (pinned, checksum-verified)
+        uses: ./.github/actions/setup-hcloud
+
+      - name: Prune (prod, apply, keep 4)
+        working-directory: ppg/packer-hetzner
+        run: |
+          set -euo pipefail
+          bash scripts/prune.sh prod 1 4 | tee -a "$GITHUB_STEP_SUMMARY"
+
+  notify:
+    needs: [bake, prune]
+    # failure() is true when ANY ancestor failed, including a check failure on a
+    # pull_request run where bake was skipped. Never ping the webhook for PR lint.
+    if: failure() && github.event_name != 'pull_request'
+    runs-on: ubuntu-latest
+    # Job-level so the step `if` below reads it reliably. A step-scoped env can be
+    # unavailable to its own step's `if`, which would skip the alert silently.
+    env:
+      SLACK_WEBHOOK: ${{ secrets.RELEASES_CI_SLACK_WEBHOOK }}
+    steps:
+      - name: Slack on failure
+        # Skip cleanly when the webhook secret is unset (e.g. fork tests), so a real
+        # bake failure is not masked by a second "missing webhook" failure.
+        if: env.SLACK_WEBHOOK != ''
+        uses: slackapi/slack-github-action@91efab103c0de0a537f72a35f6b8cda0ee76bf0a # v2.1.1
+        with:
+          webhook: ${{ env.SLACK_WEBHOOK }}
+          webhook-type: incoming-webhook
+          payload: |
+            text: "PPG hcloud factory FAILED - ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"

--- a/.github/workflows/ppg-hcloud-factory.yml
+++ b/.github/workflows/ppg-hcloud-factory.yml
@@ -82,6 +82,8 @@ jobs:
       contents: read
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          persist-credentials: false
 
       - name: Setup Packer
         uses: hashicorp/setup-packer@3286471d6cc6756d056a0b199fea5e0becdbc189 # v3.3.0
@@ -97,7 +99,9 @@ jobs:
   bake:
     name: ${{ matrix.os || 'rocky' }} ${{ matrix.os_major }} ${{ matrix.arch }}
     needs: check # no server launches until templates validate
-    if: github.event_name != 'pull_request' # PRs run the no-token check only
+    # Explicit event allowlist (not a pull_request blocklist), so a later
+    # trigger addition (e.g. pull_request_target) can never reach the token.
+    if: contains(fromJSON('["push", "schedule", "workflow_dispatch"]'), github.event_name)
     runs-on: ubuntu-latest
     timeout-minutes: 60
     permissions:
@@ -116,25 +120,12 @@ jobs:
       matrix:
         include: ${{ fromJSON(github.event.inputs.combos || '[{"os":"rocky","os_major":"8","arch":"x86_64"},{"os":"rocky","os_major":"9","arch":"x86_64"},{"os":"rocky","os_major":"10","arch":"x86_64"},{"os":"almalinux","os_major":"8","arch":"x86_64"},{"os":"almalinux","os_major":"9","arch":"x86_64"},{"os":"almalinux","os_major":"10","arch":"x86_64"},{"os":"oraclelinux","os_major":"9","arch":"x86_64"}]') }}
     steps:
+      # All tool-setup actions run BEFORE authentication, and neither the AWS
+      # credentials nor the token enter the job env: only the steps below that
+      # explicitly wire them see them.
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
-
-      # Master-pinned OIDC trust + SSM token: a branch-ref dispatch fails at
-      # AssumeRole, and GitHub stores no Hetzner credential.
-      - name: Configure AWS credentials (OIDC)
-        uses: aws-actions/configure-aws-credentials@7474bc4690e29a8392af63c5b98e7449536d5c3a # v4.3.1
         with:
-          # Fallback prod ARN; security is the master-only trust, not ARN secrecy.
-          role-to-assume: ${{ secrets.PPG_HCLOUD_FACTORY_ROLE_ARN || 'arn:aws:iam::119175775298:role/percona-ci-platform-gha-ppg-hcloud-factory' }}
-          role-session-name: ppg-hcloud-bake-${{ github.run_id }}-${{ github.run_attempt }}
-          aws-region: us-east-1
-
-      - name: Read factory token from SSM
-        run: |
-          set -euo pipefail
-          token=$(aws ssm get-parameter --name /ppg/hcloud-factory-token \
-            --with-decryption --query Parameter.Value --output text)
-          echo "::add-mask::$token"
-          echo "HCLOUD_TOKEN=$token" >> "$GITHUB_ENV"
+          persist-credentials: false
 
       - name: Install hcloud CLI (pinned, checksum-verified)
         uses: ./.github/actions/setup-hcloud
@@ -151,12 +142,45 @@ jobs:
         working-directory: ppg/packer-hetzner
         run: packer init .
 
+      # Master-pinned OIDC trust + SSM token: a branch-ref dispatch fails at
+      # AssumeRole, and GitHub stores no Hetzner credential.
+      - name: Configure AWS credentials (OIDC)
+        id: aws
+        uses: aws-actions/configure-aws-credentials@7474bc4690e29a8392af63c5b98e7449536d5c3a # v4.3.1
+        with:
+          # Hardcoded on purpose; security is the master-only trust, not ARN secrecy.
+          role-to-assume: arn:aws:iam::119175775298:role/percona-ci-platform-gha-ppg-hcloud-factory
+          role-session-name: ppg-hcloud-bake-${{ github.run_id }}-${{ github.run_attempt }}
+          aws-region: us-east-1
+          role-duration-seconds: 900
+          output-credentials: true
+          output-env-credentials: false
+
+      - name: Read factory token from SSM
+        id: hcloud_token
+        env:
+          AWS_ACCESS_KEY_ID: ${{ steps.aws.outputs.aws-access-key-id }}
+          AWS_SECRET_ACCESS_KEY: ${{ steps.aws.outputs.aws-secret-access-key }}
+          AWS_SESSION_TOKEN: ${{ steps.aws.outputs.aws-session-token }}
+          AWS_REGION: us-east-1
+        run: |
+          set -euo pipefail
+          token=$(aws ssm get-parameter --name /ppg/hcloud-factory-token \
+            --with-decryption --query Parameter.Value --output text)
+          if [ -z "$token" ] || [ "$token" = "REPLACE-out-of-band" ]; then
+            echo "SSM parameter still holds the placeholder; populate it first" >&2
+            exit 1
+          fi
+          echo "::add-mask::$token"
+          echo "token=$token" >> "$GITHUB_OUTPUT"
+
       - name: Build candidate snapshot (${{ matrix.os || 'rocky' }} ${{ matrix.os_major }} ${{ matrix.arch }}, env=${{ env.FACTORY_ENV }})
         id: build
         working-directory: ppg/packer-hetzner
         # Matrix values via env, not inline ${{ }}, so they reach packer as data
         # (quoted shell vars) and cannot break out of the run shell.
         env:
+          HCLOUD_TOKEN: ${{ steps.hcloud_token.outputs.token }}
           OS: ${{ matrix.os || 'rocky' }}
           SEED: ${{ matrix.seed || false }}
           OS_MAJOR: ${{ matrix.os_major }}
@@ -182,6 +206,7 @@ jobs:
       - name: Smoke test (fresh boot + install)
         working-directory: ppg/packer-hetzner
         env:
+          HCLOUD_TOKEN: ${{ steps.hcloud_token.outputs.token }}
           SNAPSHOT_ID: ${{ steps.build.outputs.snapshot_id }}
           OS: ${{ matrix.os || 'rocky' }}
           OS_MAJOR: ${{ matrix.os_major }}
@@ -198,6 +223,7 @@ jobs:
       - name: Promote (env=${{ env.FACTORY_ENV }})
         working-directory: ppg/packer-hetzner
         env:
+          HCLOUD_TOKEN: ${{ steps.hcloud_token.outputs.token }}
           SNAPSHOT_ID: ${{ steps.build.outputs.snapshot_id }}
         run: |
           set -euo pipefail
@@ -225,27 +251,45 @@ jobs:
       id-token: write # same OIDC trust boundary as bake
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
-
-      - name: Configure AWS credentials (OIDC)
-        uses: aws-actions/configure-aws-credentials@7474bc4690e29a8392af63c5b98e7449536d5c3a # v4.3.1
         with:
-          role-to-assume: ${{ secrets.PPG_HCLOUD_FACTORY_ROLE_ARN || 'arn:aws:iam::119175775298:role/percona-ci-platform-gha-ppg-hcloud-factory' }}
-          role-session-name: ppg-hcloud-prune-${{ github.run_id }}-${{ github.run_attempt }}
-          aws-region: us-east-1
-
-      - name: Read factory token from SSM
-        run: |
-          set -euo pipefail
-          token=$(aws ssm get-parameter --name /ppg/hcloud-factory-token \
-            --with-decryption --query Parameter.Value --output text)
-          echo "::add-mask::$token"
-          echo "HCLOUD_TOKEN=$token" >> "$GITHUB_ENV"
+          persist-credentials: false
 
       - name: Install hcloud CLI (pinned, checksum-verified)
         uses: ./.github/actions/setup-hcloud
 
+      - name: Configure AWS credentials (OIDC)
+        id: aws
+        uses: aws-actions/configure-aws-credentials@7474bc4690e29a8392af63c5b98e7449536d5c3a # v4.3.1
+        with:
+          role-to-assume: arn:aws:iam::119175775298:role/percona-ci-platform-gha-ppg-hcloud-factory
+          role-session-name: ppg-hcloud-prune-${{ github.run_id }}-${{ github.run_attempt }}
+          aws-region: us-east-1
+          role-duration-seconds: 900
+          output-credentials: true
+          output-env-credentials: false
+
+      - name: Read factory token from SSM
+        id: hcloud_token
+        env:
+          AWS_ACCESS_KEY_ID: ${{ steps.aws.outputs.aws-access-key-id }}
+          AWS_SECRET_ACCESS_KEY: ${{ steps.aws.outputs.aws-secret-access-key }}
+          AWS_SESSION_TOKEN: ${{ steps.aws.outputs.aws-session-token }}
+          AWS_REGION: us-east-1
+        run: |
+          set -euo pipefail
+          token=$(aws ssm get-parameter --name /ppg/hcloud-factory-token \
+            --with-decryption --query Parameter.Value --output text)
+          if [ -z "$token" ] || [ "$token" = "REPLACE-out-of-band" ]; then
+            echo "SSM parameter still holds the placeholder; populate it first" >&2
+            exit 1
+          fi
+          echo "::add-mask::$token"
+          echo "token=$token" >> "$GITHUB_OUTPUT"
+
       - name: Prune (prod, apply, keep 4)
         working-directory: ppg/packer-hetzner
+        env:
+          HCLOUD_TOKEN: ${{ steps.hcloud_token.outputs.token }}
         run: |
           set -euo pipefail
           bash scripts/prune.sh prod 1 4 | tee -a "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/ppg-hcloud-factory.yml
+++ b/.github/workflows/ppg-hcloud-factory.yml
@@ -102,13 +102,7 @@ jobs:
     timeout-minutes: 60
     permissions:
       contents: read
-    # The factory token secret lives in this environment, whose protected-branch
-    # deployment rule keeps a branch-ref dispatch from ever reading it.
-    environment: hcloud-factory
-    # Job-level so packer, the smoke, and the promote/delete steps all read the
-    # same project-scoped token without repeating the secret per step.
-    env:
-      HCLOUD_TOKEN: ${{ secrets.HCLOUD_TOKEN_PPG_FACTORY }}
+      id-token: write # OIDC token for AssumeRole
     strategy:
       fail-fast: false
       max-parallel: 12
@@ -123,6 +117,24 @@ jobs:
         include: ${{ fromJSON(github.event.inputs.combos || '[{"os":"rocky","os_major":"8","arch":"x86_64"},{"os":"rocky","os_major":"9","arch":"x86_64"},{"os":"rocky","os_major":"10","arch":"x86_64"},{"os":"almalinux","os_major":"8","arch":"x86_64"},{"os":"almalinux","os_major":"9","arch":"x86_64"},{"os":"almalinux","os_major":"10","arch":"x86_64"},{"os":"oraclelinux","os_major":"9","arch":"x86_64"}]') }}
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+
+      # Master-pinned OIDC trust + SSM token: a branch-ref dispatch fails at
+      # AssumeRole, and GitHub stores no Hetzner credential.
+      - name: Configure AWS credentials (OIDC)
+        uses: aws-actions/configure-aws-credentials@7474bc4690e29a8392af63c5b98e7449536d5c3a # v4.3.1
+        with:
+          # Fallback prod ARN; security is the master-only trust, not ARN secrecy.
+          role-to-assume: ${{ secrets.PPG_HCLOUD_FACTORY_ROLE_ARN || 'arn:aws:iam::119175775298:role/percona-ci-platform-gha-ppg-hcloud-factory' }}
+          role-session-name: ppg-hcloud-bake-${{ github.run_id }}-${{ github.run_attempt }}
+          aws-region: us-east-1
+
+      - name: Read factory token from SSM
+        run: |
+          set -euo pipefail
+          token=$(aws ssm get-parameter --name /ppg/hcloud-factory-token \
+            --with-decryption --query Parameter.Value --output text)
+          echo "::add-mask::$token"
+          echo "HCLOUD_TOKEN=$token" >> "$GITHUB_ENV"
 
       - name: Install hcloud CLI (pinned, checksum-verified)
         uses: ./.github/actions/setup-hcloud
@@ -210,12 +222,24 @@ jobs:
     timeout-minutes: 15
     permissions:
       contents: read
-    # Same environment-scoped secret as bake (protected-branch deployment rule).
-    environment: hcloud-factory
-    env:
-      HCLOUD_TOKEN: ${{ secrets.HCLOUD_TOKEN_PPG_FACTORY }}
+      id-token: write # same OIDC trust boundary as bake
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+
+      - name: Configure AWS credentials (OIDC)
+        uses: aws-actions/configure-aws-credentials@7474bc4690e29a8392af63c5b98e7449536d5c3a # v4.3.1
+        with:
+          role-to-assume: ${{ secrets.PPG_HCLOUD_FACTORY_ROLE_ARN || 'arn:aws:iam::119175775298:role/percona-ci-platform-gha-ppg-hcloud-factory' }}
+          role-session-name: ppg-hcloud-prune-${{ github.run_id }}-${{ github.run_attempt }}
+          aws-region: us-east-1
+
+      - name: Read factory token from SSM
+        run: |
+          set -euo pipefail
+          token=$(aws ssm get-parameter --name /ppg/hcloud-factory-token \
+            --with-decryption --query Parameter.Value --output text)
+          echo "::add-mask::$token"
+          echo "HCLOUD_TOKEN=$token" >> "$GITHUB_ENV"
 
       - name: Install hcloud CLI (pinned, checksum-verified)
         uses: ./.github/actions/setup-hcloud

--- a/.github/workflows/ppg-hcloud-janitor.yml
+++ b/.github/workflows/ppg-hcloud-janitor.yml
@@ -42,17 +42,32 @@ jobs:
     timeout-minutes: 15
     permissions:
       contents: read
-    # The factory token secret lives in this environment, whose protected-branch
-    # deployment rule keeps a branch-ref dispatch from ever reading it.
-    environment: hcloud-factory
+      id-token: write # OIDC token for AssumeRole
     # Job-level so the alert step's `if` below reads SLACK_WEBHOOK reliably. A
     # step-scoped env can be unavailable to its own step's `if`, which would
     # skip the alert silently.
     env:
-      HCLOUD_TOKEN: ${{ secrets.HCLOUD_TOKEN_PPG_FACTORY }}
       SLACK_WEBHOOK: ${{ secrets.RELEASES_CI_SLACK_WEBHOOK }}
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+
+      # Master-pinned OIDC trust + SSM token: a branch-ref dispatch fails at
+      # AssumeRole, and GitHub stores no Hetzner credential.
+      - name: Configure AWS credentials (OIDC)
+        uses: aws-actions/configure-aws-credentials@7474bc4690e29a8392af63c5b98e7449536d5c3a # v4.3.1
+        with:
+          # Fallback prod ARN; security is the master-only trust, not ARN secrecy.
+          role-to-assume: ${{ secrets.PPG_HCLOUD_FACTORY_ROLE_ARN || 'arn:aws:iam::119175775298:role/percona-ci-platform-gha-ppg-hcloud-factory' }}
+          role-session-name: ppg-hcloud-janitor-${{ github.run_id }}-${{ github.run_attempt }}
+          aws-region: us-east-1
+
+      - name: Read factory token from SSM
+        run: |
+          set -euo pipefail
+          token=$(aws ssm get-parameter --name /ppg/hcloud-factory-token \
+            --with-decryption --query Parameter.Value --output text)
+          echo "::add-mask::$token"
+          echo "HCLOUD_TOKEN=$token" >> "$GITHUB_ENV"
 
       - name: Install hcloud CLI (pinned, checksum-verified)
         uses: ./.github/actions/setup-hcloud

--- a/.github/workflows/ppg-hcloud-janitor.yml
+++ b/.github/workflows/ppg-hcloud-janitor.yml
@@ -1,7 +1,8 @@
 # Janitor for leaked Hetzner Cloud resources (ppg/packer-hetzner/scripts/janitor.sh):
 # factory builder/smoke servers a crashed bake left behind, molecule test servers,
-# and the per-run SSH keys the molecule create playbook uploads. Selection is
-# label-contract-only and age-bound (see the script header).
+# and leaked SSH keys: Packer's labeled per-build temp keys plus the per-run keys
+# the bootstrap and molecule producers upload. Selection is label-contract-only
+# and age-bound (see the script header).
 #
 # Triggers: hourly cron (APPLIES with a conservative 6h age floor: a leak the
 # producers' own cleanup missed for 6h is debris, and a list-only cron is pure

--- a/.github/workflows/ppg-hcloud-janitor.yml
+++ b/.github/workflows/ppg-hcloud-janitor.yml
@@ -1,0 +1,117 @@
+# Janitor for leaked Hetzner Cloud resources (ppg/packer-hetzner/scripts/janitor.sh):
+# factory builder/smoke servers a crashed bake left behind, molecule test servers,
+# and the per-run SSH keys the molecule create playbook uploads. Selection is
+# label-contract-only and age-bound (see the script header).
+#
+# Triggers: hourly cron (APPLIES with a conservative 6h age floor: a leak the
+# producers' own cleanup missed for 6h is debris, and a list-only cron is pure
+# noise), manual dispatch with both knobs (apply defaults to list-only there).
+# Any leak listed or deleted posts a Slack alert.
+# Actions are pinned to commit SHAs. The trailing "# vX.Y.Z" records the tag.
+
+name: ppg-hcloud-janitor
+run-name: ppg hcloud janitor (${{ (github.event_name == 'schedule' || inputs.apply == true) && 'APPLY' || 'list-only' }}, ${{ github.event_name }})
+
+on:
+  workflow_dispatch:
+    inputs:
+      apply:
+        description: 'Actually delete the selected leaks (default: list only)'
+        required: false
+        default: false
+        type: boolean
+      max_age_hours:
+        description: 'Only touch resources older than this many hours (long molecule suites can pass 2h, so stay conservative)'
+        required: false
+        default: '6'
+  schedule:
+    - cron: '22 * * * *' # hourly apply sweep (offset from the top of the hour)
+
+permissions:
+  contents: read # workflow-level default: read-only
+
+concurrency:
+  group: ppg-hcloud-janitor
+  cancel-in-progress: false
+
+jobs:
+  sweep:
+    name: Sweep leaked servers + ssh keys (${{ (github.event_name == 'schedule' || inputs.apply == true) && 'APPLY' || 'list-only' }})
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      contents: read
+    # The factory token secret lives in this environment, whose protected-branch
+    # deployment rule keeps a branch-ref dispatch from ever reading it.
+    environment: hcloud-factory
+    # Job-level so the alert step's `if` below reads SLACK_WEBHOOK reliably. A
+    # step-scoped env can be unavailable to its own step's `if`, which would
+    # skip the alert silently.
+    env:
+      HCLOUD_TOKEN: ${{ secrets.HCLOUD_TOKEN_PPG_FACTORY }}
+      SLACK_WEBHOOK: ${{ secrets.RELEASES_CI_SLACK_WEBHOOK }}
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+
+      - name: Install hcloud CLI (pinned, checksum-verified)
+        uses: ./.github/actions/setup-hcloud
+
+      - name: Run janitor
+        id: janitor
+        # Scheduled sweeps APPLY at a conservative 6h age floor. Dispatch keeps
+        # both knobs and stays list-only unless apply=true is picked.
+        env:
+          APPLY: ${{ (github.event_name == 'schedule' || inputs.apply == true) && '1' || '0' }}
+          MAX_AGE_HOURS: ${{ github.event_name == 'schedule' && '6' || inputs.max_age_hours || '6' }}
+        run: |
+          set -euo pipefail
+          set +e
+          bash ppg/packer-hetzner/scripts/janitor.sh "${APPLY}" "${MAX_AGE_HOURS}" | tee janitor.log
+          janitor_exit="${PIPESTATUS[0]}"
+          set -e
+          cat janitor.log >> "$GITHUB_STEP_SUMMARY"
+          # Idempotent probe: a run that died before its summary line has no
+          # count. Default to 0 and let the exit-code check below surface it.
+          count=$(grep -oE '^(leaked|deleted)=[0-9]+$' janitor.log | tail -n 1 | cut -d= -f2 || true)
+          {
+            echo "count=${count:-0}"
+            echo "mode=$([ "${APPLY}" = "1" ] && echo deleted || echo listed)"
+          } >> "$GITHUB_OUTPUT"
+          # Exit 3 is the janitor's "leaks listed" signal, not a sweep failure:
+          # the alert step below reports it. Anything else non-zero is real.
+          if [ "${janitor_exit}" -ne 0 ] && [ "${janitor_exit}" -ne 3 ]; then
+            exit "${janitor_exit}"
+          fi
+
+      - name: Slack alert on leaks (listed or deleted)
+        # Alert whenever the sweep touched anything. Skip cleanly when the
+        # webhook secret is unset (e.g. fork tests), same guard pattern as the
+        # factory notify, so the sweep result is never masked by a second
+        # "missing webhook" failure.
+        if: steps.janitor.outputs.count != '0' && env.SLACK_WEBHOOK != ''
+        uses: slackapi/slack-github-action@91efab103c0de0a537f72a35f6b8cda0ee76bf0a # v2.1.1
+        with:
+          webhook: ${{ env.SLACK_WEBHOOK }}
+          webhook-type: incoming-webhook
+          payload: |
+            text: "PPG hcloud janitor: ${{ steps.janitor.outputs.count }} leaked resource(s) ${{ steps.janitor.outputs.mode }} in ${{ github.repository }} - ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+
+  notify:
+    needs: sweep
+    if: failure()
+    runs-on: ubuntu-latest
+    # Job-level so the step `if` below reads it reliably. A step-scoped env can be
+    # unavailable to its own step's `if`, which would skip the alert silently.
+    env:
+      SLACK_WEBHOOK: ${{ secrets.RELEASES_CI_SLACK_WEBHOOK }}
+    steps:
+      - name: Slack on failure
+        # Skip cleanly when the webhook secret is unset (e.g. fork tests), so a real
+        # sweep failure is not masked by a second "missing webhook" failure.
+        if: env.SLACK_WEBHOOK != ''
+        uses: slackapi/slack-github-action@91efab103c0de0a537f72a35f6b8cda0ee76bf0a # v2.1.1
+        with:
+          webhook: ${{ env.SLACK_WEBHOOK }}
+          webhook-type: incoming-webhook
+          payload: |
+            text: "PPG hcloud janitor FAILED - ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"

--- a/.github/workflows/ppg-hcloud-janitor.yml
+++ b/.github/workflows/ppg-hcloud-janitor.yml
@@ -43,40 +43,59 @@ jobs:
     permissions:
       contents: read
       id-token: write # OIDC token for AssumeRole
-    # Job-level so the alert step's `if` below reads SLACK_WEBHOOK reliably. A
-    # step-scoped env can be unavailable to its own step's `if`, which would
-    # skip the alert silently.
-    env:
-      SLACK_WEBHOOK: ${{ secrets.RELEASES_CI_SLACK_WEBHOOK }}
+    # Consumed by the credential-free alert job below, so the Slack action
+    # never runs beside the token-bearing steps.
+    outputs:
+      count: ${{ steps.janitor.outputs.count }}
+      mode: ${{ steps.janitor.outputs.mode }}
     steps:
+      # Tool setup runs BEFORE authentication; neither the AWS credentials nor
+      # the token enter the job env (explicitly wired per step only).
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          persist-credentials: false
+
+      - name: Install hcloud CLI (pinned, checksum-verified)
+        uses: ./.github/actions/setup-hcloud
 
       # Master-pinned OIDC trust + SSM token: a branch-ref dispatch fails at
       # AssumeRole, and GitHub stores no Hetzner credential.
       - name: Configure AWS credentials (OIDC)
+        id: aws
         uses: aws-actions/configure-aws-credentials@7474bc4690e29a8392af63c5b98e7449536d5c3a # v4.3.1
         with:
-          # Fallback prod ARN; security is the master-only trust, not ARN secrecy.
-          role-to-assume: ${{ secrets.PPG_HCLOUD_FACTORY_ROLE_ARN || 'arn:aws:iam::119175775298:role/percona-ci-platform-gha-ppg-hcloud-factory' }}
+          # Hardcoded on purpose; security is the master-only trust, not ARN secrecy.
+          role-to-assume: arn:aws:iam::119175775298:role/percona-ci-platform-gha-ppg-hcloud-factory
           role-session-name: ppg-hcloud-janitor-${{ github.run_id }}-${{ github.run_attempt }}
           aws-region: us-east-1
+          role-duration-seconds: 900
+          output-credentials: true
+          output-env-credentials: false
 
       - name: Read factory token from SSM
+        id: hcloud_token
+        env:
+          AWS_ACCESS_KEY_ID: ${{ steps.aws.outputs.aws-access-key-id }}
+          AWS_SECRET_ACCESS_KEY: ${{ steps.aws.outputs.aws-secret-access-key }}
+          AWS_SESSION_TOKEN: ${{ steps.aws.outputs.aws-session-token }}
+          AWS_REGION: us-east-1
         run: |
           set -euo pipefail
           token=$(aws ssm get-parameter --name /ppg/hcloud-factory-token \
             --with-decryption --query Parameter.Value --output text)
+          if [ -z "$token" ] || [ "$token" = "REPLACE-out-of-band" ]; then
+            echo "SSM parameter still holds the placeholder; populate it first" >&2
+            exit 1
+          fi
           echo "::add-mask::$token"
-          echo "HCLOUD_TOKEN=$token" >> "$GITHUB_ENV"
-
-      - name: Install hcloud CLI (pinned, checksum-verified)
-        uses: ./.github/actions/setup-hcloud
+          echo "token=$token" >> "$GITHUB_OUTPUT"
 
       - name: Run janitor
         id: janitor
         # Scheduled sweeps APPLY at a conservative 6h age floor. Dispatch keeps
         # both knobs and stays list-only unless apply=true is picked.
         env:
+          HCLOUD_TOKEN: ${{ steps.hcloud_token.outputs.token }}
           APPLY: ${{ (github.event_name == 'schedule' || inputs.apply == true) && '1' || '0' }}
           MAX_AGE_HOURS: ${{ github.event_name == 'schedule' && '6' || inputs.max_age_hours || '6' }}
         run: |
@@ -99,18 +118,28 @@ jobs:
             exit "${janitor_exit}"
           fi
 
+  # Separate job so the third-party Slack action never runs in the
+  # token-bearing sweep job.
+  alert:
+    needs: sweep
+    if: needs.sweep.outputs.count != '0'
+    runs-on: ubuntu-latest
+    # Job-level so the step `if` below reads it reliably. A step-scoped env can be
+    # unavailable to its own step's `if`, which would skip the alert silently.
+    env:
+      SLACK_WEBHOOK: ${{ secrets.RELEASES_CI_SLACK_WEBHOOK }}
+    steps:
       - name: Slack alert on leaks (listed or deleted)
-        # Alert whenever the sweep touched anything. Skip cleanly when the
-        # webhook secret is unset (e.g. fork tests), same guard pattern as the
-        # factory notify, so the sweep result is never masked by a second
-        # "missing webhook" failure.
-        if: steps.janitor.outputs.count != '0' && env.SLACK_WEBHOOK != ''
+        # Skip cleanly when the webhook secret is unset (e.g. fork tests), same
+        # guard pattern as the factory notify, so the sweep result is never
+        # masked by a second "missing webhook" failure.
+        if: env.SLACK_WEBHOOK != ''
         uses: slackapi/slack-github-action@91efab103c0de0a537f72a35f6b8cda0ee76bf0a # v2.1.1
         with:
           webhook: ${{ env.SLACK_WEBHOOK }}
           webhook-type: incoming-webhook
           payload: |
-            text: "PPG hcloud janitor: ${{ steps.janitor.outputs.count }} leaked resource(s) ${{ steps.janitor.outputs.mode }} in ${{ github.repository }} - ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+            text: "PPG hcloud janitor: ${{ needs.sweep.outputs.count }} leaked resource(s) ${{ needs.sweep.outputs.mode }} in ${{ github.repository }} - ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
 
   notify:
     needs: sweep

--- a/ppg/packer-hetzner/.gitignore
+++ b/ppg/packer-hetzner/.gitignore
@@ -1,0 +1,4 @@
+manifest.json
+*.log
+packer_cache/
+.packer.d/

--- a/ppg/packer-hetzner/README.md
+++ b/ppg/packer-hetzner/README.md
@@ -1,0 +1,153 @@
+# PPG EL snapshot factory (Rocky, Alma, and Oracle Linux on Hetzner Cloud)
+
+Builds the Rocky Linux, AlmaLinux, and Oracle Linux package-test target
+snapshots that PG release testing runs against on Hetzner Cloud. Sibling of
+the AWS AMI factory
+([../packer](../packer)): same structure (refresh + seed + fresh-boot smoke +
+separate retried promote), same scripts driven by both the `justfile` and the
+GitHub Actions workflow (`.github/workflows/ppg-hcloud-factory.yml`).
+
+## Why this exists
+
+Hetzner ships official, current system images for every combo this factory
+covers: `rocky-8/9/10` and `alma-8/9/10`, x86_64 **and** arm64. So unlike the
+AWS factory there is no import/re-image machinery: every lineage seeds
+directly from the official image (`-var seed=true`), then refreshes weekly
+from its own newest promoted snapshot.
+
+Oracle Linux has no Hetzner system image. Its lineage roots are base
+snapshots (`role=ppg-base`, `source=bootstrap`) that
+`bootstrap/bootstrap-base.sh` uploads one-time per combo from Oracle's
+official KVM qcow2 (checksum-verified, written via
+[hcloud-upload-image](https://github.com/apricote/hcloud-upload-image)'s
+rescue-mode flow, then boot-checked). An `os=oraclelinux` seed sources the
+newest matching base instead of an official image name. From there the OL
+lineage refreshes exactly like Rocky/Alma. OL9 x86_64 is proven end to end.
+OL8/OL10 bases are wired but unbootstrapped, and arm64 waits on CAX stock,
+so `oraclelinux` stays OUT of the justfile `os_list` (the CI seed/validate
+matrix) until its base coverage matches.
+
+## Matrix
+
+Full matrix: {rocky, almalinux, oraclelinux} x {8, 9, 10} x {x86_64, arm64}.
+The workflow's default (weekly/push) matrix carries only the combos with a
+promoted lineage today, so no leg is guaranteed red: rocky and almalinux
+8/9/10 x86_64 plus oraclelinux 9 x86_64. The OL8/OL10 x86_64 rows sit
+commented in the workflow until their `ppg-base` bootstrap + seed land, and
+the arm64 rows return when CAX stock allows seeding (zero stock in
+fsn1/nbg1/hel1 since 2026-08-05). Builders: `cpx32` (x86_64) / `cax21`
+(arm64), location `fsn1` by default, overridable to `nbg1`/`hel1` (CAX exists
+only in those three).
+
+## Label contract
+
+Snapshots have no API name. The identity string
+`PPG-<Rocky|Alma|OL><major>-<arch>-<UTCstamp>` (bases:
+`PPG-Base-OL<major>-<arch>-<UTCstamp>`) lands in the image description, and
+everything else is labels:
+
+| Label | Values | Meaning |
+|-------|--------|---------|
+| `role` | `ppg-candidate` -> `ppg-package-test`, or `ppg-base` | Candidate at build time. The smoke pass + promote flips it to the promoted role the consumers and the refresh lineage select. `ppg-base` marks a bootstrap-uploaded OL lineage root (never promoted, never consumed directly). |
+| `os` / `os_major` / `arch` | `rocky\|almalinux\|oraclelinux` / `8\|9\|10` / `x86_64\|arm64` | The combo. |
+| `source` | `factory` | Factory-produced (env=test: `factory-test`, bootstrap-uploaded bases: `bootstrap`). |
+| `factory_env` | `prod\|test` | Namespace: env=test bakes carry `role=ppg-test-candidate` -> `ppg-test-package-test` and are never selected by production. |
+| `factory_run` | UTC stamp | Build correlation. |
+| `base_image` / `base_mode` | e.g. `rocky-9` / `seed\|lineage` | Lineage provenance: the official image family the chain descends from, and whether this bake sourced it directly (seed) or via the chain. The hcloud builder has no source-image interpolation, so there is no per-parent ID label (the parent is the previously promoted snapshot of the same combo). |
+| `smoke` | `passed` | Set by the smoke gate right after a pass (before promotion, so a candidate whose promote failed transiently stays distinguishable from debris) and re-asserted by promote. Never set at build time. |
+
+## Consumer lookup rule
+
+"Latest" is the newest promoted snapshot by creation date, selected by labels,
+never by pinned ID:
+
+```bash
+hcloud image list -t snapshot \
+  -l 'role=ppg-package-test,os=rocky,os_major=9,arch=arm64' \
+  -s created:desc -o noheader -o columns=id | head -1
+```
+
+`just latest 9 arm64 rocky` runs exactly this.
+
+## Usage
+
+```bash
+export HCLOUD_TOKEN=...   # project-scoped factory token, check/fmt/validate need none
+just check                # fmt-check + validate all combos + drift guards (no API)
+just seed 9 x86_64        # one-time lineage root for ONE combo (bake + smoke + promote)
+just ci-seed              # dispatch the GHA workflow to seed ALL 12 combos (env=prod)
+bootstrap/bootstrap-base.sh          # one-time OL base upload + boot check (OS_MAJOR=9)
+just seed 9 x86_64 prod oraclelinux  # OL lineage root: seeds from that ppg-base snapshot
+just bake 9 x86_64        # refresh one combo: build + smoke + promote
+just all                  # every major x arch for one os (default rocky)
+just all prod almalinux   # same for almalinux
+just test 9 x86_64        # isolated env=test bake (never consumed)
+just list                 # current factory snapshots (prod|test)
+just prune                # retention sweep, lists only (`just prune prod 1` deletes)
+```
+
+Each build snapshots a candidate (`role=ppg-candidate`), then the native-Packer
+smoke (`smoke/smoke.pkr.hcl`, a `skip_create_snapshot` build) fresh-boots it:
+cloud-init must re-initialise (proving the bake's cleanup worked and Hetzner
+can re-inject SSH keys), identity must match, and a real
+`percona-release enable-only ppg-17` + `dnf install percona-postgresql17-server`
+must succeed. The smoke template ONLY validates. `scripts/smoke-run.sh` (shared
+by the justfile and the workflow) gates what happens next on the
+`SMOKE-PROVISIONER-STARTED` sentinel the provisioner echoes first: a failure
+AFTER the sentinel is a genuine boot/install failure and deletes the candidate,
+a failure WITHOUT it (server create failed, CAX stock-out, API 5xx, SSH
+timeout) keeps the candidate for a retry. On a pass the candidate is labeled
+`smoke=passed` immediately, then **promotion runs as a separate, retried step**
+(`scripts/promote.sh`, which refuses a snapshot whose role or `factory_env`
+does not match the requested env), so a transient label-API failure can never
+delete a smoke-passed snapshot. The refresh lineage selector additionally
+requires `source=factory` + `smoke=passed`, so a manually labeled or
+test-leaked snapshot can never become a parent. Login user: `root` for every
+os. Rocky/Alma ship that natively.
+On OL, Hetzner's vendor-data makes root cloud-init's default user but
+Oracle's stock `disable_root: true` stubs the injected key, so the refresh
+template passes `disable_root: false` user-data for the build boot and
+`provision.sh` bakes that override into the lineage (the pristine `ppg-base`
+snapshot itself needs the user-data line to be reachable, see
+`bootstrap/bootstrap-base.sh`).
+
+## Retention and cleanup
+
+Hetzner has no `deprecate_at`, so `scripts/prune.sh` is the PRIMARY retention:
+keep the newest 4 promoted snapshots per combo (justfile `keep_last`) plus a
+two-tier stale-candidate sweep (unlabeled candidates older than 7 days are
+debris from a run that died between build and smoke/promote/delete, and
+`smoke=passed` candidates age out only after 21 days: promote-retry material
+is spared, not immortal). Fail-safe: lists
+by default, deletes only on an explicit `apply=1`, selects exclusively by the
+factory's own label contract (never touches what it cannot identify), and
+never deletes the newest N promoted per combo. The weekly scheduled bake
+self-prunes: the workflow's `prune` job runs `prune.sh prod 1 4` after a green
+scheduled bake (manual dispatches never prune).
+
+Leaked servers and SSH keys are the janitor's job
+(`scripts/janitor.sh` + `.github/workflows/ppg-hcloud-janitor.yml`): the
+hourly cron APPLIES with a conservative 6-hour age floor, a manual dispatch
+defaults to list-only, and anything listed or deleted posts a Slack alert.
+
+## Token
+
+One project-scoped Hetzner API token, exported as `HCLOUD_TOKEN` locally and
+stored as the `HCLOUD_TOKEN_PPG_FACTORY` secret in the `hcloud-factory`
+GitHub environment for the workflows. The environment's protected-branch
+deployment rule keeps a branch-ref dispatch from ever reading the secret. It
+never appears in files or output. `check`/`fmt`/`validate` run tokenless (the
+plugin insists on a non-empty token even offline, so `check.sh` exports an
+inert placeholder).
+
+## Deviations from the AWS factory
+
+- Plain SSH as root, no Session Manager and no baked agents: Hetzner injects
+  the temp key at server create, `ssh_clear_authorized_keys` strips it.
+- Promotion flips a label on the same image ID (`hcloud image add-label
+  --overwrite`). AWS re-tags an immutable AMI. Same fail-safe ordering.
+- No `deprecate_at`: retention is `prune.sh` (see above).
+- Lineage provenance is `base_image`+`base_mode` labels, not parent-image IDs
+  (no source-image interpolation in the hcloud builder).
+- SELinux gate asserts NOT disabled (vs enforcing on AWS): the mode Hetzner's
+  official images ship is unverified. Tighten once the seeds prove enforcing.

--- a/ppg/packer-hetzner/README.md
+++ b/ppg/packer-hetzner/README.md
@@ -132,13 +132,15 @@ defaults to list-only, and anything listed or deleted posts a Slack alert.
 
 ## Token
 
-One project-scoped Hetzner API token, exported as `HCLOUD_TOKEN` locally and
-stored as the `HCLOUD_TOKEN_PPG_FACTORY` secret in the `hcloud-factory`
-GitHub environment for the workflows. The environment's protected-branch
-deployment rule keeps a branch-ref dispatch from ever reading the secret. It
-never appears in files or output. `check`/`fmt`/`validate` run tokenless (the
-plugin insists on a non-empty token even offline, so `check.sh` exports an
-inert placeholder).
+One project-scoped Hetzner API token, exported as `HCLOUD_TOKEN` locally. The
+workflows keep no Hetzner credential in GitHub: each token-using job assumes
+a GitHub-OIDC AWS role whose trust is pinned to master (exact-subject
+`StringEquals`, no wildcards) and reads the token from the
+`/ppg/hcloud-factory-token` SSM SecureString parameter (both defined in
+percona-cd-platform `terraform/iam-gha-ppg-hcloud-factory.tf`), so a
+branch-ref dispatch fails at AssumeRole. The token never appears in files or
+output. `check`/`fmt`/`validate` run tokenless (the plugin insists on a
+non-empty token even offline, so `check.sh` exports an inert placeholder).
 
 ## Deviations from the AWS factory
 

--- a/ppg/packer-hetzner/bootstrap/bootstrap-base.sh
+++ b/ppg/packer-hetzner/bootstrap/bootstrap-base.sh
@@ -1,0 +1,275 @@
+#!/usr/bin/env bash
+# OL base-snapshot bootstrap - upload Oracle's official OL cloud image to
+# Hetzner Cloud as the ppg-base snapshot the refresh template's oraclelinux
+# seed sources (one-time per major x arch, OL has no Hetzner system image).
+# Sibling of the AWS factory's scripts/bootstrap-ol10.sh (../../packer).
+#
+# Flow:  download official qcow2 (checksum-verified) -> hcloud-upload-image
+#        (rescue-mode dd via a temp server) -> role=ppg-base snapshot
+#        -> boot check (fresh cpx32 server from the snapshot, identity +
+#        cloud-init + dnf asserts) -> delete the check server + key.
+#
+# Login user on Hetzner (verified empirically on OL9U8, 2026-08-05): ROOT,
+# but only with user-data `disable_root: false` at server create. Hetzner's
+# vendor-data (embedded in the metadata DataSourceHetzner consumes) resolves
+# cloud-init's default user to root, overriding the image's cloud-user. The
+# image's stock `disable_root: true` then wraps root's injected key in a
+# "Please login as..." command stub, leaving NO ssh-able account at all on a
+# pristine boot. The one-line user-data un-stubs root. The snapshot itself
+# stays pristine Oracle. The refresh template's oraclelinux seed passes the
+# same user-data and bakes the override in for the rest of the lineage.
+#
+# Per-major source: x86_64 KVM templates from
+# yum.oracle.com/oracle-linux-templates.html (bump build bNNN + sha as Oracle
+# republishes). Only OL9 is boot-verified on Hetzner so far. OL8/OL10 entries
+# carry Oracle's published checksums but their first upload must be watched.
+# arm64 is NOT wired up: CAX server types have zero stock in fsn1/nbg1/hel1
+# (verified 2026-08-05), so an arm64 base could not be boot-checked. Add the
+# aarch64 -kvm-cloud- sources once CAX stock returns.
+#
+#   Usage:  HCLOUD_TOKEN in env, then
+#           ./bootstrap-base.sh            # OL9 x86_64
+#           OS_MAJOR=8 ./bootstrap-base.sh
+#
+# Idempotent: an existing ppg-base snapshot for the combo skips the download/
+# upload (FORCE=1 re-uploads without deleting the old base - prune manually).
+# The boot check always runs against the newest base. On a boot-check failure
+# the snapshot is KEPT for forensics. The printed id makes manual deletion a
+# one-liner. Every server/key this script creates is deleted on exit.
+set -euo pipefail
+
+# Linux-only: the body relies on GNU stat -c/sha256sum and bash >= 4.4
+# empty-array expansion ("${upload_compression[@]}" under set -u), all of
+# which break on the macOS/BSD userland.
+[[ "$(uname -s)" = "Linux" ]] || {
+  echo "bootstrap-base.sh must run on Linux (GNU stat/sha256sum, bash >= 4.4); got $(uname -s)" >&2
+  exit 1
+}
+
+: "${HCLOUD_TOKEN:?export the project-scoped factory token}"
+
+OS_MAJOR="${OS_MAJOR:-9}"
+ARCH="${ARCH:-x86_64}"
+FORCE="${FORCE:-0}"
+
+# Upload server: its DISK size becomes the snapshot's min-disk floor for every
+# future consumer, so use the smallest type the 37 GiB image fits, cx23 (40GB,
+# in stock in nbg1 as of 2026-08-05), with cpx22/fsn1 as the 80GB fallback.
+UPLOAD_SERVER_TYPE="${UPLOAD_SERVER_TYPE:-cx23}"
+UPLOAD_LOCATION="${UPLOAD_LOCATION:-nbg1}"
+
+# Boot check server: same family the factory builds with. Gen-1 cpx31/cpx41
+# are out of stock in fsn1/nbg1/hel1, so cpx32 is the current x86 tier.
+CHECK_SERVER_TYPE="${CHECK_SERVER_TYPE:-cpx32}"
+CHECK_LOCATION="${CHECK_LOCATION:-fsn1}"
+
+# hcloud-upload-image: pinned exact + checksum-verified (supply-chain, same
+# rationale as the packer plugin pin in ../refresh.pkr.hcl).
+UPLOADER_VERSION="${UPLOADER_VERSION:-1.5.0}"
+
+case "${ARCH}" in
+  x86_64)
+    # The upload passes --server-type (implies x86). Nothing else to derive.
+    ;;
+  arm64)
+    echo "arm64 bases are not wired up yet: CAX (arm64) server types have zero" >&2
+    echo "stock in fsn1/nbg1/hel1, so the boot check cannot run. Re-attempt" >&2
+    echo "when CAX stock returns (and add the aarch64 -kvm-cloud- source here)." >&2
+    exit 1
+    ;;
+  *)
+    echo "ARCH must be x86_64 or arm64 (got '${ARCH}')" >&2
+    exit 1
+    ;;
+esac
+
+# Oracle's published per-image SHA256 (the kvm-sha256 column of the templates
+# page). The qcow2 must stay under the rescue system's ~960MB tmpfs cap, or
+# the upload needs a local `qemu-img convert -O raw` + --compression instead.
+case "${OS_MAJOR}" in
+  8)
+    src_url="https://yum.oracle.com/templates/OracleLinux/OL8/u10/x86_64/OL8U10_x86_64-kvm-b287.qcow2"
+    src_sha256="cf9eb243b7390311f1e2896e3e6849241e521e6592c8be9907956e3a6cee1f0c"
+    ;;
+  9)
+    src_url="https://yum.oracle.com/templates/OracleLinux/OL9/u8/x86_64/OL9U8_x86_64-kvm-b293.qcow2"
+    src_sha256="b12103391327abee8090686759c0d62dac9a7af2bf0f45fdf6b0d085a0fbb52b"
+    ;;
+  10)
+    src_url="https://yum.oracle.com/templates/OracleLinux/OL10/u1/x86_64/OL10U1_x86_64-kvm-b291.qcow2"
+    src_sha256="8e59326c4bf7cfa58a6cac404db8ed583fe3a5f4c460e2b73c64988785bb4f0f"
+    ;;
+  *)
+    echo "OS_MAJOR must be 8, 9, or 10 (got '${OS_MAJOR}')" >&2
+    exit 1
+    ;;
+esac
+src_file="$(basename "${src_url}")"
+
+WORK="${WORK:-${TMPDIR:-/tmp}/ppg-ol-bootstrap}"
+mkdir -p "${WORK}/bin"
+stamp="$(date -u +%Y%m%d-%H%M%S)"
+base_selector="role=ppg-base,os=oraclelinux,os_major=${OS_MAJOR},arch=${ARCH}"
+log_step() { echo -e "\n=== $* ==="; }
+
+# --- ephemeral check resources: ALWAYS deleted, even on failure -------------
+check_server_name="ppg-bootstrap-check-ol${OS_MAJOR}-${ARCH//_/-}"
+check_key_name="ppg-bootstrap-check-${stamp}"
+check_key_file="${WORK}/check-key-${stamp}"
+cleanup() {
+  set +e
+  hcloud server delete "${check_server_name}" >/dev/null 2>&1 \
+    && echo "cleanup: deleted check server ${check_server_name}"
+  hcloud ssh-key delete "${check_key_name}" >/dev/null 2>&1 \
+    && echo "cleanup: deleted ssh key ${check_key_name}"
+  rm -f "${check_key_file}" "${check_key_file}.pub"
+}
+trap cleanup EXIT
+
+newest_base() {
+  hcloud image list -t snapshot -l "${base_selector}" -s created:desc \
+    -o noheader -o columns=id | head -1
+}
+
+# 1. Reuse an existing base for this combo unless FORCE=1. Never re-download,
+#    never delete the previous base (prune superseded bases manually).
+snapshot_id="$(newest_base)"
+if [[ -n "${snapshot_id}" && "${FORCE}" != 1 ]]; then
+  log_step "reuse existing ppg-base snapshot ${snapshot_id} (FORCE=1 re-uploads)"
+else
+  # 2. Download + verify Oracle's image (reuse a previously verified file).
+  log_step "download ${src_file} + verify Oracle's published sha256"
+  if [[ ! -f "${WORK}/${src_file}" ]]; then
+    curl -fsSL -o "${WORK}/${src_file}" "${src_url}"
+  fi
+  echo "${src_sha256}  ${WORK}/${src_file}" | sha256sum -c -
+
+  # Rescue-tmpfs cap: a qcow2 over ~900MB cannot be written directly (the
+  # rescue ramdisk holds the whole qcow2 before dd). Convert to raw + xz
+  # locally and the tool stream-decompresses straight to disk instead. The
+  # raw intermediate is sparse (xz reads the virtual size but writes small).
+  upload_file="${WORK}/${src_file}"
+  upload_format="qcow2"
+  upload_compression=()
+  qcow_bytes=$(stat -c %s "${WORK}/${src_file}")
+  if (( qcow_bytes > 900 * 1024 * 1024 )); then
+    log_step "qcow2 is $((qcow_bytes / 1024 / 1024))MB (over the rescue cap); convert to raw + xz"
+    command -v qemu-img >/dev/null || { echo "FATAL: qemu-img is required for the raw+xz path" >&2; exit 1; }
+    raw_file="${WORK}/${src_file%.qcow2}.raw"
+    if [[ ! -f "${raw_file}.xz" ]]; then
+      qemu-img convert -O raw "${WORK}/${src_file}" "${raw_file}"
+      xz -T0 -3 -f "${raw_file}"
+    fi
+    upload_file="${raw_file}.xz"
+    upload_format="raw"
+    upload_compression=(--compression xz)
+  fi
+
+  # 3. Ensure the pinned hcloud-upload-image host binary. The actual write
+  #    happens remotely in rescue mode, so local arch only picks the binary.
+  log_step "ensure hcloud-upload-image v${UPLOADER_VERSION}"
+  uploader="hcloud-upload-image"
+  if ! command -v "${uploader}" >/dev/null 2>&1; then
+    uploader="${WORK}/bin/hcloud-upload-image"
+    if [[ ! -x "${uploader}" ]]; then
+      host_os="$(uname -s)"                              # Linux | Darwin
+      host_arch="$(uname -m)"                            # x86_64 | aarch64
+      if [[ "${host_arch}" == "aarch64" ]]; then
+        host_arch=arm64
+      fi
+      release_base="https://github.com/apricote/hcloud-upload-image/releases/download/v${UPLOADER_VERSION}"
+      tarball="hcloud-upload-image_${host_os}_${host_arch}.tar.gz"
+      curl -fsSL -o "${WORK}/${tarball}" "${release_base}/${tarball}"
+      curl -fsSL -o "${WORK}/uploader-checksums.txt" \
+        "${release_base}/hcloud-upload-image_${UPLOADER_VERSION}_checksums.txt"
+      (cd "${WORK}" && grep "${tarball}" uploader-checksums.txt | sha256sum -c -)
+      tar -xzf "${WORK}/${tarball}" -C "${WORK}/bin" hcloud-upload-image
+    fi
+  fi
+  "${uploader}" version
+
+  # 4. Upload as the ppg-base snapshot (rescue-mode dd through a temp server
+  #    the tool creates and deletes, ~5 min). Label contract per ../README.md.
+  log_step "upload -> ppg-base snapshot (${UPLOAD_SERVER_TYPE}/${UPLOAD_LOCATION})"
+  "${uploader}" upload \
+    --image-path "${upload_file}" \
+    --format "${upload_format}" \
+    "${upload_compression[@]}" \
+    --server-type "${UPLOAD_SERVER_TYPE}" \
+    --location "${UPLOAD_LOCATION}" \
+    --description "PPG-Base-OL${OS_MAJOR}-${ARCH}-${stamp}" \
+    --labels "role=ppg-base,os=oraclelinux,os_major=${OS_MAJOR},arch=${ARCH},source=bootstrap"
+  snapshot_id="$(newest_base)"
+  [[ -n "${snapshot_id}" ]] || { echo "FATAL: upload reported success but no ${base_selector} snapshot found" >&2; exit 1; }
+  echo "uploaded base snapshot: ${snapshot_id}"
+fi
+
+# 5. Boot check: fresh server from the base, root SSH via the disable_root
+#    user-data (see header), fail-closed identity/health asserts.
+log_step "boot check ${snapshot_id} on ${CHECK_SERVER_TYPE}/${CHECK_LOCATION}"
+ssh-keygen -q -t ed25519 -f "${check_key_file}" -N ''
+# The role label makes a leaked key sweepable by scripts/janitor.sh.
+hcloud ssh-key create --name "${check_key_name}" \
+  --label role=ppg-bootstrap-check \
+  --public-key-from-file "${check_key_file}.pub" >/dev/null
+printf '#cloud-config\ndisable_root: false\n' > "${WORK}/check-user-data.yaml"
+hcloud server create --name "${check_server_name}" \
+  --type "${CHECK_SERVER_TYPE}" --location "${CHECK_LOCATION}" \
+  --image "${snapshot_id}" --ssh-key "${check_key_name}" \
+  --user-data-from-file "${WORK}/check-user-data.yaml" \
+  --label role=ppg-bootstrap-check >/dev/null
+check_ip="$(hcloud server ip "${check_server_name}")"
+
+ssh_opts=(-o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null
+  -o ConnectTimeout=5 -o BatchMode=yes -i "${check_key_file}")
+ssh_ready=""
+for _ in $(seq 1 60); do
+  if ssh "${ssh_opts[@]}" "root@${check_ip}" true 2>/dev/null; then
+    ssh_ready=1
+    break
+  fi
+  sleep 5
+done
+[[ -n "${ssh_ready}" ]] || { echo "BOOT CHECK FAIL: no root SSH on ${check_ip} after 5 min (snapshot ${snapshot_id} kept for forensics)" >&2; exit 1; }
+
+# shellcheck disable=SC2029  # the command string must expand on the remote side
+remote() { ssh "${ssh_opts[@]}" "root@${check_ip}" "$@"; }
+assert() {
+  local label="$1"
+  shift
+  if "$@"; then
+    echo "  ok: ${label}"
+  else
+    echo "BOOT CHECK FAIL: ${label} (snapshot ${snapshot_id} kept for forensics)" >&2
+    exit 1
+  fi
+}
+
+# shellcheck disable=SC2016  # $ID expands remotely by design
+found_id="$(remote '. /etc/os-release; echo "$ID"')"
+# shellcheck disable=SC2016  # $VERSION_ID expands remotely by design
+found_version="$(remote '. /etc/os-release; echo "$VERSION_ID"')"
+found_machine="$(remote uname -m)"
+echo "  identity: ID=${found_id} VERSION_ID=${found_version} $(remote uname -mr)"
+assert "os-release ID=ol"                 [ "${found_id}" = ol ]
+assert "os-release major=${OS_MAJOR}"     [ "${found_version%%.*}" = "${OS_MAJOR}" ]
+assert "arch=${ARCH}"                     [ "${found_machine}" = "${ARCH}" ]
+assert "cloud-init present"               remote 'command -v cloud-init >/dev/null'
+# Judge the cloud-init status TEXT, not the exit code, same rule as the smoke
+# template: EL10 images ship cloud-init 24.x, which exits 2 ("degraded done")
+# on Hetzner because the IPv4 link-local metadata probe times out even on the
+# pristine official images (key injection still works, via the retried
+# datasource paths). A boot that reaches done/disabled passes.
+ci_status="$(remote 'cloud-init status --wait 2>/dev/null' || true)"
+assert "cloud-init done/disabled"         grep -qE 'done|disabled' <<< "${ci_status}"
+assert "dnf makecache"                    remote 'dnf -q makecache >/dev/null'
+assert "CRB repo defined (ol${OS_MAJOR}_codeready_builder)" \
+  remote "dnf -q repolist --all 2>/dev/null | grep -q '^ol${OS_MAJOR}_codeready_builder'"
+echo "  context: selinux=$(remote getenforce) kernel=$(remote uname -r)"
+
+cat <<EOF
+
+BOOTSTRAP-BASE (OL${OS_MAJOR} ${ARCH}) COMPLETE.
+  base snapshot: ${snapshot_id}  (${base_selector},source=bootstrap)
+NEXT: just seed ${OS_MAJOR} ${ARCH} prod oraclelinux   # lineage root: bake + smoke + promote
+EOF

--- a/ppg/packer-hetzner/justfile
+++ b/ppg/packer-hetzner/justfile
@@ -1,0 +1,186 @@
+# EL snapshot factory (Rocky Linux + AlmaLinux on Hetzner Cloud) - local build
+# management. Sibling of the AWS AMI factory justfile (../packer/justfile).
+#
+# Runs the SAME packer templates + scripts the GitHub Actions workflow uses, so
+# a snapshot built locally is identical to a CI-built one. Recipes are
+# parameterized by os / os_major / arch / env, and every factory-identity
+# constant (labels, roles, location, server types) is a VARIABLE below -- to
+# lift this dir to another product, relabel HERE (and in the packer templates'
+# label blocks) and point a new consumer at the labels.
+#
+# Auth: `export HCLOUD_TOKEN=...` first (project-scoped factory token). The
+# token is read from the environment by packer and the hcloud CLI directly and
+# is never echoed. check/fmt/validate need no real token.
+#
+# env=prod  -> real labels the consumers select (role={{role_prod}}, source=factory)
+# env=test  -> isolated labels (role={{role_test}}, source=factory-test, factory_env=test),
+#              NEVER consumed by production. Use for local/CI testing, then `just prune test`.
+
+# --- factory identity: SINGLE SOURCE OF TRUTH (relabel here to lift this dir to another product) ---
+location        := "fsn1"                       # CAX (arm64) exists only in fsn1/nbg1/hel1
+role_prod       := "ppg-package-test"           # promoted role the consumers select
+role_test       := "ppg-test-package-test"      # isolated promoted role for env=test bakes
+keep_last       := "4"                          # promoted snapshots kept per combo by prune
+
+# --- build matrix dimensions ---
+os_list         := "rocky almalinux"
+os_majors       := "8 9 10"
+arches          := "x86_64 arm64"
+
+# list recipes
+default:
+    @just --list
+
+# ===========================================================================
+# generic helpers (private, hidden from --list)
+# ===========================================================================
+
+# fail fast when the live-API token is missing (never echoes it). The check/
+# fmt/validate recipes stay tokenless on purpose
+_need-token:
+    @[ -n "${HCLOUD_TOKEN:-}" ] || { echo "HCLOUD_TOKEN not set (export the project-scoped factory token)" >&2; exit 1; }
+
+# ===========================================================================
+# packer build / validate (refresh path, lineage roots via seed)
+# ===========================================================================
+
+# install/upgrade the hcloud plugin
+init:
+    packer init .
+
+# format the HCL (main + smoke templates)
+fmt:
+    packer fmt .
+    packer fmt smoke
+
+# validate one combo  (os_major=8|9|10  arch=x86_64|arm64  os=rocky|almalinux)
+validate os_major="9" arch="x86_64" os="rocky":
+    HCLOUD_TOKEN="${HCLOUD_TOKEN:-offline-validate-placeholder}" \
+      packer validate -var os={{os}} -var os_major={{os_major}} -var arch={{arch}} .
+
+# fmt-check + validate everything + drift guards (scripts/check.sh, the SAME
+# file the workflow check job runs, so the two gates cannot drift) + actionlint
+check:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    bash scripts/check.sh
+
+    if command -v actionlint >/dev/null; then
+      actionlint ../../.github/workflows/ppg-hcloud-factory.yml ../../.github/workflows/ppg-hcloud-janitor.yml
+    else
+      echo "actionlint not installed; skipping workflow lint"
+    fi
+
+# trigger the GHA factory workflow for the FULL os x major x arch matrix, derived
+# from the dimension constants above so it never drifts from them. Targets the
+# current repo's origin. env=test isolates from the consumers (use for validation).
+[doc("trigger the GHA factory workflow for the full 12-combo matrix (env=test isolates)")]
+ci-validate ref="master" env="test":
+    #!/usr/bin/env bash
+    set -euo pipefail
+    combos=$(python3 -c "import json,sys; oses,majors,arches=(part.split() for part in sys.argv[1:4]); print(json.dumps([{'os':os_name,'os_major':major,'arch':arch} for os_name in oses for major in majors for arch in arches]))" "{{os_list}}" "{{os_majors}}" "{{arches}}")
+    gh workflow run ppg-hcloud-factory.yml --ref "{{ref}}" -f "env={{env}}" -f "combos=${combos}"
+    echo "dispatched {{ref}} (env={{env}}) with the full matrix; list runs: gh run list --workflow ppg-hcloud-factory.yml -L1"
+
+# dispatch the GHA workflow to seed ALL twelve lineage roots from the official
+# Hetzner system images. Defaults to env=prod like seed: a test seed promotes
+# only the isolated test role, which the prod-role refresh lineage lookup never
+# sees (env=test validates only).
+[doc("dispatch the GHA workflow to seed all 12 lineage roots (env=prod|test)")]
+ci-seed ref="master" env="prod":
+    #!/usr/bin/env bash
+    set -euo pipefail
+    combos=$(python3 -c "import json,sys; oses,majors,arches=(part.split() for part in sys.argv[1:4]); print(json.dumps([{'os':os_name,'os_major':major,'arch':arch,'seed':True} for os_name in oses for major in majors for arch in arches]))" "{{os_list}}" "{{os_majors}}" "{{arches}}")
+    gh workflow run ppg-hcloud-factory.yml --ref "{{ref}}" -f "env={{env}}" -f "combos=${combos}"
+    echo "dispatched {{ref}} (env={{env}}) with all 12 seeds; list runs: gh run list --workflow ppg-hcloud-factory.yml -L1"
+
+# build one combo  (env=prod real labels | test isolated labels)  -- candidate only, no promote
+build os_major="9" arch="x86_64" env="prod" os="rocky" seed="false": _need-token
+    #!/usr/bin/env bash
+    set -euo pipefail
+    rm -f manifest.json
+    packer build -color=false \
+      -var os={{os}} -var seed={{seed}} -var os_major={{os_major}} -var arch={{arch}} \
+      -var env={{env}} -var location={{location}} .
+
+# smoke-test (fresh boot + install) an already-built candidate snapshot, then
+# promote on success. Both steps are the SAME scripts the workflow runs:
+# scripts/smoke-run.sh deletes the candidate only on a genuine post-SSH
+# failure (sentinel-gated, transient infrastructure failures keep it), and
+# scripts/promote.sh retries the label flip so a transient promote failure
+# never deletes a smoke-passed snapshot.
+[doc("smoke-test (boot+install) a candidate snapshot then promote on pass; delete only on genuine post-SSH failure")]
+smoke snapshot_id os_major arch env="prod" os="rocky": _need-token
+    #!/usr/bin/env bash
+    set -euo pipefail
+    bash scripts/smoke-run.sh {{snapshot_id}} {{os_major}} {{arch}} {{env}} {{os}} {{location}}
+    bash scripts/promote.sh {{snapshot_id}} {{env}}
+
+# full one-combo factory run: build (env) -> native smoke boot-test -> promote
+bake os_major="9" arch="x86_64" env="prod" os="rocky" seed="false": _need-token
+    #!/usr/bin/env bash
+    set -euo pipefail
+    just build {{os_major}} {{arch}} {{env}} {{os}} {{seed}}
+    snapshot_id=$(python3 -c "import json;print(json.load(open('manifest.json'))['builds'][-1]['artifact_id'])")
+    just smoke "${snapshot_id}" {{os_major}} {{arch}} {{env}} {{os}}
+
+# isolated TEST bake of one combo (env=test) - never consumed by production
+test os_major="9" arch="x86_64" os="rocky":
+    @just bake {{os_major}} {{arch}} test {{os}}
+
+# one-time per combo: seed a lineage root from the official Hetzner system image
+# (rocky-<major> / alma-<major>), then smoke + promote. After this,
+# `just bake <os_major> <arch> prod <os>` refreshes it. Defaults to env=prod like
+# `bake`: a test seed promotes only the isolated test role, which the refresh
+# lineage lookup (pinned to the prod role) never sees.
+[doc("seed a lineage root from the official Hetzner system image: bake + smoke + promote (env=test isolates)")]
+seed os_major="9" arch="x86_64" env="prod" os="rocky":
+    @just bake {{os_major}} {{arch}} {{env}} {{os}} true
+
+# build + promote ALL major x arch for one os (env=prod by default, pass test for
+# isolated). Resilient: a failed combo is recorded and the rest still run. Exits
+# non-zero with a summary if any combo failed (each combo's own delete-on-smoke-
+# failure still applies).
+[doc("build + promote every major x arch for one os (env=prod|test); resilient, non-zero if any combo fails")]
+all env="prod" os="rocky":
+    #!/usr/bin/env bash
+    set -uo pipefail
+    ok=""
+    fail=""
+
+    for major in {{os_majors}}; do
+      for arch in {{arches}}; do
+        echo "=========== bake {{os}} ${major} ${arch} (env={{env}}) ==========="
+
+        if just bake "${major}" "${arch}" {{env}} {{os}}; then
+          ok="${ok} {{os}}${major}-${arch}"
+        else
+          fail="${fail} {{os}}${major}-${arch}"
+        fi
+      done
+    done
+    echo "=========== summary (env={{env}}) ==========="
+    echo "  ok:    ${ok:- none}"
+    echo "  failed:${fail:- none}"
+    [[ -z "${fail}" ]] || exit 1
+
+# list factory snapshots for an env (prod|test) with identity + creation date
+list env="prod": _need-token
+    hcloud image list -t snapshot -l "factory_env={{env}}" -s created:desc \
+      -o columns=id,description,labels,created
+
+# resolve the newest promoted snapshot for a combo (exactly the consumer lookup)
+latest os_major="9" arch="x86_64" os="rocky" role=role_prod: _need-token
+    hcloud image list -t snapshot \
+      -l "role={{role}},os={{os}},os_major={{os_major}},arch={{arch}}" \
+      -s created:desc -o noheader -o columns=id | head -1
+
+# promote a smoke-passed candidate (retried label flip via scripts/promote.sh)
+promote snapshot_id env="prod": _need-token
+    bash scripts/promote.sh {{snapshot_id}} {{env}}
+
+# retention sweep (scripts/prune.sh): keep newest {{keep_last}} promoted per
+# combo + remove stale candidates. Lists by default. Pass apply=1 to delete.
+[doc("keep newest N promoted per combo + drop stale candidates; lists unless apply=1")]
+prune env="prod" apply="0" keep=keep_last: _need-token
+    bash scripts/prune.sh {{env}} {{apply}} {{keep}}

--- a/ppg/packer-hetzner/refresh.pkr.hcl
+++ b/ppg/packer-hetzner/refresh.pkr.hcl
@@ -1,0 +1,267 @@
+# EL package-test snapshot factory (refresh path): Rocky Linux, AlmaLinux, and
+# Oracle Linux on Hetzner Cloud. Sibling of the AWS AMI factory
+# (../packer/refresh.pkr.hcl).
+#
+# Rebakes a current package-test target snapshot from the newest self-owned
+# promoted snapshot of the same os+major+arch: create server -> dnf update ->
+# validate (fail-closed) -> snapshot. Chains forward (each build's output is
+# the next build's source).
+#
+# Usage (one combo per invocation, HCLOUD_TOKEN in env):
+#   packer init .
+#   packer build -var os=rocky -var os_major=9 -var arch=x86_64 .
+#   packer build -var os=almalinux -var os_major=9 -var arch=arm64 .
+#
+# Lineage roots: every combo seeds once with `-var seed=true`, which sources
+# the official Hetzner system image (rocky-8/9/10, alma-8/9/10, both arches)
+# instead of the self-owned lineage. Once the seed is promoted, refreshes here
+# chain from it. Oracle Linux has no Hetzner system image: an oraclelinux seed
+# sources the newest role=ppg-base snapshot instead, uploaded from Oracle's
+# official KVM image by bootstrap/bootstrap-base.sh (one-time per combo).
+
+packer {
+  required_plugins {
+    hcloud = {
+      source = "github.com/hetznercloud/hcloud"
+      # Pinned exact (supply-chain): a float would let `packer init` pull newer
+      # plugin code under the factory token. Bump deliberately.
+      version = "1.7.2"
+    }
+  }
+}
+
+variable "location" {
+  type    = string
+  default = "fsn1"
+  validation {
+    # Both arches of a combo must bake somewhere CAX (arm64) exists, which is
+    # only fsn1/nbg1/hel1. Pinning the x86 half to the same trio keeps every
+    # lineage in one location family.
+    condition     = contains(["fsn1", "nbg1", "hel1"], var.location)
+    error_message = "Value of location must be fsn1, nbg1, or hel1 (CAX arm64 servers exist only there)."
+  }
+}
+
+variable "os_major" {
+  type    = string # "8" | "9" | "10"
+  default = "9"
+  validation {
+    condition     = contains(["8", "9", "10"], var.os_major)
+    error_message = "Value of os_major must be 8, 9, or 10."
+  }
+}
+
+variable "arch" {
+  type    = string # "x86_64" | "arm64"
+  default = "x86_64"
+  validation {
+    condition     = contains(["x86_64", "arm64"], var.arch)
+    error_message = "Value of arch must be x86_64 or arm64."
+  }
+}
+
+variable "os" {
+  type    = string # "rocky" | "almalinux" | "oraclelinux"
+  default = "rocky"
+  validation {
+    condition     = contains(["rocky", "almalinux", "oraclelinux"], var.os)
+    error_message = "Value of os must be rocky, almalinux, or oraclelinux."
+  }
+}
+
+variable "seed" {
+  type        = bool
+  default     = false
+  description = "First bake per combo: source the official Hetzner system image (rocky/almalinux) or the bootstrap-uploaded role=ppg-base snapshot (oraclelinux) instead of the self-owned lineage snapshot. After the seed is promoted, the normal refresh takes over."
+}
+
+variable "server_type_x86" {
+  type        = string
+  default     = "cpx32"
+  description = "Builder server type for x86_64 combos (shared-vCPU AMD). The gen-1 cpx#1 types are no longer offered in fsn1/nbg1/hel1; cpx32 is the current 4c/8GB generation there."
+}
+
+variable "server_type_arm" {
+  type        = string
+  default     = "cax21"
+  description = "Builder server type for arm64 combos (Ampere; CAX exists only in fsn1/nbg1/hel1)."
+}
+
+variable "env" {
+  type        = string
+  default     = "prod"
+  description = "prod = real factory labels the consumers select; test = temporary isolated labels (role=ppg-test-*, source=factory-test) so test bakes are never consumed by production."
+  validation {
+    condition     = contains(["prod", "test"], var.env)
+    error_message = "Value of env must be prod or test."
+  }
+}
+
+locals {
+  server_type = var.arch == "arm64" ? var.server_type_arm : var.server_type_x86
+  uname_arch  = var.arch == "arm64" ? "aarch64" : "x86_64"
+  # Label values allow only alnum/dash/underscore/dot, so the stamp carries no
+  # colons (formatdate over timestamp() is UTC).
+  ts = formatdate("YYYYMMDD-hhmmss", timestamp())
+  # Test bakes carry isolated labels so the production consumers (which select
+  # role=ppg-package-test, source=factory) never pick them up.
+  candidate_role = var.env == "test" ? "ppg-test-candidate" : "ppg-candidate"
+  src_label      = var.env == "test" ? "factory-test" : "factory"
+  os_short       = var.os == "rocky" ? "Rocky" : var.os == "almalinux" ? "Alma" : "OL"
+  name_prefix    = var.env == "test" ? "TEST-PPG-" : "PPG-"
+  # Snapshots have no name in the Hetzner API, so snapshot_name lands in the
+  # image DESCRIPTION, which is where consumers see this identity string.
+  snapshot_name = "${local.name_prefix}${local.os_short}${var.os_major}-${var.arch}-${local.ts}"
+
+  # Seed source: the official Hetzner system images, named rocky-<major> /
+  # alma-<major>. One name covers both arches. The builder resolves it against
+  # the server type's architecture, so cax builders get the arm64 variant.
+  # "ol-<major>" is NOT an official image (none exists): for oraclelinux this
+  # local only feeds the base_image provenance label, and the seed sources the
+  # ppg-base snapshot below instead.
+  seed_image = "${var.os == "rocky" ? "rocky" : var.os == "almalinux" ? "alma" : "ol"}-${var.os_major}"
+
+  # Oracle Linux seed source: the newest base snapshot the bootstrap uploaded
+  # (bootstrap/bootstrap-base.sh, pristine Oracle KVM image). Env-blind like
+  # the lineage selector: test seeds read the same bases.
+  ol_seed = var.os == "oraclelinux" && var.seed
+  base_selector = [
+    "role=ppg-base",
+    "os=oraclelinux",
+    "os_major=${var.os_major}",
+    "arch=${var.arch}",
+    "source=bootstrap",
+  ]
+
+  # Oracle Linux only: Hetzner's vendor-data resolves cloud-init's default
+  # user to root, and Oracle's stock cloud.cfg ships `disable_root: true`,
+  # which wraps the injected key in a "Please login as..." stub, leaving NO
+  # ssh-able account on a pristine boot. This user-data un-stubs root for the
+  # build boot. provision.sh bakes the same override into the image so smoke,
+  # refresh, and consumer boots need no user-data (verified on OL9U8).
+  ol_user_data = "#cloud-config\ndisable_root: false\n"
+
+  # Refresh source: newest self-owned promoted snapshot of the same
+  # os+major+arch, selected by FACTORY LABELS (the analog of the AWS factory's
+  # source_ami_filter on tags): label selection only ever picks snapshots this
+  # factory (or the promoted seed rooting the lineage) produced. The role pin
+  # is env-blind by design: test bakes SOURCE the prod lineage (isolation
+  # applies to what they produce, not what they read), so a lineage root must
+  # be seeded with env=prod to be refreshable. The arch label is redundant with
+  # the builder's native architecture filter but kept explicit so the selector
+  # states the full combo. source=factory + smoke=passed pin the parent to a
+  # factory-produced, smoke-passed promoted snapshot: a manually labeled or
+  # test-leaked snapshot can never become a parent of the production lineage.
+  lineage_selector = [
+    "role=ppg-package-test",
+    "os=${var.os}",
+    "os_major=${var.os_major}",
+    "arch=${var.arch}",
+    "source=factory",
+    "smoke=passed",
+  ]
+
+  # Hostnames cannot carry underscores, so the server name flattens the arch.
+  hostname_arch = replace(var.arch, "_", "-")
+}
+
+source "hcloud" "el" {
+  location    = var.location
+  server_type = local.server_type
+  server_name = "ppg-factory-${var.os}${var.os_major}-${local.hostname_arch}"
+
+  # Plain SSH as root: Hetzner injects Packer's temp key at server create (via
+  # cloud-init on snapshot sources), and ssh_clear_authorized_keys strips it
+  # from the image natively before the snapshot is taken.
+  ssh_username              = "root"
+  ssh_timeout               = "10m"
+  ssh_clear_authorized_keys = true
+
+  # Seed: official system image by name (rocky/alma) or the ppg-base snapshot
+  # by label selector (oraclelinux, which has no official image). Refresh:
+  # newest promoted lineage snapshot by label selector. Name and filter are
+  # mutually exclusive in the plugin (image XOR image_filter), hence the
+  # null / dynamic-block split.
+  image = var.seed && !local.ol_seed ? local.seed_image : null
+
+  dynamic "image_filter" {
+    for_each = var.seed && !local.ol_seed ? [] : [1]
+    content {
+      with_selector = local.ol_seed ? local.base_selector : local.lineage_selector
+      most_recent   = true
+    }
+  }
+
+  # OL only (harmless re-assert on lineage boots): unlock root SSH. See the
+  # ol_user_data local. Null omits the attribute for rocky/alma.
+  user_data = var.os == "oraclelinux" ? local.ol_user_data : null
+
+  # Builder-server labels: identify leaked builders (a crashed run leaves the
+  # server behind) without touching anything not carrying these labels.
+  server_labels = {
+    role        = "ppg-factory-builder"
+    factory_env = var.env
+    os          = var.os
+    os_major    = var.os_major
+    arch        = var.arch
+  }
+
+  # role=ppg-candidate at build time. The fresh-boot smoke test passes and the
+  # caller promotes (role -> ppg-package-test, what the lineage selector and
+  # the consumers select). A non-booting image therefore never becomes
+  # selectable. base_image/base_mode replace the AWS base_ami/base_name pair:
+  # the hcloud builder exposes no source-image interpolation, so the labels
+  # record the official image family the lineage descends from (base_image)
+  # and whether this bake sourced it directly or via the chain (base_mode).
+  snapshot_name = local.snapshot_name
+  snapshot_labels = {
+    role        = local.candidate_role
+    os          = var.os
+    os_major    = var.os_major
+    arch        = var.arch
+    source      = local.src_label
+    factory_env = var.env
+    factory_run = local.ts
+    base_image  = local.seed_image
+    base_mode   = var.seed ? "seed" : "lineage"
+  }
+}
+
+build {
+  name    = "ppg-el-refresh"
+  sources = ["source.hcloud.el"]
+
+  provisioner "shell" {
+    script = "${path.root}/scripts/provision.sh"
+    # OS drives the script's oraclelinux-only branch (root-login override).
+    environment_vars = [
+      "OS=${var.os}",
+    ]
+    # The build runs as root (Hetzner default login), so no sudo wrapper. env
+    # passes packer's vars as arguments, immune to any shell env filtering.
+    execute_command = "env {{ .Vars }} bash '{{ .Path }}'"
+  }
+
+  # Fail-closed identity/health gates: a failure here aborts the build, so a
+  # broken image is never snapshotted.
+  provisioner "shell" {
+    script = "${path.root}/scripts/validate.sh"
+    environment_vars = [
+      "OS=${var.os}",
+      "OS_MAJOR=${var.os_major}",
+      "UNAME_ARCH=${local.uname_arch}",
+    ]
+    execute_command = "env {{ .Vars }} bash '{{ .Path }}'"
+  }
+
+  post-processor "manifest" {
+    output     = "${path.root}/manifest.json"
+    strip_path = true
+    custom_data = {
+      os            = var.os
+      os_major      = var.os_major
+      arch          = var.arch
+      snapshot_name = local.snapshot_name
+    }
+  }
+}

--- a/ppg/packer-hetzner/refresh.pkr.hcl
+++ b/ppg/packer-hetzner/refresh.pkr.hcl
@@ -206,10 +206,8 @@ source "hcloud" "el" {
     arch        = var.arch
   }
 
-  # The plugin uploads a temporary packer-<uuid> SSH key per build and labels
-  # it with ONLY this map. Without it a killed run leaves an unlabeled key no
-  # janitor selector can positively identify, so it would leak forever. Same
-  # role contract as the builder server (the janitor sweeps both kinds).
+  # Label the plugin's temporary per-build SSH key so the janitor can sweep
+  # keys leaked by killed runs (an unlabeled key matches no selector).
   ssh_keys_labels = {
     role        = "ppg-factory-builder"
     factory_env = var.env

--- a/ppg/packer-hetzner/refresh.pkr.hcl
+++ b/ppg/packer-hetzner/refresh.pkr.hcl
@@ -206,6 +206,18 @@ source "hcloud" "el" {
     arch        = var.arch
   }
 
+  # The plugin uploads a temporary packer-<uuid> SSH key per build and labels
+  # it with ONLY this map. Without it a killed run leaves an unlabeled key no
+  # janitor selector can positively identify, so it would leak forever. Same
+  # role contract as the builder server (the janitor sweeps both kinds).
+  ssh_keys_labels = {
+    role        = "ppg-factory-builder"
+    factory_env = var.env
+    os          = var.os
+    os_major    = var.os_major
+    arch        = var.arch
+  }
+
   # role=ppg-candidate at build time. The fresh-boot smoke test passes and the
   # caller promotes (role -> ppg-package-test, what the lineage selector and
   # the consumers select). A non-booting image therefore never becomes

--- a/ppg/packer-hetzner/scripts/check.sh
+++ b/ppg/packer-hetzner/scripts/check.sh
@@ -1,0 +1,114 @@
+#!/bin/bash
+# Single no-API gate for the factory templates: fmt-check, validate every
+# os x major x arch combo (refresh + seed variants and the smoke template),
+# and the drift guards. Run from ppg/packer-hetzner. Both `just check` and the
+# workflow check job execute THIS file, so the two gates cannot drift apart.
+set -euo pipefail
+
+# The hcloud plugin refuses an empty token even for offline work (its config
+# Prepare errors before any API call, unlike the amazon plugin), so export an
+# inert placeholder when no real token is present: fmt and validate never call
+# the API, and the placeholder never leaves this process.
+export HCLOUD_TOKEN="${HCLOUD_TOKEN:-offline-validate-placeholder}"
+
+packer fmt -check -diff .
+packer fmt -check -diff smoke
+
+packer init .
+
+for os_name in rocky almalinux oraclelinux; do
+  for major in 8 9 10; do
+    for arch in x86_64 arm64; do
+      echo "validate ${os_name} ${major} ${arch}"
+      packer validate -var "os=${os_name}" -var "os_major=${major}" -var "arch=${arch}" .
+      echo "validate ${os_name} ${major} ${arch} seed"
+      packer validate -var "os=${os_name}" -var seed=true -var "os_major=${major}" -var "arch=${arch}" .
+    done
+  done
+done
+
+(
+  cd smoke
+  packer init .
+  packer validate -var candidate_image=100000000 -var os=rocky -var os_major=9 -var arch=x86_64 .
+  packer validate -var candidate_image=100000000 -var os=almalinux -var os_major=8 -var arch=arm64 .
+  packer validate -var candidate_image=100000000 -var os=oraclelinux -var os_major=9 -var arch=x86_64 .
+)
+
+# Drift guard: the promoted role literal must be identical in the justfile
+# (role_prod), the refresh template's lineage selector, the promote and prune
+# scripts, the workflow promote step's summary mapping, and the Jenkins env
+# var (vars/moleculeEnvPPGHetzner.groovy, whose selector documentation names
+# the promoted role + source=factory), else a promoted snapshot would never be
+# selected (or never retained) by one of them. The test role keeps the same
+# inline env-to-role copies as the AWS factory, guarded over its own consumers.
+role_prod=$(awk -F'"' '/^role_prod[[:space:]]*:=/{print $2; exit}' justfile)
+role_test=$(awk -F'"' '/^role_test[[:space:]]*:=/{print $2; exit}' justfile)
+
+if [[ -z "${role_prod}" || -z "${role_test}" ]]; then
+  echo "DRIFT: role_prod/role_test not found in justfile" >&2
+  exit 1
+fi
+
+for consumer in refresh.pkr.hcl scripts/promote.sh scripts/prune.sh \
+  ../../vars/moleculeEnvPPGHetzner.groovy ../../.github/workflows/ppg-hcloud-factory.yml; do
+  if ! grep -q -- "role=${role_prod}\|\"${role_prod}\"" "${consumer}"; then
+    echo "DRIFT: promoted role '${role_prod}' (justfile role_prod) missing from ${consumer}" >&2
+    exit 1
+  fi
+done
+
+for consumer in scripts/promote.sh scripts/prune.sh ../../.github/workflows/ppg-hcloud-factory.yml; do
+  if ! grep -q -- "role=${role_test}\|\"${role_test}\"" "${consumer}"; then
+    echo "DRIFT: test role '${role_test}' (justfile role_test) missing from ${consumer}" >&2
+    exit 1
+  fi
+done
+
+# The retention count lives in three places: the justfile keep_last default,
+# prune.sh's own default, and the literal the workflow prune job passes.
+keep_last=$(grep -oP 'keep_last\s+:=\s+"\K[0-9]+' justfile)
+
+if ! grep -q "keep=\"\${3:-${keep_last}}\"" scripts/prune.sh; then
+  echo "DRIFT: prune.sh default keep does not match justfile keep_last (${keep_last})" >&2
+  exit 1
+fi
+
+if ! grep -q "prune.sh prod 1 ${keep_last}" ../../.github/workflows/ppg-hcloud-factory.yml; then
+  echo "DRIFT: workflow prune job does not pass justfile keep_last (${keep_last})" >&2
+  exit 1
+fi
+
+# Packer HCL escapes ONLY $${ (and %%{). A bare $$ before anything else passes
+# through literally and the target shell then expands $$ to its process id,
+# which broke the AWS smoke identity check once. Fail on any $$ not followed by {.
+for template in refresh.pkr.hcl smoke/smoke.pkr.hcl; do
+  # shellcheck disable=SC2016  # the regex must stay literal, no expansion wanted
+  if grep -nE '\$\$([^{]|$)' "${template}"; then
+    echo "DRIFT: bare \$\$ in ${template} renders literally and the shell expands it to a PID; use \$\${...} for shell expansions" >&2
+    exit 1
+  fi
+done
+
+# The hcloud plugin must be pinned to ONE version across both templates, so a
+# supply-chain bump is all-or-nothing instead of drifting silently per file.
+hcloud_pin() {
+  awk '/hetznercloud\/hcloud/{f=1} f&&/version =/{gsub(/[^0-9.]/,"");print;exit}' "$1"
+}
+
+pins=""
+
+for template in refresh.pkr.hcl smoke/smoke.pkr.hcl; do
+  pins+="$(hcloud_pin "${template}")"$'\n'
+done
+
+pin_count=$(printf '%s' "${pins}" | grep -c .)
+unique_pins=$(printf '%s' "${pins}" | sort -u | grep -c .)
+
+if [[ "${pin_count}" -ne 2 || "${unique_pins}" -ne 1 ]]; then
+  echo "DRIFT: hcloud plugin pin not uniform across the 2 templates:" >&2
+  printf '%s' "${pins}" >&2
+  exit 1
+fi
+
+echo "check OK"

--- a/ppg/packer-hetzner/scripts/check.sh
+++ b/ppg/packer-hetzner/scripts/check.sh
@@ -111,4 +111,9 @@ if [[ "${pin_count}" -ne 2 || "${unique_pins}" -ne 1 ]]; then
   exit 1
 fi
 
+# Stubbed behavior tests (fake hcloud/packer, no API): the smoke-run identity
+# guard and the janitor's SSH-key selector coverage.
+bash tests/smoke-run-guard-test.sh
+bash tests/janitor-stub-test.sh
+
 echo "check OK"

--- a/ppg/packer-hetzner/scripts/janitor.sh
+++ b/ppg/packer-hetzner/scripts/janitor.sh
@@ -9,7 +9,10 @@
 #             (smoke/smoke.pkr.hcl), role=ppg-bootstrap-check
 #             (bootstrap/bootstrap-base.sh), role=ppg-molecule-test
 #             (ppg-testing playbooks/create-hetzner.yml)
-#   ssh keys: role=ppg-bootstrap-check, role=ppg-molecule-test
+#   ssh keys: the same four roles. Packer's temporary per-build keys carry
+#             role=ppg-factory-builder / role=ppg-smoke via ssh_keys_labels in
+#             the two templates; the bootstrap and molecule producers label
+#             the keys they upload themselves.
 # ppg_run (the molecule per-run label) is never a selector: it is a generic-
 # looking key another producer could plausibly use, and role=ppg-molecule-test
 # already covers everything that carries it.
@@ -36,6 +39,8 @@ readonly SERVER_SELECTORS=(
   'role=ppg-molecule-test'
 )
 readonly SSH_KEY_SELECTORS=(
+  'role=ppg-factory-builder'
+  'role=ppg-smoke'
   'role=ppg-bootstrap-check'
   'role=ppg-molecule-test'
 )

--- a/ppg/packer-hetzner/scripts/janitor.sh
+++ b/ppg/packer-hetzner/scripts/janitor.sh
@@ -1,0 +1,136 @@
+#!/usr/bin/env bash
+# Janitor for LEAKED Hetzner Cloud resources from the PPG factory and the
+# molecule package-test runs: servers a crashed bake/smoke/test left behind,
+# and the per-run SSH keys the molecule create playbook uploads.
+#
+# Selection is exclusively by the label contracts these producers set, so a
+# resource this janitor cannot positively identify is never touched:
+#   servers:  role=ppg-factory-builder (refresh.pkr.hcl), role=ppg-smoke
+#             (smoke/smoke.pkr.hcl), role=ppg-bootstrap-check
+#             (bootstrap/bootstrap-base.sh), role=ppg-molecule-test
+#             (ppg-testing playbooks/create-hetzner.yml)
+#   ssh keys: role=ppg-bootstrap-check, role=ppg-molecule-test
+# ppg_run (the molecule per-run label) is never a selector: it is a generic-
+# looking key another producer could plausibly use, and role=ppg-molecule-test
+# already covers everything that carries it.
+#
+# Age-bound: anything younger than the threshold is treated as a live run and
+# skipped (bakes finish in ~30 min, but long molecule suites can run past 2h,
+# hence the conservative 6h default), so the sweep never races in-flight work.
+# Resources without a created timestamp are never touched.
+#
+# Fail-safe: LISTS by default and deletes only on an exact apply=1.
+#
+# Usage (HCLOUD_TOKEN in env): janitor.sh [apply] [max_age_hours]
+#   apply:         0 list-only (default) | 1 delete
+#   max_age_hours: age threshold in hours (default 6)
+# Exit codes: 0 clean list or fully successful apply (prints deleted=<n> and
+#             delete_failures=<n>), 3 list mode found leaks (prints
+#             leaked=<n>), 1 apply had failed deletes, else a real failure
+set -euo pipefail
+
+readonly SERVER_SELECTORS=(
+  'role=ppg-factory-builder'
+  'role=ppg-smoke'
+  'role=ppg-bootstrap-check'
+  'role=ppg-molecule-test'
+)
+readonly SSH_KEY_SELECTORS=(
+  'role=ppg-bootstrap-check'
+  'role=ppg-molecule-test'
+)
+
+apply="${1:-0}"
+max_age_hours="${2:-6}"
+leaked_count=0
+delete_failures=0
+
+[[ "${max_age_hours}" =~ ^[0-9]+$ ]] \
+  || { echo "max_age_hours must be an integer (got '${max_age_hours}')" >&2; exit 1; }
+
+# stdin: hcloud JSON array. stdout: "id<TAB>name<TAB>age" for entries older
+# than the threshold. Entries without a created timestamp are dropped (never
+# delete what cannot be age-classified).
+filter_older_than() {
+  python3 -c '
+import datetime, json, sys
+threshold = datetime.timedelta(hours=int(sys.argv[1]))
+now = datetime.datetime.now(datetime.timezone.utc)
+for item in json.load(sys.stdin) or []:
+    created_raw = item.get("created")
+    if not created_raw:
+        continue
+    created = datetime.datetime.fromisoformat(created_raw.replace("Z", "+00:00"))
+    age = now - created
+    if age > threshold:
+        age_hours = age.total_seconds() / 3600
+        print("\t".join([str(item["id"]), item.get("name") or "-", "%.1fh" % age_hours]))
+' "${max_age_hours}"
+}
+
+# Delete on an exact apply=1 only. Any other value lists without deleting.
+# The delete itself is guarded: one failed delete (API blip, a protected
+# resource) must not abort the sweep before the remaining leaks are attempted.
+# Failures are counted and fail the run at the end.
+remove_resource() {
+  local kind="$1" resource_id="$2" reason="$3"
+  leaked_count=$((leaked_count + 1))
+  if [[ "${apply}" = "1" ]]; then
+    echo "  delete ${kind} ${resource_id} (${reason})"
+    if ! hcloud "${kind}" delete "${resource_id}"; then
+      delete_failures=$((delete_failures + 1))
+      echo "  FAILED to delete ${kind} ${resource_id} (continuing with the rest)" >&2
+    fi
+  else
+    echo "  would delete ${kind} ${resource_id} (${reason})"
+  fi
+}
+
+# kind is the hcloud subcommand (server | ssh-key). The remaining args are
+# label selectors that positively identify our own resources. Ids are
+# deduplicated before acting, so selectors that ever come to overlap cannot
+# double-count or double-delete.
+sweep() {
+  local kind="$1"
+  shift
+  local -A seen=()
+  local selector listing filtered resource_id name age
+  echo "${kind} sweep:"
+  for selector in "$@"; do
+    # Both captures are their own statements so a failing hcloud (or filter)
+    # kills the script under set -e: a swallowed listing failure would report
+    # a clean sweep over resources that were never actually listed.
+    listing=$(hcloud "${kind}" list -l "${selector}" -o json)
+    filtered=$(printf '%s' "${listing}" | filter_older_than)
+    while IFS=$'\t' read -r resource_id name age; do
+      [[ -z "${resource_id}" || -n "${seen[${resource_id}]:-}" ]] && continue
+      seen["${resource_id}"]=1
+      remove_resource "${kind}" "${resource_id}" "${name}, ${selector}, age ${age}"
+    done <<< "${filtered}"
+  done
+}
+
+main() {
+  echo "janitor (apply=${apply}; lists unless apply=1; threshold ${max_age_hours}h)"
+  sweep server "${SERVER_SELECTORS[@]}"
+  sweep ssh-key "${SSH_KEY_SELECTORS[@]}"
+
+  if [[ "${apply}" = "1" ]]; then
+    echo "deleted=$((leaked_count - delete_failures))"
+    echo "delete_failures=${delete_failures}"
+    echo "janitor done (apply=${apply})"
+    # Every delete was ATTEMPTED. Any failure still fails the run so the
+    # workflow alerts instead of reporting a clean apply.
+    [[ "${delete_failures}" -eq 0 ]] || exit 1
+    exit 0
+  fi
+
+  echo "leaked=${leaked_count}"
+  echo "janitor done (apply=${apply})"
+  # Exit 3 signals "leaks listed" distinctly from both a clean run (0) and a
+  # real failure (anything else), so the workflow can alert on leaks without
+  # treating a dirty list as a broken sweep.
+  [[ "${leaked_count}" -eq 0 ]] || exit 3
+}
+
+main "$@"

--- a/ppg/packer-hetzner/scripts/promote.sh
+++ b/ppg/packer-hetzner/scripts/promote.sh
@@ -1,0 +1,72 @@
+#!/usr/bin/env bash
+# Promote a smoke-passed candidate snapshot: flip its role label to the
+# promoted role the consumers and the refresh lineage selector pick up, and
+# record smoke=passed. `add-label --overwrite` replaces the candidate role
+# value in place, so no remove-label pass is needed.
+#
+# Retried: a transient label-API failure must never leave a smoke-passed
+# snapshot unpromoted, and this script NEVER deletes a snapshot (deleting a
+# failed candidate is the caller's job, before promotion is ever attempted).
+#
+# Usage (HCLOUD_TOKEN in env): promote.sh <snapshot_id> [prod|test]
+set -euo pipefail
+
+snapshot_id="${1:?usage: promote.sh <snapshot_id> [prod|test]}"
+factory_env="${2:-prod}"
+
+case "${factory_env}" in
+  prod)
+    role_promoted="ppg-package-test"
+    role_candidate="ppg-candidate"
+    ;;
+  test)
+    role_promoted="ppg-test-package-test"
+    role_candidate="ppg-test-candidate"
+    ;;
+  *)
+    echo "usage: promote.sh <snapshot_id> [prod|test]" >&2
+    exit 1
+    ;;
+esac
+
+# Fail-closed identity guard, BEFORE any label change: promote only an image
+# that is a candidate of the requested env. A wrong role or a factory_env
+# mismatch aborts with no changes, because promoting across envs would leak a
+# test bake into the production selector (and vice versa).
+image_json=$(hcloud image describe "${snapshot_id}" -o json)
+read -r image_role image_env <<< "$(python3 -c '
+import json, sys
+labels = json.load(sys.stdin).get("labels") or {}
+print(labels.get("role", "-"), labels.get("factory_env", "-"))
+' <<< "${image_json}")"
+image_role="${image_role/#-/}"
+image_env="${image_env/#-/}"
+mismatch=""
+
+if [[ "${image_role}" != "${role_candidate}" ]]; then
+  mismatch="${mismatch} role=${image_role:-<missing>} (want ${role_candidate})"
+fi
+
+if [[ "${image_env}" != "${factory_env}" ]]; then
+  mismatch="${mismatch} factory_env=${image_env:-<missing>} (want ${factory_env})"
+fi
+
+if [[ -n "${mismatch}" ]]; then
+  echo "FATAL: refusing to promote ${snapshot_id} for env=${factory_env}:${mismatch} (no labels changed)" >&2
+  exit 1
+fi
+
+for attempt in 1 2 3 4 5; do
+  if hcloud image add-label --overwrite "${snapshot_id}" \
+    "role=${role_promoted}" "smoke=passed"; then
+    echo "promoted ${snapshot_id} -> role=${role_promoted}"
+    exit 0
+  fi
+  if [[ "${attempt}" -lt 5 ]]; then
+    echo "promote attempt ${attempt} failed; retry in $((attempt * 5))s"
+    sleep $((attempt * 5))
+  fi
+done
+
+echo "FATAL: promote ${snapshot_id} -> role=${role_promoted} failed after retries (snapshot left intact for manual promote)" >&2
+exit 1

--- a/ppg/packer-hetzner/scripts/provision.sh
+++ b/ppg/packer-hetzner/scripts/provision.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+# Rocky Linux / AlmaLinux / Oracle Linux package-test target refresh
+# provisioner (Hetzner Cloud). Minimal by design: refresh packages and keep
+# the image close to a vanilla EL target so package tests stay faithful.
+# De-instancing of the temp SSH key is native (Packer
+# ssh_clear_authorized_keys). This script resets cloud-init + machine-id below
+# so a server created from the snapshot re-initialises. Runs as root (Hetzner
+# default login), no AWS agents to bake.
+#
+# Env (from packer): OS (rocky|almalinux|oraclelinux)
+set -euxo pipefail
+
+# Core refresh: absorb all pending errata.
+dnf -y update
+
+# Baseline tooling molecule/ansible drivers expect. These ship in the Hetzner
+# system images, so this is normally a no-op. Fail loudly if the base genuinely
+# lacks them.
+dnf -y install python3 cloud-init
+
+# Oracle Linux only: keep root ssh-able on every boot from this lineage.
+# Hetzner's vendor-data makes root cloud-init's default user, and Oracle's
+# stock cloud.cfg ships `disable_root: true`, which stubs the injected key
+# (the pristine ppg-base boot needs user-data to unlock, passed by the
+# refresh template). Baking the override means smoke, consumer, and refresh
+# boots need no user-data. Rocky/Alma ship root login natively (no override
+# needed).
+if [[ "${OS:-}" = "oraclelinux" ]]; then
+  printf 'disable_root: false\n' > /etc/cloud/cloud.cfg.d/95_hetzner_root.cfg
+fi
+
+dnf clean all
+rm -rf /var/cache/dnf
+
+# Reset cloud-init + machine-id so a server created from the snapshot
+# re-initialises: fresh instance ID, regenerated host keys, and the SSH key
+# Hetzner passes at create time gets applied. The temp build key is cleared
+# natively by Packer (ssh_clear_authorized_keys) after the build.
+cloud-init clean --logs
+rm -rf /var/lib/cloud/instances
+: > /etc/machine-id
+
+echo "PROVISION OK: $(. /etc/os-release; echo "${PRETTY_NAME}") $(uname -m)"

--- a/ppg/packer-hetzner/scripts/prune.sh
+++ b/ppg/packer-hetzner/scripts/prune.sh
@@ -1,0 +1,114 @@
+#!/usr/bin/env bash
+# Retention for the Hetzner factory snapshots: keep the newest N promoted
+# snapshots per os x major x arch combo, and remove stale candidates left by
+# runs that died between build and their smoke/promote/delete step. This is
+# the PRIMARY retention: Hetzner snapshots have no deprecate_at analog, so
+# without this sweep the weekly bakes accumulate unbounded.
+#
+# Fail-safe: LISTS by default and deletes only on an exact apply=1. Selection
+# is exclusively by the factory's own label contract (role + os + os_major +
+# arch + source), so a snapshot this factory cannot positively identify is
+# never touched, and the newest N promoted snapshots per combo are never
+# deleted (they are what the consumers and the refresh lineage select).
+#
+# Usage (HCLOUD_TOKEN in env): prune.sh [prod|test] [apply] [keep]
+#   apply: 0 list-only (default) | 1 delete
+#   keep:  promoted snapshots to keep per combo (default 2)
+#   STALE_HOURS (env): candidate age threshold in hours (default 24)
+set -euo pipefail
+
+factory_env="${1:-prod}"
+apply="${2:-0}"
+keep="${3:-4}"
+stale_hours="${STALE_HOURS:-168}"
+unpromoted_stale_hours="${UNPROMOTED_STALE_HOURS:-504}"
+
+case "${factory_env}" in
+  prod)
+    role_promoted="ppg-package-test"
+    role_candidate="ppg-candidate"
+    source_label="factory"
+    ;;
+  test)
+    role_promoted="ppg-test-package-test"
+    role_candidate="ppg-test-candidate"
+    source_label="factory-test"
+    ;;
+  *)
+    echo "usage: prune.sh [prod|test] [apply] [keep]" >&2
+    exit 1
+    ;;
+esac
+
+[[ "${keep}" =~ ^[0-9]+$ && "${keep}" -ge 1 ]] \
+  || { echo "keep must be a positive integer (got '${keep}')" >&2; exit 1; }
+[[ "${stale_hours}" =~ ^[0-9]+$ ]] \
+  || { echo "STALE_HOURS must be an integer (got '${stale_hours}')" >&2; exit 1; }
+
+echo "prune (env=${factory_env}, apply=${apply}; lists unless apply=1; keep=${keep} promoted per combo, candidates stale after ${stale_hours}h)"
+
+# Delete on an exact apply=1 only. Any other value lists without deleting.
+remove_snapshot() {
+  local snapshot_id="$1" reason="$2"
+  if [[ "${apply}" = "1" ]]; then
+    echo "  delete ${snapshot_id} (${reason})"
+    hcloud image delete "${snapshot_id}"
+  else
+    echo "  would delete ${snapshot_id} (${reason})"
+  fi
+}
+
+# Superseded promoted snapshots: per combo, keep the newest ${keep} (server-
+# side created:desc sort) and remove the rest. The full-combo selector is the
+# "don't delete what you can't identify" guard: only snapshots carrying every
+# factory label can ever match.
+for os_name in rocky almalinux oraclelinux; do
+  for os_major in 8 9 10; do
+    for arch in x86_64 arm64; do
+      selector="role=${role_promoted},os=${os_name},os_major=${os_major},arch=${arch},source=${source_label}"
+      superseded=$(hcloud image list -t snapshot -l "${selector}" -s created:desc \
+        -o noheader -o columns=id | tail -n "+$((keep + 1))")
+      while read -r snapshot_id; do
+        [[ -z "${snapshot_id}" ]] && continue
+        remove_snapshot "${snapshot_id}" "${os_name}${os_major} ${arch} superseded promoted"
+      done <<< "${superseded}"
+    done
+  done
+done
+
+# Stale candidates, two tiers. A candidate normally lives minutes (build ->
+# smoke -> promote or delete), so an unlabeled one older than the short
+# threshold is debris from a run that died in between (the age floor keeps
+# the sweep from racing an in-flight bake). A smoke-passed candidate whose
+# promote failed transiently is promote-retry material and gets the LONG
+# threshold instead: spared long enough for a human retry, but not immortal.
+list_stale() {
+  local selector="$1"
+  local threshold_hours="$2"
+
+  hcloud image list -t snapshot -l "${selector}" -o json \
+    | python3 -c '
+import datetime, json, sys
+threshold = datetime.datetime.now(datetime.timezone.utc) - datetime.timedelta(hours=int(sys.argv[1]))
+for image in json.load(sys.stdin) or []:
+    created = datetime.datetime.fromisoformat(image["created"].replace("Z", "+00:00"))
+    if created < threshold:
+        print(image["id"])
+' "${threshold_hours}"
+}
+
+stale_candidates=$(list_stale "role=${role_candidate},source=${source_label},smoke!=passed" "${stale_hours}")
+
+while read -r snapshot_id; do
+  [[ -z "${snapshot_id}" ]] && continue
+  remove_snapshot "${snapshot_id}" "stale candidate, older than ${stale_hours}h"
+done <<< "${stale_candidates}"
+
+unpromoted_passed=$(list_stale "role=${role_candidate},source=${source_label},smoke=passed" "${unpromoted_stale_hours}")
+
+while read -r snapshot_id; do
+  [[ -z "${snapshot_id}" ]] && continue
+  remove_snapshot "${snapshot_id}" "smoke-passed but unpromoted for ${unpromoted_stale_hours}h"
+done <<< "${unpromoted_passed}"
+
+echo "prune done (env=${factory_env}, apply=${apply})"

--- a/ppg/packer-hetzner/scripts/smoke-run.sh
+++ b/ppg/packer-hetzner/scripts/smoke-run.sh
@@ -1,0 +1,82 @@
+#!/usr/bin/env bash
+# Fresh-boot smoke gate for a candidate snapshot, shared by the justfile
+# `smoke` recipe and the workflow "Smoke test" step so the local and CI gates
+# cannot drift. Runs the native-Packer smoke build (smoke/smoke.pkr.hcl) and
+# gates the candidate delete on the SMOKE-PROVISIONER-STARTED sentinel the
+# template echoes as its first provisioner command:
+#
+#   fail WITH the sentinel:    SSH was up and the provisioner ran, so the
+#                              candidate genuinely fails boot/install ->
+#                              delete it, exit 1
+#   fail WITHOUT the sentinel: transient infrastructure (server create failed,
+#                              CAX stock-out, API 5xx, SSH timeout) -> KEEP
+#                              the candidate for a retry, exit 1
+#   pass:                      label the candidate smoke=passed (retried,
+#                              non-fatal) so a later transient promote failure
+#                              leaves it distinguishable from debris, exit 0
+#
+# Promotion stays the caller's separate retried step (scripts/promote.sh).
+#
+# Usage (HCLOUD_TOKEN in env, run from ppg/packer-hetzner):
+#   smoke-run.sh <snapshot_id> <os_major> <arch> [prod|test] [os] [location]
+set -euo pipefail
+
+usage="usage: smoke-run.sh <snapshot_id> <os_major> <arch> [prod|test] [os] [location]"
+snapshot_id="${1:?${usage}}"
+os_major="${2:?${usage}}"
+arch="${3:?${usage}}"
+factory_env="${4:-prod}"
+os_name="${5:-rocky}"
+location="${6:-fsn1}"
+
+sentinel_started="SMOKE-PROVISIONER-STARTED"
+sentinel_completed="SMOKE-PROVISIONER-COMPLETED"
+smoke_log="$(mktemp -t ppg-smoke-XXXXXX.log)"
+trap 'rm -f "${smoke_log}"' EXIT
+
+echo "smoke candidate ${snapshot_id} (${os_name}${os_major} ${arch}, env=${factory_env})"
+
+smoke_status=0
+( cd smoke && packer init . >/dev/null && \
+  packer build -color=false \
+    -var "candidate_image=${snapshot_id}" -var "os=${os_name}" \
+    -var "os_major=${os_major}" -var "arch=${arch}" \
+    -var "location=${location}" . ) 2>&1 | tee "${smoke_log}" \
+  || smoke_status=$?
+
+if [[ "${smoke_status}" -ne 0 ]]; then
+
+  # Delete only when the provisioner began and did not finish: that is a
+  # genuine boot/install failure. Failures before the provisioner (server
+  # create, SSH) and after it completed (packer teardown, API) keep the
+  # candidate. Residual window: a mid-provision transient (an SSH drop) is
+  # indistinguishable from an install hang and also deletes. A re-bake is
+  # the cheap retry for both.
+  if grep -qF "${sentinel_started}" "${smoke_log}" \
+    && ! grep -qF "${sentinel_completed}" "${smoke_log}"; then
+    echo "smoke (boot+install) failed after the provisioner started; deleting candidate ${snapshot_id}"
+    hcloud image delete "${snapshot_id}"
+  else
+    echo "transient failure outside the smoke provisioner, candidate ${snapshot_id} kept for retry"
+  fi
+
+  exit 1
+fi
+
+# Mark the pass on the image BEFORE the caller promotes: a transient promote
+# failure then leaves a candidate the prune sweep can tell apart from debris.
+# Non-fatal on label failure: the smoke PASSED, and promote.sh sets
+# smoke=passed again as part of the role flip.
+for attempt in 1 2 3; do
+  if hcloud image add-label --overwrite "${snapshot_id}" "smoke=passed"; then
+    break
+  fi
+  if [[ "${attempt}" -eq 3 ]]; then
+    echo "WARNING: could not label ${snapshot_id} smoke=passed after 3 attempts (continuing, promote.sh sets it too)" >&2
+  else
+    echo "smoke=passed label attempt ${attempt} failed; retry in $((attempt * 5))s"
+    sleep $((attempt * 5))
+  fi
+done
+
+echo "smoke passed for ${snapshot_id}"

--- a/ppg/packer-hetzner/scripts/smoke-run.sh
+++ b/ppg/packer-hetzner/scripts/smoke-run.sh
@@ -17,6 +17,11 @@
 #
 # Promotion stays the caller's separate retried step (scripts/promote.sh).
 #
+# The snapshot ID is untrusted input: a fail-closed identity guard (the
+# promote.sh pattern) describes the image before the boot and again right
+# before the delete, and refuses both unless every label of the expected
+# candidate combo matches.
+#
 # Usage (HCLOUD_TOKEN in env, run from ppg/packer-hetzner):
 #   smoke-run.sh <snapshot_id> <os_major> <arch> [prod|test] [os] [location]
 set -euo pipefail
@@ -29,12 +34,73 @@ factory_env="${4:-prod}"
 os_name="${5:-rocky}"
 location="${6:-fsn1}"
 
+case "${factory_env}" in
+  prod)
+    role_candidate="ppg-candidate"
+    source_expected="factory"
+    ;;
+  test)
+    role_candidate="ppg-test-candidate"
+    source_expected="factory-test"
+    ;;
+  *)
+    echo "${usage}" >&2
+    exit 1
+    ;;
+esac
+
+# Fail-closed identity guard, following the promote.sh pattern: describe the
+# image and require every label of the expected candidate combo before any
+# hcloud mutation. Runs BEFORE the boot and again immediately before the
+# delete, so a copied or mistyped ID (a promoted package-test snapshot, a
+# rollback, an OL base) is never booted by the smoke, let alone deleted by it.
+verify_candidate_identity() {
+  local stage="$1"
+  local image_json
+  image_json=$(hcloud image describe "${snapshot_id}" -o json)
+
+  local image_role image_env image_source image_os image_major image_arch
+  read -r image_role image_env image_source image_os image_major image_arch \
+    <<< "$(python3 -c '
+import json, sys
+labels = json.load(sys.stdin).get("labels") or {}
+keys = ("role", "factory_env", "source", "os", "os_major", "arch")
+print(" ".join(labels.get(key) or "-" for key in keys))
+' <<< "${image_json}")"
+
+  local mismatch=""
+  local check name want got
+
+  for check in \
+    "role|${role_candidate}|${image_role}" \
+    "factory_env|${factory_env}|${image_env}" \
+    "source|${source_expected}|${image_source}" \
+    "os|${os_name}|${image_os}" \
+    "os_major|${os_major}|${image_major}" \
+    "arch|${arch}|${image_arch}"; do
+
+    IFS='|' read -r name want got <<< "${check}"
+    [[ "${got}" == "-" ]] && got=""
+
+    if [[ "${got}" != "${want}" ]]; then
+      mismatch+=" ${name}=${got:-<missing>} (want ${want})"
+    fi
+  done
+
+  if [[ -n "${mismatch}" ]]; then
+    echo "FATAL: ${snapshot_id} is not the expected ${factory_env} candidate (${stage} check):${mismatch} (no hcloud mutation)" >&2
+    return 1
+  fi
+}
+
 sentinel_started="SMOKE-PROVISIONER-STARTED"
 sentinel_completed="SMOKE-PROVISIONER-COMPLETED"
 smoke_log="$(mktemp -t ppg-smoke-XXXXXX.log)"
 trap 'rm -f "${smoke_log}"' EXIT
 
 echo "smoke candidate ${snapshot_id} (${os_name}${os_major} ${arch}, env=${factory_env})"
+
+verify_candidate_identity "pre-boot"
 
 smoke_status=0
 ( cd smoke && packer init . >/dev/null && \
@@ -54,8 +120,17 @@ if [[ "${smoke_status}" -ne 0 ]]; then
   # the cheap retry for both.
   if grep -qF "${sentinel_started}" "${smoke_log}" \
     && ! grep -qF "${sentinel_completed}" "${smoke_log}"; then
-    echo "smoke (boot+install) failed after the provisioner started; deleting candidate ${snapshot_id}"
-    hcloud image delete "${snapshot_id}"
+
+    # Re-verify identity immediately before the destructive call: the pre-boot
+    # check bounds the window, this one closes it (a promote racing this run,
+    # or any label change since the boot, refuses the delete).
+    if verify_candidate_identity "pre-delete"; then
+      echo "smoke (boot+install) failed after the provisioner started; deleting candidate ${snapshot_id}"
+      hcloud image delete "${snapshot_id}"
+    else
+      echo "candidate ${snapshot_id} kept: identity guard refused the delete" >&2
+    fi
+
   else
     echo "transient failure outside the smoke provisioner, candidate ${snapshot_id} kept for retry"
   fi

--- a/ppg/packer-hetzner/scripts/validate.sh
+++ b/ppg/packer-hetzner/scripts/validate.sh
@@ -1,0 +1,90 @@
+#!/usr/bin/env bash
+# Fail-closed identity/health gates for a Rocky Linux / AlmaLinux / Oracle
+# Linux package-test target snapshot (Hetzner Cloud). Runs as the LAST
+# provisioner: any non-zero exit aborts the build so a broken or mislabeled
+# image is never snapshotted. De-instancing is native (see the tail note):
+# Packer clears the temp key and cloud-init re-seeds on boot.
+#
+# Env (from packer): OS (rocky|almalinux|oraclelinux), OS_MAJOR (8|9|10),
+# UNAME_ARCH (x86_64|aarch64)
+set -euo pipefail
+
+: "${OS:?OS not set}"
+: "${OS_MAJOR:?OS_MAJOR not set}"
+: "${UNAME_ARCH:?UNAME_ARCH not set}"
+
+fail() { echo "VALIDATE FAIL: $*" >&2; exit 1; }
+
+. /etc/os-release
+echo "VALIDATE: ${PRETTY_NAME:-?} $(uname -m) (want ${OS} ${OS_MAJOR} / ${UNAME_ARCH})"
+
+# 1. Genuine OS of the expected major (fidelity gate). Keyed on /etc/os-release
+#    ID + VERSION_ID (sourced above): distro release-file names cannot tell EL
+#    distros apart once more are added (every clone ships /etc/redhat-release).
+case "${OS}" in
+  rocky)       expected_id=rocky ;;
+  almalinux)   expected_id=almalinux ;;
+  oraclelinux) expected_id=ol ;;
+  *)           fail "unknown OS '${OS}' (want rocky|almalinux|oraclelinux)" ;;
+esac
+
+[[ "${ID:-}" = "${expected_id}" ]] || fail "os-release ID '${ID:-}' != '${expected_id}'"
+os_major_found="${VERSION_ID:-}"
+os_major_found="${os_major_found%%.*}"
+[[ "${os_major_found}" = "${OS_MAJOR}" ]] \
+  || fail "os-release major '${os_major_found}' != '${OS_MAJOR}' (VERSION_ID='${VERSION_ID:-}')"
+
+# 2. Architecture matches the target.
+[[ "$(uname -m)" = "${UNAME_ARCH}" ]] || fail "arch $(uname -m) != ${UNAME_ARCH}"
+
+# 3. The CRB repo must be DEFINED on the image (disabled by default, and PG
+#    -devel deps need it). Rocky and Alma share the naming: "powertools" on
+#    EL8, "crb" on EL9/10. Oracle names it ol<major>_codeready_builder. The
+#    AUTHORITATIVE resolvability check is the smoke test, which enables it
+#    and actually installs percona-postgresql17-server.
+if [[ "${OS}" = "oraclelinux" ]]; then
+  crb="ol${OS_MAJOR}_codeready_builder"
+else
+  case "${OS_MAJOR}" in
+    8)    crb="powertools" ;;
+    9|10) crb="crb" ;;
+    *)    fail "no CRB mapping for ${OS}/${OS_MAJOR}" ;;
+  esac
+fi
+
+dnf repolist --all 2>/dev/null | grep -qiE "^${crb}([[:space:]]|$)" \
+  || fail "CRB repo (${crb}) not defined on image"
+echo "  CRB ok: repo defined (${crb})"
+
+# 4. cloud-init present (server bootstrap, Hetzner applies SSH keys through it).
+command -v cloud-init >/dev/null 2>&1 || fail "cloud-init missing"
+
+# 5. SELinux not disabled (fidelity gate). Relaxed vs the AWS factory's
+#    enforcing assert: Hetzner's official Rocky/Alma images are not verified
+#    to ship enforcing, so this gate fail-closes only on an explicit disable
+#    (or a missing config, which means no SELinux at all). Tighten to
+#    enforcing once the seeded images prove they ship it.
+grep -Eq "^SELINUX=(enforcing|permissive)" /etc/selinux/config 2>/dev/null \
+  || fail "SELinux disabled (or /etc/selinux/config missing)"
+
+# 6. dnf metadata is fresh enough to confirm the refresh ran.
+dnf -q makecache >/dev/null 2>&1 || fail "dnf makecache failed (broken repos)"
+
+# 7. Refresh actually applied: list what is still upgradable (informational).
+#    provision.sh runs `dnf -y update` under set -e, so a hard failure aborts
+#    there. The Obsoleting Packages section and "Security: ..." advisory
+#    notices (installed-vs-running kernel on the never-rebooted builder) are
+#    excluded: neither is a pending upgrade, but a bare count included them.
+pending=$(dnf -q check-update 2>/dev/null | sed '/^Obsoleting Packages/,$d' | grep -E '^[A-Za-z0-9]' | grep -vE '^Security: ' || true)
+
+if [[ -z "${pending}" ]]; then
+  echo "  update ok: 0 packages upgradable"
+else
+  echo "VALIDATE WARN: packages still upgradable after dnf update:"
+  printf '%s\n' "${pending}"
+fi
+
+echo "VALIDATE OK: ${OS} ${OS_MAJOR} ${UNAME_ARCH}"
+# De-instancing is native: packer `ssh_clear_authorized_keys` strips the temp
+# key, and cloud-init's default `ssh_deletekeys: true` regenerates host keys on
+# first boot. provision.sh already ran `cloud-init clean` + reset machine-id.

--- a/ppg/packer-hetzner/smoke/smoke.pkr.hcl
+++ b/ppg/packer-hetzner/smoke/smoke.pkr.hcl
@@ -77,6 +77,13 @@ source "hcloud" "smoke" {
   server_labels = {
     role = "ppg-smoke"
   }
+
+  # The plugin uploads a temporary packer-<uuid> SSH key per build and labels
+  # it with ONLY this map: unlabeled keys from a killed run would be invisible
+  # to the janitor's selectors and leak forever.
+  ssh_keys_labels = {
+    role = "ppg-smoke"
+  }
 }
 
 build {

--- a/ppg/packer-hetzner/smoke/smoke.pkr.hcl
+++ b/ppg/packer-hetzner/smoke/smoke.pkr.hcl
@@ -78,9 +78,8 @@ source "hcloud" "smoke" {
     role = "ppg-smoke"
   }
 
-  # The plugin uploads a temporary packer-<uuid> SSH key per build and labels
-  # it with ONLY this map: unlabeled keys from a killed run would be invisible
-  # to the janitor's selectors and leak forever.
+  # Label the plugin's temporary per-build SSH key so the janitor can sweep
+  # keys leaked by killed runs (an unlabeled key matches no selector).
   ssh_keys_labels = {
     role = "ppg-smoke"
   }

--- a/ppg/packer-hetzner/smoke/smoke.pkr.hcl
+++ b/ppg/packer-hetzner/smoke/smoke.pkr.hcl
@@ -1,0 +1,123 @@
+# Fresh-boot smoke test - native Packer, sibling of the AWS factory's
+# smoke/smoke.pkr.hcl.
+#
+# Boots the just-built candidate snapshot with `skip_create_snapshot` (pure
+# boot-test, no new image), connects over plain SSH as root (Hetzner re-injects
+# the temp key through cloud-init, proving the candidate re-initialises after
+# the bake cleaned cloud-init state), and runs the identity + real PPG-install
+# checks as a Packer provisioner. This template ONLY validates. It does NOT
+# promote. The caller (scripts/smoke-run.sh, shared by justfile and workflow)
+# deletes the candidate only when this build fails AFTER the provisioner's
+# SMOKE-PROVISIONER-STARTED sentinel appeared WITHOUT its COMPLETED twin
+# (the provisioner began and did not finish: a genuine boot/install failure).
+# A failure without the sentinel is transient infrastructure and keeps the
+# candidate. Promotion (role -> ppg-package-test) is a SEPARATE retried step
+# ONLY after a pass, so a transient promote-label failure can never delete a
+# smoke-passed snapshot.
+#
+#   packer init . && packer build -var candidate_image=123456789 -var os=rocky -var os_major=9 -var arch=x86_64 .
+
+packer {
+  required_plugins {
+    hcloud = {
+      source  = "github.com/hetznercloud/hcloud"
+      version = "1.7.2" # pinned exact (supply-chain), matches the refresh template
+    }
+  }
+}
+
+variable "candidate_image" {
+  type        = string
+  description = "Numeric ID of the candidate snapshot to boot-test (snapshots have no API name; ID lookup is arch-exact)."
+}
+variable "os" {
+  type    = string # "rocky" | "almalinux" | "oraclelinux"
+  default = "rocky"
+  validation {
+    condition     = contains(["rocky", "almalinux", "oraclelinux"], var.os)
+    error_message = "Value of os must be rocky, almalinux, or oraclelinux."
+  }
+}
+variable "os_major" { type = string }
+variable "arch" { type = string } # x86_64 | arm64
+variable "location" {
+  type    = string
+  default = "fsn1"
+}
+variable "server_type_x86" {
+  type    = string
+  default = "cpx32"
+}
+variable "server_type_arm" {
+  type    = string
+  default = "cax21"
+}
+
+locals {
+  server_type = var.arch == "arm64" ? var.server_type_arm : var.server_type_x86
+  uname_arch  = var.arch == "arm64" ? "aarch64" : "x86_64"
+  # Identity via /etc/os-release ID (release-file names cannot tell EL distros
+  # apart once more are added: every clone ships /etc/redhat-release).
+  expected_id = var.os == "rocky" ? "rocky" : var.os == "almalinux" ? "almalinux" : "ol"
+  # CRB naming is shared by Rocky and Alma ("powertools" on 8, "crb" on 9/10).
+  # Oracle names it per major: ol<major>_codeready_builder.
+  crb_repo      = var.os == "oraclelinux" ? "ol${var.os_major}_codeready_builder" : var.os_major == "8" ? "powertools" : "crb"
+  hostname_arch = replace(var.arch, "_", "-")
+}
+
+source "hcloud" "smoke" {
+  location             = var.location
+  server_type          = local.server_type
+  server_name          = "ppg-smoke-${var.os}${var.os_major}-${local.hostname_arch}"
+  image                = var.candidate_image
+  skip_create_snapshot = true # boot-test only, produce no image
+  ssh_username         = "root"
+  ssh_timeout          = "10m"
+
+  server_labels = {
+    role = "ppg-smoke"
+  }
+}
+
+build {
+  name    = "ppg-smoke"
+  sources = ["source.hcloud.smoke"]
+
+  # Identity + a real PPG install on a FRESH boot of the candidate. Inline (no
+  # external script). HCL interpolates ${var..}/${local..}, shell $(...) passes
+  # through, and it runs as root so no sudo.
+  provisioner "shell" {
+    # Run the inline body under bash (pipefail is a bashism), the inline analog
+    # of the refresh template's bash execute_command.
+    inline_shebang = "/bin/bash -e"
+    inline = [
+      "set -euo pipefail",
+      # First provisioner output on purpose: proves SSH came up and the
+      # provisioner ran. scripts/smoke-run.sh gates the candidate delete on
+      # this sentinel (a failure without it is transient infrastructure, never
+      # a bad image).
+      "echo SMOKE-PROVISIONER-STARTED",
+      ". /etc/os-release; [ \"$ID\" = '${local.expected_id}' ] || { echo \"wrong distro ID $ID (want ${local.expected_id})\"; exit 1; }",
+      ". /etc/os-release; [ \"$${VERSION_ID%%.*}\" = '${var.os_major}' ] || { echo \"wrong major $VERSION_ID (want ${var.os_major})\"; exit 1; }",
+      "[ \"$(uname -m)\" = '${local.uname_arch}' ] || { echo \"wrong arch $(uname -m)\"; exit 1; }",
+      # EL10 images ship cloud-init 24.x, which exits 2 ("degraded done") on
+      # Hetzner because the IPv4 link-local metadata probe times out even on
+      # the pristine official images (key injection still works, via the
+      # retried datasource paths). Judge the status TEXT, not the exit code:
+      # a boot that reaches done/disabled passes, anything else fails.
+      "ci_status=$(cloud-init status --wait 2>/dev/null) || true; echo \"$ci_status\" | grep -qE 'done|disabled' || { echo \"cloud-init not done: $ci_status\"; exit 1; }",
+      "dnf -y install dnf-plugins-core",
+      # Enable CRB and ASSERT it stuck: some PPG dependencies live there, so a
+      # silently missing CRB would fail later with a misleading dnf error.
+      "dnf config-manager --set-enabled ${local.crb_repo}",
+      "dnf repolist --enabled | grep -q '${local.crb_repo}' || { echo \"CRB repo ${local.crb_repo} did not enable (repolist --enabled has no match)\"; exit 1; }",
+      "dnf -y install https://repo.percona.com/yum/percona-release-latest.noarch.rpm",
+      "percona-release enable-only ppg-17 release",
+      "dnf -qy module reset postgresql 2>/dev/null || true",
+      "dnf -qy module disable postgresql 2>/dev/null || true",
+      "dnf -y install percona-postgresql17-server || dnf -y install percona-ppg-server17",
+      "echo \"PPG install ok: $(rpm -q percona-postgresql17-server 2>/dev/null || rpm -qa 'percona-ppg-server*' | head -1)\"",
+      "echo SMOKE-PROVISIONER-COMPLETED",
+    ]
+  }
+}

--- a/ppg/packer-hetzner/tests/janitor-stub-test.sh
+++ b/ppg/packer-hetzner/tests/janitor-stub-test.sh
@@ -1,0 +1,114 @@
+#!/bin/bash
+# Stubbed behavior test for scripts/janitor.sh's SSH-key sweep: old keys
+# carrying the factory/smoke role labels (Packer's ssh_keys_labels) are listed
+# and deleted, young keys are skipped as live runs, and a key matching no
+# selector is never even queried. Runs against tests/stubs (fake hcloud), so
+# no token and no API. Executed by scripts/check.sh.
+set -euo pipefail
+
+err() {
+  echo "$*" >&2
+}
+
+factory_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+readonly factory_root
+
+test_root=$(mktemp -d -t ppg-janitor-stub-XXXXXX)
+trap 'rm -rf "${test_root}"' EXIT
+
+export STUB_CALL_LOG="${test_root}/calls.log"
+export STUB_FIXTURE_DIR="${test_root}/fixtures"
+mkdir -p "${STUB_FIXTURE_DIR}"
+
+# hcloud-shaped created timestamps relative to now, so the fixtures age
+# correctly no matter when the test runs.
+created_at() {
+  python3 -c '
+import datetime, sys
+delta = datetime.timedelta(hours=int(sys.argv[1]))
+print((datetime.datetime.now(datetime.timezone.utc) - delta).isoformat())
+' "$1"
+}
+
+# Factory-builder keys: one leaked (10h), one from a live run (1h). Smoke
+# keys: one leaked (8h). Key 999 carries no selector-matching role, so no
+# fixture returns it and the janitor must never touch it.
+cat > "${STUB_FIXTURE_DIR}/ssh-keys-role_ppg-factory-builder.json" <<EOF
+[
+  {"id": 101, "name": "packer-leaked-factory", "created": "$(created_at 10)"},
+  {"id": 102, "name": "packer-live-factory", "created": "$(created_at 1)"}
+]
+EOF
+cat > "${STUB_FIXTURE_DIR}/ssh-keys-role_ppg-smoke.json" <<EOF
+[
+  {"id": 103, "name": "packer-leaked-smoke", "created": "$(created_at 8)"}
+]
+EOF
+
+run_janitor() {
+  janitor_rc=0
+  janitor_output=$(cd "${factory_root}" \
+    && PATH="${factory_root}/tests/stubs:${PATH}" \
+      bash scripts/janitor.sh "$@" 2>&1) || janitor_rc=$?
+}
+
+assert_eq() {
+  local what="$1" want="$2" got="$3"
+
+  if [[ "${got}" != "${want}" ]]; then
+    err "FAIL ${mode}: ${what}: want '${want}', got '${got}'"
+    err "--- output ---"
+    err "${janitor_output}"
+    err "--- calls ---"
+    cat "${STUB_CALL_LOG}" >&2
+    exit 1
+  fi
+}
+
+assert_output_has() {
+  assert_eq "output contains '$1'" "yes" \
+    "$(grep -qF -- "$1" <<< "${janitor_output}" && echo yes || echo no)"
+}
+
+assert_calls_count() {
+  local pattern="$1" want="$2"
+  assert_eq "calls matching '${pattern}'" "${want}" \
+    "$(grep -c -- "${pattern}" "${STUB_CALL_LOG}" || true)"
+}
+
+main() {
+  mode="list"
+  : > "${STUB_CALL_LOG}"
+  run_janitor
+  assert_eq "exit code" 3 "${janitor_rc}"
+  assert_output_has "would delete ssh-key 101"
+  assert_output_has "would delete ssh-key 103"
+  assert_output_has "leaked=2"
+  assert_calls_count "delete" 0
+  echo "PASS janitor ${mode} mode"
+
+  mode="apply"
+  : > "${STUB_CALL_LOG}"
+  run_janitor 1
+  assert_eq "exit code" 0 "${janitor_rc}"
+  assert_output_has "deleted=2"
+  assert_output_has "delete_failures=0"
+  assert_calls_count "^ssh-key delete 101$" 1
+  assert_calls_count "^ssh-key delete 103$" 1
+  assert_calls_count "delete 102" 0
+  assert_calls_count "999" 0
+  echo "PASS janitor ${mode} mode"
+
+  # The sweep must query EXACTLY the contracted selectors: a lost selector
+  # here is an invisible leak class in production.
+  mode="selector-contract"
+  assert_eq "ssh-key selectors queried" \
+    "role=ppg-bootstrap-check role=ppg-factory-builder role=ppg-molecule-test role=ppg-smoke" \
+    "$(awk '/^ssh-key list -l /{print $4}' "${STUB_CALL_LOG}" \
+      | sort -u | xargs)"
+  echo "PASS janitor ${mode}"
+
+  echo "janitor stub test OK"
+}
+
+main "$@"

--- a/ppg/packer-hetzner/tests/smoke-run-guard-test.sh
+++ b/ppg/packer-hetzner/tests/smoke-run-guard-test.sh
@@ -1,0 +1,133 @@
+#!/bin/bash
+# Stubbed behavior test for the fail-closed identity guard in
+# scripts/smoke-run.sh: a wrong or relabeled snapshot ID must never be booted
+# or deleted, while a genuine boot/install failure on a real candidate still
+# deletes it. Runs against tests/stubs (fake hcloud + packer), so no token and
+# no API. Executed by scripts/check.sh.
+set -euo pipefail
+
+err() {
+  echo "$*" >&2
+}
+
+factory_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+readonly factory_root
+
+test_root=$(mktemp -d -t ppg-smoke-guard-XXXXXX)
+trap 'rm -rf "${test_root}"' EXIT
+
+candidate_json='{"id": 42, "labels": {"role": "ppg-candidate", "factory_env": "prod", "source": "factory", "os": "rocky", "os_major": "9", "arch": "x86_64"}}'
+promoted_json='{"id": 42, "labels": {"role": "ppg-package-test", "factory_env": "prod", "source": "factory", "os": "rocky", "os_major": "9", "arch": "x86_64", "smoke": "passed"}}'
+readonly candidate_json promoted_json
+
+# Fresh per-scenario stub state: call log, fixture dir, packer transcript.
+scenario_setup() {
+  local name="$1"
+  scenario_dir="${test_root}/${name}"
+  mkdir -p "${scenario_dir}/fixtures"
+  export STUB_CALL_LOG="${scenario_dir}/calls.log"
+  export STUB_FIXTURE_DIR="${scenario_dir}/fixtures"
+  export STUB_PACKER_OUTPUT="${scenario_dir}/packer-output.txt"
+  : > "${STUB_CALL_LOG}"
+}
+
+# Run smoke-run.sh with the stubs first in PATH; never aborts the test on a
+# nonzero exit (the exit code is itself an assertion target).
+run_smoke() {
+  smoke_rc=0
+  smoke_output=$(cd "${factory_root}" \
+    && PATH="${factory_root}/tests/stubs:${PATH}" \
+      bash scripts/smoke-run.sh "$@" 2>&1) || smoke_rc=$?
+}
+
+assert_eq() {
+  local what="$1" want="$2" got="$3"
+
+  if [[ "${got}" != "${want}" ]]; then
+    err "FAIL ${scenario}: ${what}: want '${want}', got '${got}'"
+    err "--- output ---"
+    err "${smoke_output}"
+    err "--- calls ---"
+    cat "${STUB_CALL_LOG}" >&2
+    exit 1
+  fi
+}
+
+assert_output_has() {
+  assert_eq "output contains '$1'" "yes" \
+    "$(grep -qF -- "$1" <<< "${smoke_output}" && echo yes || echo no)"
+}
+
+assert_calls_count() {
+  local pattern="$1" want="$2"
+  assert_eq "calls matching '${pattern}'" "${want}" \
+    "$(grep -c -- "${pattern}" "${STUB_CALL_LOG}" || true)"
+}
+
+main() {
+  scenario="wrong-identity-refuses-boot"
+  scenario_setup "${scenario}"
+  echo "${promoted_json}" > "${STUB_FIXTURE_DIR}/image-42.json"
+  export STUB_PACKER_EXIT=0
+  : > "${STUB_PACKER_OUTPUT}"
+  run_smoke 42 9 x86_64 prod rocky
+  assert_eq "exit code" 1 "${smoke_rc}"
+  assert_output_has "FATAL: 42 is not the expected prod candidate (pre-boot"
+  assert_calls_count "^packer build" 0
+  assert_calls_count "^image delete" 0
+  echo "PASS ${scenario}"
+
+  scenario="genuine-failure-deletes-candidate"
+  scenario_setup "${scenario}"
+  echo "${candidate_json}" > "${STUB_FIXTURE_DIR}/image-42.json"
+  export STUB_PACKER_EXIT=1
+  echo "SMOKE-PROVISIONER-STARTED" > "${STUB_PACKER_OUTPUT}"
+  run_smoke 42 9 x86_64 prod rocky
+  assert_eq "exit code" 1 "${smoke_rc}"
+  assert_calls_count "^image describe 42" 2
+  assert_calls_count "^image delete 42" 1
+  assert_eq "delete is the last hcloud call" "image delete 42" \
+    "$(tail -n 1 "${STUB_CALL_LOG}")"
+  echo "PASS ${scenario}"
+
+  scenario="relabeled-mid-run-refuses-delete"
+  scenario_setup "${scenario}"
+  echo "${candidate_json}" > "${STUB_FIXTURE_DIR}/image-42.json"
+  echo "${promoted_json}" > "${STUB_FIXTURE_DIR}/image-42.2.json"
+  export STUB_PACKER_EXIT=1
+  echo "SMOKE-PROVISIONER-STARTED" > "${STUB_PACKER_OUTPUT}"
+  run_smoke 42 9 x86_64 prod rocky
+  assert_eq "exit code" 1 "${smoke_rc}"
+  assert_output_has "kept: identity guard refused the delete"
+  assert_calls_count "^image delete" 0
+  echo "PASS ${scenario}"
+
+  scenario="transient-failure-keeps-candidate"
+  scenario_setup "${scenario}"
+  echo "${candidate_json}" > "${STUB_FIXTURE_DIR}/image-42.json"
+  export STUB_PACKER_EXIT=1
+  echo "Error: could not create server: rate limit exceeded" \
+    > "${STUB_PACKER_OUTPUT}"
+  run_smoke 42 9 x86_64 prod rocky
+  assert_eq "exit code" 1 "${smoke_rc}"
+  assert_output_has "kept for retry"
+  assert_calls_count "^image describe 42" 1
+  assert_calls_count "^image delete" 0
+  echo "PASS ${scenario}"
+
+  scenario="pass-labels-and-keeps"
+  scenario_setup "${scenario}"
+  echo "${candidate_json}" > "${STUB_FIXTURE_DIR}/image-42.json"
+  export STUB_PACKER_EXIT=0
+  printf '%s\n%s\n' "SMOKE-PROVISIONER-STARTED" "SMOKE-PROVISIONER-COMPLETED" \
+    > "${STUB_PACKER_OUTPUT}"
+  run_smoke 42 9 x86_64 prod rocky
+  assert_eq "exit code" 0 "${smoke_rc}"
+  assert_calls_count "^image add-label --overwrite 42 smoke=passed" 1
+  assert_calls_count "^image delete" 0
+  echo "PASS ${scenario}"
+
+  echo "smoke-run guard test OK"
+}
+
+main "$@"

--- a/ppg/packer-hetzner/tests/stubs/hcloud
+++ b/ppg/packer-hetzner/tests/stubs/hcloud
@@ -1,0 +1,50 @@
+#!/bin/bash
+# Fake hcloud for the stub tests (tests/*.sh): records every invocation to
+# STUB_CALL_LOG and serves canned JSON from STUB_FIXTURE_DIR. No network, no
+# token. Unexpected invocations fail loudly so a test can never silently pass
+# over a call path it does not model.
+set -euo pipefail
+
+echo "$*" >> "${STUB_CALL_LOG}"
+
+case "$1 $2" in
+  "image describe")
+    # Serve image-<id>.json; from the SECOND describe of the same id on, serve
+    # image-<id>.2.json when present (lets a test flip labels mid-run to prove
+    # the pre-delete re-check).
+    describe_count=$(grep -c "^image describe $3 " "${STUB_CALL_LOG}" || true)
+
+    if [[ "${describe_count}" -ge 2 && -f "${STUB_FIXTURE_DIR}/image-$3.2.json" ]]; then
+      cat "${STUB_FIXTURE_DIR}/image-$3.2.json"
+    else
+      cat "${STUB_FIXTURE_DIR}/image-$3.json"
+    fi
+    ;;
+  "image delete")
+    exit 0
+    ;;
+  "image add-label")
+    exit 0
+    ;;
+  "server list")
+    echo "[]"
+    ;;
+  "ssh-key list")
+    # $3 $4 are "-l <selector>"; serve ssh-keys-<selector>.json ("=" -> "_")
+    # or an empty listing for selectors the test seeds no fixture for.
+    fixture="${STUB_FIXTURE_DIR}/ssh-keys-${4//=/_}.json"
+
+    if [[ -f "${fixture}" ]]; then
+      cat "${fixture}"
+    else
+      echo "[]"
+    fi
+    ;;
+  "ssh-key delete")
+    exit 0
+    ;;
+  *)
+    echo "stub hcloud: unexpected invocation: $*" >&2
+    exit 64
+    ;;
+esac

--- a/ppg/packer-hetzner/tests/stubs/packer
+++ b/ppg/packer-hetzner/tests/stubs/packer
@@ -1,0 +1,21 @@
+#!/bin/bash
+# Fake packer for the smoke-run guard test: `init` succeeds silently, `build`
+# prints the scripted transcript (STUB_PACKER_OUTPUT) and exits with the
+# scripted status (STUB_PACKER_EXIT). Everything else fails loudly.
+set -euo pipefail
+
+echo "packer $*" >> "${STUB_CALL_LOG}"
+
+case "$1" in
+  init)
+    exit 0
+    ;;
+  build)
+    cat "${STUB_PACKER_OUTPUT}"
+    exit "${STUB_PACKER_EXIT}"
+    ;;
+  *)
+    echo "stub packer: unexpected invocation: $*" >&2
+    exit 64
+    ;;
+esac

--- a/ppg/ppg-hetzner-poc.groovy
+++ b/ppg/ppg-hetzner-poc.groovy
@@ -1,0 +1,205 @@
+library changelog: false, identifier: "lib@master", retriever: modernSCM([
+    $class: 'GitSCMSource',
+    remote: 'https://github.com/Percona-Lab/jenkins-pipelines.git'
+])
+
+def sendSlackNotification(scenario, version) {
+    if (currentBuild.result == "SUCCESS") {
+        buildSummary = "Job: ${env.JOB_NAME}\nScenario: ${scenario}\nVersion: ${version}\nStatus: *SUCCESS*\nBuild Report: ${env.BUILD_URL}"
+        slackSend color: "good", message: "${buildSummary}", channel: '#postgresql-test'
+    } else {
+        buildSummary = "Job: ${env.JOB_NAME}\nScenario: ${scenario}\nVersion: ${version}\nStatus: *FAILURE*\nBuild number: ${env.BUILD_NUMBER}\nBuild Report :${env.BUILD_URL}"
+        slackSend color: "danger", message: "${buildSummary}", channel: '#postgresql-test'
+    }
+}
+
+
+// Hetzner Cloud pilot: single-OS variant of ppg-multiOS-parallel running one
+// molecule scenario on the factory snapshots (ppg/packer-hetzner) through the
+// delegated driver. SCENARIO here is the molecule scenario name inside
+// MOLECULE_DIR (ppg/pg-17), not the ppgScenarios() product name.
+pipeline {
+    agent {
+        label 'min-ol-9-x64'
+    }
+    parameters {
+        choice(
+            name: 'REPO',
+            description: 'Repo for testing',
+            choices: [
+                'testing',
+                'release',
+                'experimental'
+            ]
+        )
+        string(
+            defaultValue: 'ppg-17.10',
+            description: 'PG version for test',
+            name: 'VERSION'
+        )
+        string(
+            defaultValue: 'rocky-9-hetzner',
+            description: 'Molecule scenario (Hetzner delegated driver) inside ppg/pg-17',
+            name: 'SCENARIO'
+        )
+        choice(
+            name: 'ARCH',
+            description: 'Server architecture: picks the hcloud server type and the snapshot arch label',
+            choices: [
+                'x86_64',
+                'arm64'
+            ]
+        )
+        string(
+            defaultValue: 'main',
+            description: 'Branch for testing repository',
+            name: 'TESTING_BRANCH'
+        )
+        string(
+            defaultValue: 'https://github.com/Percona-QA/ppg-testing.git',
+            description: 'Testing repository URL (override for fork-based validation)',
+            name: 'TESTING_REPO'
+        )
+        booleanParam(
+            name: 'MAJOR_REPO',
+            description: "Enable to use major (ppg-17) repo instead of ppg-17.0"
+        )
+    }
+    environment {
+        PATH = '/usr/local/bin:/usr/bin:/usr/local/sbin:/usr/sbin:/home/ec2-user/.local/bin'
+        MOLECULE_DIR = "ppg/pg-17"
+    }
+    options {
+        // No pipeline-wide credential binding: HCLOUD_TOKEN is scoped to the
+        // Test and destroy sh blocks below, so the checkout and prepare of an
+        // arbitrary ppg-testing fork never see it.
+        buildDiscarder(logRotator(daysToKeepStr: '30', numToKeepStr: '100', artifactNumToKeepStr: '10'))
+        retry(conditions: [agent()], count: 2)
+    }
+    stages {
+        stage('Validate parameters') {
+            steps {
+                script {
+                    // Fail fast on anything that could smuggle shell into the
+                    // sh blocks (SCENARIO) or point the checkout at a
+                    // non-ppg-testing repository (TESTING_REPO).
+                    if (!(params.SCENARIO ==~ /^[A-Za-z0-9._-]+$/)) {
+                        error("SCENARIO '${params.SCENARIO}' is not a plain scenario name (allowed: A-Z a-z 0-9 . _ -)")
+                    }
+                    if (!(params.TESTING_REPO ==~ /^https:\/\/github\.com\/[A-Za-z0-9_.-]+\/ppg-testing(\.git)?$/)) {
+                        error("TESTING_REPO '${params.TESTING_REPO}' must be an https github.com ppg-testing repository (fork or upstream)")
+                    }
+                }
+            }
+        }
+        stage('Set build name') {
+            steps {
+                script {
+                    if (params.MAJOR_REPO) {
+                        currentBuild.displayName = "${env.BUILD_NUMBER}-${env.SCENARIO}-${env.ARCH}-${env.VERSION}-Major_Repo"
+                    } else {
+                        currentBuild.displayName = "${env.BUILD_NUMBER}-${env.SCENARIO}-${env.ARCH}-${env.VERSION}"
+                    }
+                }
+            }
+        }
+        stage('Checkout') {
+            steps {
+                deleteDir()
+                git poll: false, branch: TESTING_BRANCH, url: TESTING_REPO
+            }
+        }
+        stage('Prepare') {
+            steps {
+                script {
+                    installMoleculePython39()
+                }
+                // The pip 'ansible' package already bundles both collections.
+                // Prepare re-installs them at pinned releases, mirroring how
+                // installMoleculePython39 refreshes amazon.aws for the EC2 path.
+                sh '''
+                    . virtenv/bin/activate
+                    # Per-workspace collections dir: concurrent builds on one worker must
+                    # not race each other's install + patch of a shared ~/.ansible copy.
+                    # The Test and destroy sh blocks export the same path so runtime uses
+                    # this patched copy.
+                    export ANSIBLE_COLLECTIONS_PATH="$WORKSPACE/.collections"
+                    # --force with a pinned 4.x: the venv's ansible bundle ships hetzner.hcloud 1.x
+                    # (pre-rename hcloud_* module names), which galaxy otherwise reports as
+                    # "already installed". 4.x is the newest line supporting ansible-core 2.15.
+                    # community.crypto is pinned to the validated release too, so Prepare
+                    # is reproducible instead of floating to whatever galaxy serves.
+                    ansible-galaxy collection install --force 'hetzner.hcloud:4.3.0' 'community.crypto:3.3.0'
+                    # The 2026 Hetzner API dropped the per-server datacenter field. Every
+                    # collection release that handles it needs ansible-core >=2.17, which
+                    # needs python >=3.10, and this venv is the canon python3.9/core-2.15
+                    # stack. Guard the two result lines that dereference it, fail-closed:
+                    # the asserts abort Prepare if a version bump moves the anchors.
+                    python3 - <<'PYEOF'
+import os
+import pathlib
+base = pathlib.Path(os.environ["ANSIBLE_COLLECTIONS_PATH"]) / "ansible_collections/hetzner/hcloud/plugins/modules"
+for fname, obj in (("server.py", "self.hcloud_server"), ("server_info.py", "server")):
+    f = base / fname
+    s = f.read_text()
+    dc_old = '"datacenter": %s.datacenter.name,' % obj
+    dc_new = '"datacenter": %s.datacenter.name if %s.datacenter is not None else None,' % (obj, obj)
+    loc_old = '"location": %s.datacenter.location.name,' % obj
+    loc_new = '"location": %s.datacenter.location.name if %s.datacenter is not None else None,' % (obj, obj)
+    assert s.count(dc_old) == 1 and s.count(loc_old) == 1, "datacenter guard anchors missing in " + fname
+    f.write_text(s.replace(dc_old, dc_new).replace(loc_old, loc_new))
+    print("patched", fname)
+PYEOF
+                '''
+            }
+        }
+        stage('Test') {
+            steps {
+                script {
+                    // HCLOUD_TOKEN scope starts here, after checkout + prepare.
+                    // The only groovy interpolation is moleculeEnvPPGHetzner()
+                    // (static library text): params reach the shell as quoted
+                    // env vars (\$-escaped), never spliced into the script.
+                    withCredentials(moleculeDistributionJenkinsCredsHetzner()) {
+                        sh """
+                            . virtenv/bin/activate
+                            export ANSIBLE_COLLECTIONS_PATH="\$WORKSPACE/.collections"
+                            cd "\$MOLECULE_DIR"
+                            ${moleculeEnvPPGHetzner()}
+                            export HETZNER_ARCH="\$ARCH"
+                            if [ "\$ARCH" = "arm64" ]; then
+                                export HETZNER_SERVER_TYPE="\${htz_server_type_arm64}"
+                            else
+                                export HETZNER_SERVER_TYPE="\${htz_server_type_x86_64}"
+                            fi
+                            molecule test -s "\$SCENARIO"
+                        """
+                    }
+                }
+            }
+        }
+    }
+    post {
+        always {
+            script {
+                // A failed destroy must not eat the Slack notification: log it
+                // and keep going (the hourly janitor sweeps any leftovers).
+                try {
+                    withCredentials(moleculeDistributionJenkinsCredsHetzner()) {
+                        sh """
+                            . virtenv/bin/activate
+                            export ANSIBLE_COLLECTIONS_PATH="\$WORKSPACE/.collections"
+                            cd "\$MOLECULE_DIR"
+                            ${moleculeEnvPPGHetzner()}
+                            export HETZNER_ARCH="\$ARCH"
+                            molecule destroy -s "\$SCENARIO"
+                        """
+                    }
+                } catch (err) {
+                    echo "molecule destroy failed (janitor sweeps leftovers): ${err}"
+                }
+                sendSlackNotification(env.SCENARIO, env.VERSION)
+            }
+        }
+    }
+}

--- a/ppg/ppg-hetzner-poc.yml
+++ b/ppg/ppg-hetzner-poc.yml
@@ -1,0 +1,14 @@
+- job:
+    name: ppg-hetzner-poc
+    project-type: pipeline
+    description: |
+        Do not edit this job through the web!
+    pipeline-scm:
+      scm:
+        - git:
+            url: https://github.com/Percona-Lab/jenkins-pipelines.git
+            branches:
+              - 'master'
+            wipe-workspace: false
+      lightweight-checkout: true
+      script-path: ppg/ppg-hetzner-poc.groovy

--- a/vars/moleculeDistributionJenkinsCredsHetzner.groovy
+++ b/vars/moleculeDistributionJenkinsCredsHetzner.groovy
@@ -1,0 +1,8 @@
+// Hetzner Cloud twin of moleculeDistributionJenkinsCreds: binds the QA project
+// API token (Jenkins string credential) to HCLOUD_TOKEN, which the
+// hetzner.hcloud Ansible modules and the hcloud CLI read from the environment.
+// No SSH key binding on purpose: create-hetzner.yml generates a per-run
+// ed25519 keypair instead of a shared key.
+def call() {
+  return [string(credentialsId: 'hcloud-ppg-qa-token', variable: 'HCLOUD_TOKEN')]
+}

--- a/vars/moleculeEnvPPGHetzner.groovy
+++ b/vars/moleculeEnvPPGHetzner.groovy
@@ -1,0 +1,27 @@
+// Hetzner Cloud twin of moleculeEnvPPG: environment for the molecule delegated
+// driver (playbooks/create-hetzner.yml + destroy-hetzner.yml in ppg-testing).
+// Unlike the AWS var there are no image IDs here: snapshots are resolved AT
+// RUNTIME by the create playbook via hetzner.hcloud.image_info from the label
+// contract (ppg/packer-hetzner/README.md), so nothing is pinned or pre-resolved.
+def call() {
+    return """
+        # Molecule driver: create/destroy are delegated to the hetzner playbooks.
+        # Scenarios interpolate \${driver} exactly like the AWS ones (moleculeEnvPPG
+        # exports driver=ec2)
+        export driver=delegated
+        # Placement fallback order for create-hetzner.yml (CAX arm types exist only in these three DCs)
+        export HETZNER_LOCATIONS="fsn1 nbg1 hel1"
+        # Default x86_64 server type, the hcloud analog of the t3.large tier the AWS scenarios use
+        export htz_server_type_x86_64=cpx32
+        # Default arm64 server type (Ampere CAX line)
+        export htz_server_type_arm64=cax21
+        # Snapshot lookup base: exported ONLY when the caller pre-set it, else empty
+        # ON PURPOSE (fail-closed). Every scenario must declare its own image_selector
+        # (e.g. role=ppg-package-test,source=factory,os=rocky,os_major=9) or the
+        # create playbook aborts naming the platform: a baked-in OS fallback would let
+        # a scenario silently test the wrong OS, and wrong-OS green is worse than
+        # missing-var red. create-hetzner.yml appends ,arch=<platform arch> and picks
+        # the newest matching promoted snapshot at runtime
+        export PPG_IMAGE_SELECTOR_BASE="\${PPG_IMAGE_SELECTOR_BASE:-}"
+    """
+}


### PR DESCRIPTION
**Feature**
- Hetzner snapshot factory for PPG package tests: bake, fresh-boot smoke with a real PPG install, label-flip promote, prune-based retention, weekly rebake
- Molecule consumer path (delegated-driver env exporter, token binding, pilot job) and an hourly leak janitor

**Why**
- PG QA is evaluating Hetzner as the primary substrate for package-test VMs with AWS as fallback
- Rocky/Alma seed from official Hetzner images; OL has none, so bases are rescue-uploaded once and the lineage chains from them
- Seven x86_64 combos are baked, smoke-passed and promoted (Rocky/Alma 8/9/10 + OL9). The OL8/OL10 rows follow once their bases are bootstrapped. The pilot ran the rocky-9 scenario green three times with zero leaks

**Tickets**
- [PKG-1433](https://perconadev.atlassian.net/browse/PKG-1433) (this)
- Companion: [Percona-QA/ppg-testing#128](https://github.com/Percona-QA/ppg-testing/pull/128) (molecule playbooks + PoC scenario, merge it first: the pilot job defaults point at it)

[PKG-1433]: https://perconadev.atlassian.net/browse/PKG-1433?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ