### PR TITLE
PS-11425: Run check-mysql-repo every month, not only CPU months

### DIFF
--- a/ps/jenkins/check_mysql_repo.groovy
+++ b/ps/jenkins/check_mysql_repo.groovy
@@ -51,8 +51,8 @@ pipeline {
         )
     }
     triggers {
-        // Hourly on months 1,4,7,10 from 2nd week to 4th week (days 8-28)
-        cron('H * 8-28 1,4,7,10 *')
+        // Hourly every month from 2nd week to 4th week (days 8-28)
+        cron('H * 8-28 * *')
     }
     options {
         disableConcurrentBuilds()

--- a/ps/jenkins/check_mysql_repo.yml
+++ b/ps/jenkins/check_mysql_repo.yml
@@ -14,4 +14,4 @@
       lightweight-checkout: false
       script-path: ps/jenkins/check_mysql_repo.groovy
     triggers:
-      - timed: "H * 8-28 1,4,7,10 *"
+      - timed: "H * 8-28 * *"


### PR DESCRIPTION
**Feature**
- `check-mysql-repo` now runs every month during weeks 2-4 (`H * 8-28 * *`), previously only in the quarterly CPU months (1, 4, 7, 10)

**Why**
- Oracle moved from quarterly CPUs to monthly CSPUs, so a new MySQL release can land any month
- A release outside the old window could sit undetected until the next quarterly run
- The pipeline `triggers` block and the JJB `timed` definition change together, staying in sync

**Tickets**
- [PS-11425](https://perconadev.atlassian.net/browse/PS-11425) (this)


[PS-11425]: https://perconadev.atlassian.net/browse/PS-11425?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ