### PR TITLE
K8SPG-949 Add Rancher support for PGO

### DIFF
--- a/cloud/common/vars/dependencies.groovy
+++ b/cloud/common/vars/dependencies.groovy
@@ -176,4 +176,38 @@ void installAzureCLI() {
     '''
 }
 
+void installExecutorDependencies(String testExecutorType) {
+    switch (testExecutorType) {
+        case 'kuttl':
+            installKuttl()
+            break
+
+        case 'make':
+            installUv()
+            syncPythonDeps()
+            break
+    }
+}
+
+void installProviderDependencies(Map libraries, String operator, String provider) {
+    // PSMDB requires Google and Azure CLIs, regardless of the provider.
+    // Rancher requires Google CLI to create cluster as GCE instances are used.
+
+    if (provider == 'gcloud' || provider == 'rancher' || operator == 'psmdb-operator') {
+        installGoogleCLI()
+        libraries.gcloud.auth()
+    }
+
+    if (provider == 'azure' || operator == 'psmdb-operator') {
+        installAzureCLI()
+        libraries.azure.auth()
+    }
+}
+
+void prepareNode(Map libraries, String testExecutorType,String operator, String provider) {
+    install()
+    installExecutorDependencies(testExecutorType)
+    installProviderDependencies(libraries, operator, provider)
+}
+
 return this

--- a/cloud/common/vars/dependencies.groovy
+++ b/cloud/common/vars/dependencies.groovy
@@ -117,11 +117,10 @@ void installPxcTools() {
         sudo yum install -y percona-xtrabackup-84
     '''
 }
-
-void installKuttl() {
-    sh '''
-        export PATH="${KREW_ROOT:-$HOME/.krew}/bin:$PATH"
-
+ 
+void installKuttl(String version = '0.25.0') {
+    sh """
+        export PATH="\${KREW_ROOT:-\$HOME/.krew}/bin:\$PATH"
         command -v kubectl-krew >/dev/null || {
             curl -fsSL https://github.com/kubernetes-sigs/krew/releases/latest/download/krew-linux_amd64.tar.gz | tar -xzf -
             ./krew-linux_amd64 install krew
@@ -129,11 +128,14 @@ void installKuttl() {
 
         command -v kubectl-assert >/dev/null || kubectl krew install assert
 
-        kubectl krew install --manifest-url \
-            https://raw.githubusercontent.com/kubernetes-sigs/krew-index/c16c6269999a2c2558e4fdc25df6eced0ab3dc27/plugins/kuttl.yaml
+        dir="\$(mktemp -d)"
+        git clone -q https://github.com/kubernetes-sigs/krew-index.git "\$dir"
+        commit=\$(git -C "\$dir" log -S"v${version}" --format='%H' -- plugins/kuttl.yaml | tail -1)
+        rm -rf "\$dir"
 
+        kubectl krew install --manifest-url "https://raw.githubusercontent.com/kubernetes-sigs/krew-index/\$commit/plugins/kuttl.yaml"
         kubectl kuttl --version
-    '''
+    """
 }
 
 void installOpenshiftClient(String platformVersion) {

--- a/cloud/common/vars/dependencies.groovy
+++ b/cloud/common/vars/dependencies.groovy
@@ -120,15 +120,19 @@ void installPxcTools() {
 
 void installKuttl() {
     sh '''
-        curl -fsSL https://github.com/kubernetes-sigs/krew/releases/latest/download/krew-linux_amd64.tar.gz | tar -xzf -
-        ./krew-linux_amd64 install krew
         export PATH="${KREW_ROOT:-$HOME/.krew}/bin:$PATH"
 
-        kubectl krew install assert
+        command -v kubectl-krew >/dev/null || {
+            curl -fsSL https://github.com/kubernetes-sigs/krew/releases/latest/download/krew-linux_amd64.tar.gz | tar -xzf -
+            ./krew-linux_amd64 install krew
+        }
 
-        # v0.25.0 kuttl version
-        kubectl krew install --manifest-url https://raw.githubusercontent.com/kubernetes-sigs/krew-index/c16c6269999a2c2558e4fdc25df6eced0ab3dc27/plugins/kuttl.yaml
-        echo $(kubectl kuttl --version) is installed
+        command -v kubectl-assert >/dev/null || kubectl krew install assert
+
+        kubectl krew install --manifest-url \
+            https://raw.githubusercontent.com/kubernetes-sigs/krew-index/c16c6269999a2c2558e4fdc25df6eced0ab3dc27/plugins/kuttl.yaml
+
+        kubectl kuttl --version
     '''
 }
 

--- a/cloud/common/vars/rancher.groovy
+++ b/cloud/common/vars/rancher.groovy
@@ -26,7 +26,7 @@ void createCluster(Map clusterCfg) {
         "CERT_MANAGER_VERSION=${clusterCfg.certManagerVersion ?: 'latest'}",
         "INSTALL_RKE2_CHANNEL=${clusterCfg.platformChannel ?: 'stable'}",
         "INSTALL_RKE2_VERSION=${clusterCfg.platformVersion ?: 'latest'}",
-        "KUBECONFIG=${clusterCfg.kubeconfig ?: '/tmp/kubeconfig'}"
+        "KUBECONFIG=${clusterCfg.kubeconfig}"
     ]
 
     // Default timeout for cluster creation is 60 minutes
@@ -58,8 +58,8 @@ void createCluster(Map clusterCfg) {
 void shutdownCluster(Map clusterCfg) {
     withEnv([
         "PREFIX=${cluster(clusterCfg)}",
-        "ZONE=${clusterCfg.zone ?: clusterCfg.region ?: env.GOOGLE_REGION ?: env.ZONE ?: 'us-central1-a'}",
-        "KUBECONFIG=${ clusterCfg.kubeconfig ?: env.KUBECONFIG ?: '/tmp/kubeconfig'}"
+        "ZONE=${clusterCfg.zone ?: clusterCfg.region ?: 'us-central1-a'}",
+        "KUBECONFIG=${ clusterCfg.kubeconfig}"
     ]) {
         sh '''
             set -euo pipefail
@@ -69,8 +69,8 @@ void shutdownCluster(Map clusterCfg) {
     }
 }
 
-def getLatestPlatformVersion(Map testVariables) {
-    def channel = testVariables.platform_channel
+String getLatestPlatformVersion(Map platformCfg) {
+    def channel = platformCfg.platform_channel
 
     return sh(
         script: """
@@ -81,7 +81,7 @@ def getLatestPlatformVersion(Map testVariables) {
     ).trim()
 }
 
-def getPlatformVersion(String prefixVersion) {
+String getPlatformVersion(String prefixVersion) {
     def parts = prefixVersion.tokenize('.')
     def channel = "v${parts[0]}.${parts[1]}"
 
@@ -98,7 +98,7 @@ def getPlatformVersion(String prefixVersion) {
     ).trim()
 }
 
-def getMachineType(String arch) {
+String getMachineType(String arch) {
     switch (arch) {
         case 'amd64':
             return 'e2-standard-4'

--- a/cloud/common/vars/tests.groovy
+++ b/cloud/common/vars/tests.groovy
@@ -648,7 +648,13 @@ void runTest(Map testConfig) {
             }
 
             if (attempt < maxAttempts) {
-                echo "Retrying ${testName} on the same cluster"
+                catchError(
+                    buildResult: 'SUCCESS',
+                    stageResult: 'SUCCESS',
+                    message: "Retrying ${testName} on the same cluster"
+                ) {
+                    error("Retrying ${testName} on the same cluster")
+                }
             }
         }
 

--- a/cloud/common/vars/tests.groovy
+++ b/cloud/common/vars/tests.groovy
@@ -652,7 +652,13 @@ void runTest(Map testConfig) {
             }
         }
 
-        currentBuild.result = 'FAILURE'
+        catchError(
+            buildResult: 'FAILURE',
+            stageResult: 'FAILURE',
+            message: "Test ${testName} failed after ${maxAttempts} attempts"
+        ) {
+            error("Test ${testName} failed after ${maxAttempts} attempts")
+        }
     } finally {
         updateTestTime(testVariables.tests, testId, elapsedSeconds(System.currentTimeMillis() - timeStart))
         try {
@@ -939,9 +945,17 @@ void publishPytestReports(Map config) {
         return
     }
 
+    def xmlReports = "${sourceDir}/e2e-tests/reports/*.xml"
     try {
         normalizeReports(tests, sourceDir)
+        junit testResults: xmlReports, healthScaleFactor: 1.0, allowEmptyResults: false
+        archiveArtifacts artifacts: "${xmlReports}, PipelineParameters.txt", allowEmptyArchive: false
+    } catch (err) {
+        echo "Warning: JUnit report publish failed: ${err}"
+        return
+    }
 
+    try {
         sh """
             export PATH="\$HOME/.local/bin:\$PATH"
             cd ${sourceDir}
@@ -953,8 +967,7 @@ void publishPytestReports(Map config) {
             formatReportDuration(reportHtml)
         }
 
-        junit testResults: reportXml, healthScaleFactor: 1.0, allowEmptyResults: true
-        archiveArtifacts artifacts: "${reportXml}, ${reportHtml}, PipelineParameters.txt", allowEmptyArchive: true
+        archiveArtifacts artifacts: "${reportXml}, ${reportHtml}", allowEmptyArchive: true
 
         if (pushToS3 && gitShortCommit && fileExists(reportHtml)) {
             pushReportFile(reportHtml, gitShortCommit)
@@ -964,7 +977,7 @@ void publishPytestReports(Map config) {
             currentBuild.description = currentBuild.description ? "${currentBuild.description} | ${reportLink}" : reportLink
         }
     } catch (err) {
-        echo "Warning: pytest report publish failed: ${err}"
+        echo "Warning: optional HTML report publish failed: ${err}"
     }
 }
 

--- a/cloud/common/vars/tests.groovy
+++ b/cloud/common/vars/tests.groovy
@@ -20,10 +20,6 @@ void loadCloudSecret(String operator) {
     }
 }
 
-String getKubeconfig(Map testVariables, String clusterSuffix) {
-    return "${testVariables.kubeconfigPath ?: '/tmp'}/${getClusterFullName(testVariables.cluster_name, clusterSuffix)}"
-}
-
 String getReleaseVersionsParam(String releaseVersions, String paramName, String keyName = null) {
     keyName = keyName ?: paramName
 
@@ -602,66 +598,72 @@ void removeCluster(List clusters, String clusterSuffix) {
 }
 
 void runTest(Map testConfig) {
-    def retryCount = 0
     def testVariables = testConfig.testVariables
     def testId = testConfig.testId
     def testName = testVariables.tests[testId].name
     def clusterSuffix = testConfig.clusterSuffix
+    def retries = (testConfig.retries ?: 1) as Integer
+    def maxAttempts = retries + 1
+    def timeStart = System.currentTimeMillis()
 
-    waitUntil {
-        def timeStart = System.currentTimeMillis()
+    updateTestResult(testVariables.tests, testId, "failure")
 
-        try {
-            echo "The ${testName} test was started on cluster ${getClusterFullName(testVariables.cluster_name, clusterSuffix)}!"
-            updateTestResult(testVariables.tests, testId, "failure")
+    try {
+        for (int attempt = 1; attempt <= maxAttempts; attempt++) {
+            echo "The ${testName} test was started on cluster ${getClusterFullName(testVariables.cluster_name, clusterSuffix)} (attempt ${attempt}/${maxAttempts})!"
 
+            def exitCode = 1
+            try {
+                timeout(time: 90, unit: 'MINUTES') {
+                    def exports = getExportedVariablesForTests(testVariables, clusterSuffix)
+                    def command = defineTestCommand(testVariables, testName)
 
-            timeout(time: 90, unit: 'MINUTES') {
-                def exports = getExportedVariablesForTests(testVariables, clusterSuffix)
-                def command = defineTestCommand(testVariables, testName)
-
-                sh """
-                    cd source
-                    ${exports}
-                    ${command}
-                """
+                    exitCode = sh(
+                        script: """
+                            cd source
+                            ${exports}
+                            ${command}
+                        """,
+                        returnStatus: true
+                    )
+                }
+            } catch (exc) {
+                echo "Error occurred while running test ${testName}: ${exc}"
             }
 
-            pushArtifactFile(
-                artifactFileName(testVariables, testName),
-                testVariables.git_short_commit
-            )
+            if (exitCode == 0) {
+                pushArtifactFile(
+                    artifactFileName(testVariables, testName),
+                    testVariables.git_short_commit
+                )
+                updateTestResult(testVariables.tests, testId, "passed")
+                return
+            }
 
-            updateTestResult(testVariables.tests, testId, "passed")
-            return true
-
-        } catch (exc) {
+            echo "The ${testName} test failed with exit code ${exitCode} on attempt ${attempt}/${maxAttempts}"
             try {
                 testVariables.libraries.tools.kubernetesCleanupFailedTestNamespaces(testVariables, testName, clusterSuffix)
             } catch (cleanupErr) {
                 echo "Warning: failed to cleanup namespaces for ${testName}: ${cleanupErr}"
             }
 
-            if (retryCount >= (testConfig.retries ?: 1)) {
-                currentBuild.result = 'FAILURE'
-                return true
+            if (attempt < maxAttempts) {
+                echo "Retrying ${testName} on the same cluster"
             }
-
-            retryCount++
-            return false
-
-        } finally {
-            updateTestTime(testVariables.tests, testId, elapsedSeconds(System.currentTimeMillis() - timeStart))
-            try {
-                pushLogFile(testName, [
-                    sourceDir     : 'source',
-                    gitShortCommit: testVariables.git_short_commit
-                ])
-            } catch (logErr) {
-                echo "Warning: failed to push log for ${testName}: ${logErr}"
-            }
-            echo "The ${testName} test was finished!"
         }
+
+        currentBuild.result = 'FAILURE'
+    } finally {
+        updateTestTime(testVariables.tests, testId, elapsedSeconds(System.currentTimeMillis() - timeStart))
+        try {
+            pushLogFile(testName, [
+                sourceDir     : 'source',
+                gitShortCommit: testVariables.git_short_commit
+            ])
+        } catch (logErr) {
+            echo "Warning: failed to push log for ${testName}: ${logErr}"
+        }
+        echo "The ${testName} test was finished!"
     }
 }
 

--- a/cloud/common/vars/tests.groovy
+++ b/cloud/common/vars/tests.groovy
@@ -752,13 +752,13 @@ Map buildParallelClusterStages(Map testVariables) {
             stage(clusterSuffix) {
                 if (testVariables.jenkins_agent_label) {
                     node(testVariables.jenkins_agent_label) {
+                        libraries.tools.unstashClonedGitFiles()
                         libraries.dependencies.prepareNode(
                             testVariables.libraries,
                             testVariables.test_executor_type,
                             testVariables.operator,
-                            testVariables.provider
+                            testVariables.platform_provider
                         )
-                        libraries.tools.unstashClonedGitFiles()
                         clusterRunner(clusterSuffix, testVariables)
                     }
                 } else {

--- a/cloud/common/vars/tests.groovy
+++ b/cloud/common/vars/tests.groovy
@@ -1,12 +1,27 @@
 void loadCloudSecret(String operator) {
-    withCredentials([file(
-        credentialsId: "cloud-secret-file-${operator}",
-        variable: 'CLOUD_SECRET_FILE'
-    )]) {
+    def credentialsId = operator in ["pg-operator", "pxc-operator"] ? "cloud-secret-file" : "cloud-secret-file-${operator}"
+
+    withCredentials([
+        file(
+            credentialsId: credentialsId,
+            variable: 'CLOUD_SECRET_FILE'
+        ),
+        file(
+            credentialsId: 'cloud-minio-secret-file', 
+            variable: 'CLOUD_MINIO_SECRET_FILE'
+        )
+    ]) {
         sh '''
             cp "$CLOUD_SECRET_FILE" source/e2e-tests/conf/cloud-secret.yml
+            chmod 600 source/e2e-tests/conf/cloud-secret.yml
+            cp "$CLOUD_MINIO_SECRET_FILE" source/e2e-tests/conf/cloud-secret-minio-gw.yml
+            chmod 600 source/e2e-tests/conf/cloud-secret-minio-gw.yml
         '''
     }
+}
+
+String getKubeconfig(Map testVariables, String clusterSuffix) {
+    return "${testVariables.kubeconfigPath ?: '/tmp'}/${getClusterFullName(testVariables.cluster_name, clusterSuffix)}"
 }
 
 String getReleaseVersionsParam(String releaseVersions, String paramName, String keyName = null) {
@@ -29,16 +44,16 @@ String getClusterFullName(String clusterName, String clusterSuffix) {
     return "${clusterName}-${clusterSuffix}"
 }
 
-String imageTag(String image, String fallback = "main") {
+String imageTag(String image) {
     if (!image?.trim()) {
-        return fallback
+        return ""
     }
 
     def parts = image.tokenize(":")
-    return parts.size() > 1 ? parts[-1] : fallback
+    return parts.size() > 1 ? parts[-1] : ""
 }
 
-String getDbTag(Map testVariables, String fallback = "main") {
+String getDbTag(Map testVariables) {
     def dbImage = [
         testVariables.images?.IMAGE_MONGOD,
         testVariables.images?.IMAGE_MYSQL,
@@ -46,7 +61,15 @@ String getDbTag(Map testVariables, String fallback = "main") {
         testVariables.images?.IMAGE_POSTGRESQL
     ].find { it?.trim() }
 
-    return imageTag(dbImage, fallback)
+    return imageTag(dbImage)
+}
+
+String getDbVersion(Map testVariables) {
+    return [
+        testVariables.pillar_version,
+        testVariables.db_version,
+        testVariables.db_tag
+    ].find { it?.toString()?.trim() && !it.toString().equalsIgnoreCase("none") } ?: ""
 }
 
 String getMinorPlatformVersion(String platformVersion) {
@@ -61,7 +84,7 @@ String buildJobDescription(Map testVariables) {
     return [
         getMinorPlatformVersion("${testVariables.platform_version}"),
         arch,
-        testVariables.db_tag ?: getDbTag(testVariables),
+        getDbVersion(testVariables),
         cw
     ].findAll { it?.trim() }.join(" ")
 }
@@ -95,7 +118,7 @@ void printTestVariables(Map testVariables) {
 }
 
 String getReleaseParamName(String imageName, String pillarVersion, String operator) {
-    def versionedImages = [
+    def operatorImages = [
         "psmdb-operator": [
             IMAGE_MONGOD: "IMAGE_MONGOD${pillarVersion}"
         ],
@@ -107,12 +130,19 @@ String getReleaseParamName(String imageName, String pillarVersion, String operat
             IMAGE_BACKUP: "IMAGE_BACKUP${pillarVersion}"
         ],
         "pg-operator": [
-            IMAGE_PGBOUNCER: "IMAGE_PGBOUNCER${pillarVersion}",
-            IMAGE_BACKREST : "IMAGE_BACKREST${pillarVersion}"
+            IMAGE_POSTGRESQL: "IMAGE_POSTGRESQL${pillarVersion}",
+            IMAGE_PGBOUNCER : "IMAGE_PGBOUNCER${pillarVersion}",
+            IMAGE_BACKREST  : "IMAGE_BACKREST${pillarVersion}"
         ]
     ]
 
-    return versionedImages[operator?.toLowerCase()]?.get(imageName) ?: imageName
+    if (operator?.equalsIgnoreCase("pg-operator") &&
+        imageName == "IMAGE_POSTGRESQL" &&
+        pillarVersion.endsWith("-postgis")) {
+        return "IMAGE_POSTGIS${pillarVersion}"
+    }
+
+    return operatorImages[operator?.toLowerCase()]?.get(imageName) ?: imageName
 }
 
 Boolean isReleaseRun(Map testVariables) {
@@ -140,32 +170,23 @@ void resolveReleaseRunParams(Map testVariables) {
     }
 }
 
-Boolean resolveReleasePlatformVersion(Map testVariables) {
-    if (!(testVariables.platform_version?.toLowerCase() in ["min", "max"])) {
-        return false
-    }
-
-    testVariables.platform_version = getReleaseVersionsParam(
-        testVariables.release_versions,
-        "${testVariables.platform.toUpperCase()}_${testVariables.platform_version.toUpperCase()}"
-    )
-
-    testVariables.platform_version = testVariables.libraries[testVariables.platform_provider].getPlatformVersion(
-        testVariables.platform_version
-    )
-
-    return true
-}
-
-void resolvePlatformVersion(Map testVariables, Boolean platformFromReleaseVersions) {
+void resolvePlatformVersion(Map testVariables) {
     def library = testVariables.libraries[testVariables.platform_provider]
-    if (testVariables.platform_version == "latest") {
-        testVariables.platform_version = library.getLatestPlatformVersion(testVariables)
-    } else if (!platformFromReleaseVersions) {
-        testVariables.platform_version = library.getPlatformVersion(
-            testVariables.platform_version
+    def platformVersion = testVariables.platform_version
+
+    if (platformVersion?.toLowerCase() in ["min", "max"]) {
+        platformVersion = getReleaseVersionsParam(
+            testVariables.release_versions,
+            "${testVariables.platform.toUpperCase()}_${platformVersion.toUpperCase()}"
         )
+    } else if (platformVersion == "latest") {
+        platformVersion = library.getLatestPlatformVersion(testVariables)
+
+        testVariables.platform_version = platformVersion
+        return
     }
+
+    testVariables.platform_version = library.getPlatformVersion(platformVersion)
 }
 
 void resolveMachineType(Map testVariables) {
@@ -183,12 +204,11 @@ Map prepareVersions(Map testVariables) {
         echo "=========================[ Not a release run. Using job params only! ]========================="
     }
 
-    def platformFromReleaseVersions = resolveReleasePlatformVersion(testVariables)
-    resolvePlatformVersion(testVariables, platformFromReleaseVersions)
+    resolvePlatformVersion(testVariables)
     resolveMachineType(testVariables)
 
-    if (!testVariables.db_tag || testVariables.db_tag == "main") {
-        testVariables.db_tag = getDbTag(testVariables, testVariables.db_tag ?: "main")
+    if (!testVariables.db_tag) {
+        testVariables.db_tag = getDbTag(testVariables)
     }
 
     testVariables.git_short_commit = sh(
@@ -263,7 +283,7 @@ void initTests(List tests, Map testVariables, Map config) {
             """
 
             tests.each { test ->
-                def file = artifactFileName(buildArtifactParams(testVariables, test.name))
+                def file = artifactFileName(testVariables, test.name)
                 def retFileExists = sh(
                     script: "aws s3api head-object --bucket percona-jenkins-artifactory --key ${testVariables.job_name}/${testVariables.git_short_commit}/${file} >/dev/null 2>&1",
                     returnStatus: true
@@ -287,20 +307,16 @@ void initTests(List tests, Map testVariables, Map config) {
     }
 }
 
-String artifactFileName(Map cfg) {
-    return "${cfg.gitBranch}-${cfg.gitShortCommit}-${cfg.testName}-${cfg.platformVersion}-${cfg.dbTag}-CW_${cfg.clusterWide}-${cfg.paramsHash}"
-}
-
-Map buildArtifactParams(Map testVariables, String testName) {
+String artifactFileName(Map cfg, String testName) {
     return [
-        gitBranch     : testVariables.git_branch,
-        gitShortCommit: testVariables.git_short_commit,
-        testName      : testName,
-        platformVersion : testVariables.platform_version,
-        dbTag         : testVariables.db_tag,
-        clusterWide   : testVariables.cluster_wide,
-        paramsHash    : testVariables.params_hash
-    ]
+        testVariables.git_branch,
+        testVariables.git_short_commit,
+        testName,
+        testVariables.platform_version,
+        getDbVersion(testVariables),
+        "CW_${testVariables.cluster_wide}",
+        testVariables.params_hash
+    ].findAll { it?.toString()?.trim() }.join("-")
 }
 
 String buildParamsHash(Map testVariables) {
@@ -311,7 +327,7 @@ String buildParamsHash(Map testVariables) {
         testVariables.cluster_wide,
         testVariables.platform_arch,
         testVariables.platform_channel,
-        testVariables.pillar_version
+        getDbVersion(testVariables),
     ].findAll { it != null }
 
     testVariables.images.values().findAll { it }.each { imageValue ->
@@ -358,7 +374,7 @@ void updateListWithLastExecutionStatus(Map testVariables) {
         """
 
         testVariables.tests.each { test ->
-            def file = artifactFileName(buildArtifactParams(testVariables, test.name))
+            def file = artifactFileName(testVariables, test.name)
             def retFileExists = sh(
                 script: """
                     aws s3api head-object \
@@ -472,15 +488,23 @@ Map buildPxcTestVariables(Map config) {
 }
 
 String defineTestCommand(Map testVariables, String testName) {
-    if (testVariables.test_executor_type == "kuttl") {
-        return "kubectl kuttl test --config e2e-tests/kuttl.yaml --test '^${testName}\$'"
-    }
+    switch (testVariables.test_executor_type) {
+        case "kuttl":
+            return """
+                export PATH="\${KREW_ROOT:-\$HOME/.krew}/bin:\$PATH"
+                kubectl kuttl test --config e2e-tests/kuttl.yaml --test '^${testName}\$'
+            """
 
-    if (testVariables.test_executor_type == "make") {
-        return "make e2e-test TEST=${testName}"
-    }
+        case "make":
+            return """
+                mkdir -p e2e-tests/{logs,reports}
+                set -o pipefail
+                make e2e-test TEST=${testName} 2>&1 | tee e2e-tests/logs/${testName}.log
+            """
 
-    return "e2e-tests/${testName}/run"
+        default:
+            return "e2e-tests/${testName}/run"
+    }
 }
 
 void cleanupFailedTestNamespaces(Map testVariables, String testName, String clusterSuffix) {
@@ -598,20 +622,13 @@ void runTest(Map testConfig) {
 
                 sh """
                     cd source
-
                     ${exports}
-
-                    mkdir -p e2e-tests/logs e2e-tests/reports
-                    bash -o pipefail <<BASH
-                    {
-                        ${command}
-                    } 2>&1 | tee e2e-tests/logs/${testName}.log
-BASH
+                    ${command}
                 """
             }
 
             pushArtifactFile(
-                artifactFileName(buildArtifactParams(testVariables, testName)),
+                artifactFileName(testVariables, testName),
                 testVariables.git_short_commit
             )
 
@@ -620,7 +637,7 @@ BASH
 
         } catch (exc) {
             try {
-                cleanupFailedTestNamespaces(testVariables, testName, clusterSuffix)
+                testVariables.libraries.tools.kubernetesCleanupFailedTestNamespaces(testVariables, testName, clusterSuffix)
             } catch (cleanupErr) {
                 echo "Warning: failed to cleanup namespaces for ${testName}: ${cleanupErr}"
             }
@@ -719,7 +736,7 @@ void clusterRunner(String clusterSuffix, Map testVariables) {
     }
 }
 
-Map getParallelStages(Map testVariables) {
+Map buildParallelClusterStages(Map testVariables) {
     def parallelStages = [:]
 
     testVariables.clusters = testVariables.clusters ?: []
@@ -733,7 +750,20 @@ Map getParallelStages(Map testVariables) {
 
         parallelStages[clusterSuffix] = {
             stage(clusterSuffix) {
-                clusterRunner(clusterSuffix, testVariables)
+                if (testVariables.jenkins_agent_label) {
+                    node(testVariables.jenkins_agent_label) {
+                        libraries.dependencies.prepareNode(
+                            testVariables.libraries,
+                            testVariables.test_executor_type,
+                            testVariables.operator,
+                            testVariables.provider
+                        )
+                        libraries.tools.unstashClonedGitFiles()
+                        clusterRunner(clusterSuffix, testVariables)
+                    }
+                } else {
+                    clusterRunner(clusterSuffix, testVariables)
+                }
             }
         }
     }

--- a/cloud/common/vars/tests.groovy
+++ b/cloud/common/vars/tests.groovy
@@ -951,16 +951,6 @@ void publishPytestReports(Map config) {
         return
     }
 
-    def xmlReports = "${sourceDir}/e2e-tests/reports/*.xml"
-    try {
-        normalizeReports(tests, sourceDir)
-        junit testResults: xmlReports, healthScaleFactor: 1.0, allowEmptyResults: false
-        archiveArtifacts artifacts: "${xmlReports}, PipelineParameters.txt", allowEmptyArchive: false
-    } catch (err) {
-        echo "Warning: JUnit report publish failed: ${err}"
-        return
-    }
-
     try {
         sh """
             export PATH="\$HOME/.local/bin:\$PATH"

--- a/cloud/common/vars/tools.groovy
+++ b/cloud/common/vars/tools.groovy
@@ -110,7 +110,7 @@ void dockerBuildAndPush(Map cfg) {
                 cd source
 
                 sg docker -c '
-                    docker buildx create --use || true
+                    docker buildx use multiarch 2>/dev/null || docker buildx create --name multiarch --use
                     echo "\$PASS" | docker login -u "\$USER" --password-stdin
                     export IMAGE=${cfg.operatorImage}:${cfg.branch}
                     if [[ "$cfg.operator" == "pg-operator" ]]; then

--- a/cloud/common/vars/tools.groovy
+++ b/cloud/common/vars/tools.groovy
@@ -16,6 +16,14 @@ void gitClone(Map cfg) {
             git clone -b "$GIT_BRANCH_NAME" "$GIT_REPO_URL" source
         '''
     }
+
+    stash name: 'sourceFILES', includes: 'source/**'
+}
+
+void unstashClonedGitFiles() {
+    deleteDir()
+    checkout scm
+    unstash 'sourceFILES'
 }
 
 void gitResetWorkspace() {
@@ -26,7 +34,7 @@ void gitResetWorkspace() {
     '''
 }
 
-def kubernetesCleanupCluster(String kubeconfig) {
+void kubernetesCleanupCluster(String kubeconfig) {
     sh """
         export KUBECONFIG=${kubeconfig}
 
@@ -53,6 +61,40 @@ def kubernetesCleanupCluster(String kubeconfig) {
     """
 }
 
+void kubernetesCleanupFailedTestNamespaces(Map testVariables, String testName, String clusterSuffix) {
+    def kubeconfig = getKubeconfig(testVariables, clusterSuffix)
+
+    echo "Cleaning failed test namespaces for ${testName} on ${getClusterFullName(testVariables.cluster_name, clusterSuffix)}"
+
+    sh """
+        set +e
+        export FAILED_TEST_NAME='${testName}'
+        export KUBECONFIG='${kubeconfig}'
+        if [ ! -s "\$KUBECONFIG" ] || ! kubectl get --raw='/healthz' --request-timeout=5s >/dev/null 2>&1; then
+            echo "Skipping failed test namespace cleanup: Kubernetes API is not reachable for \$KUBECONFIG"
+            exit 0
+        fi
+        kubectl get namespaces --request-timeout=10s --no-headers \
+            | awk '{print \$1}' \
+            | while read -r namespace; do
+                case "\$namespace" in
+                    "\$FAILED_TEST_NAME"-*|kuttl*)
+                        echo "Removing finalizers from resources in namespace: \$namespace"
+                        kubectl api-resources --verbs=list --namespaced -o name --request-timeout=10s \
+                            | while read -r resource; do
+                                kubectl get "\$resource" -n "\$namespace" -o name --ignore-not-found --request-timeout=10s 2>/dev/null \
+                                    | while read -r object; do
+                                        kubectl patch "\$object" -n "\$namespace" --type=merge -p '{"metadata":{"finalizers":[]}}' --request-timeout=10s || true
+                                    done
+                            done
+                        echo "Deleting namespace: \$namespace"
+                        kubectl delete namespace "\$namespace" --force --grace-period=0 --wait=false --request-timeout=10s || true
+                        ;;
+                esac
+            done
+    """
+}
+
 void dockerBuildAndPush(Map cfg) {
     echo "=========================[ Building and Pushing ${cfg.operatorImage} Docker image ]========================="
 
@@ -68,11 +110,14 @@ void dockerBuildAndPush(Map cfg) {
                 cd source
 
                 sg docker -c '
-                    docker buildx use multiarch 2>/dev/null || docker buildx create --name multiarch --use
+                    docker buildx create --use || true
                     echo "\$PASS" | docker login -u "\$USER" --password-stdin
                     export IMAGE=${cfg.operatorImage}:${cfg.branch}
-                    ${cfg.platform ? "export DOCKER_DEFAULT_PLATFORM=${cfg.platform}" : ""}
-                    e2e-tests/build
+                    if [[ "$cfg.operator" == "pg-operator" ]]; then
+                        DOCKER_DEFAULT_PLATFORM=linux/amd64,linux/arm64 make build
+                    else
+                        DOCKER_DEFAULT_PLATFORM=linux/amd64,linux/arm64 e2e-tests/build
+                    fi
                     docker logout
                 '
 

--- a/cloud/common/vars/tools.groovy
+++ b/cloud/common/vars/tools.groovy
@@ -62,9 +62,10 @@ void kubernetesCleanupCluster(String kubeconfig) {
 }
 
 void kubernetesCleanupFailedTestNamespaces(Map testVariables, String testName, String clusterSuffix) {
-    def kubeconfig = getKubeconfig(testVariables, clusterSuffix)
+    def clusterName = "${testVariables.cluster_name}-${clusterSuffix}"
+    def kubeconfig = "${testVariables.kubeconfigPath}/${clusterName}"
 
-    echo "Cleaning failed test namespaces for ${testName} on ${getClusterFullName(testVariables.cluster_name, clusterSuffix)}"
+    echo "Cleaning failed test namespaces for ${testName} on ${clusterName}"
 
     sh """
         set +e

--- a/cloud/jenkins/pgo-rancher-1.yml
+++ b/cloud/jenkins/pgo-rancher-1.yml
@@ -1,0 +1,23 @@
+- job:
+    name: pgo-rancher-1
+    project-type: pipeline
+    description: |
+        Do not edit this job through the web!
+    concurrent: false
+    properties:
+    - build-discarder:
+        days-to-keep: -1
+        num-to-keep: 10
+        artifact-days-to-keep: -1
+        artifact-num-to-keep: 10
+    - copyartifact:
+        projects: "weekly-pgo"
+    pipeline-scm:
+      scm:
+        - git:
+            url: https://github.com/Percona-Lab/jenkins-pipelines.git
+            branches:
+            - master
+            wipe-workspace: false
+      lightweight-checkout: true
+      script-path: cloud/jenkins/pgo_rancher.groovy

--- a/cloud/jenkins/pgo-rancher-2.yml
+++ b/cloud/jenkins/pgo-rancher-2.yml
@@ -1,0 +1,23 @@
+- job:
+    name: pgo-rancher-2
+    project-type: pipeline
+    description: |
+        Do not edit this job through the web!
+    concurrent: false
+    properties:
+    - build-discarder:
+        days-to-keep: -1
+        num-to-keep: 10
+        artifact-days-to-keep: -1
+        artifact-num-to-keep: 10
+    - copyartifact:
+        projects: "weekly-pgo"
+    pipeline-scm:
+      scm:
+        - git:
+            url: https://github.com/Percona-Lab/jenkins-pipelines.git
+            branches:
+            - master
+            wipe-workspace: false
+      lightweight-checkout: true
+      script-path: cloud/jenkins/pgo_rancher.groovy

--- a/cloud/jenkins/pgo_rancher.groovy
+++ b/cloud/jenkins/pgo_rancher.groovy
@@ -238,7 +238,6 @@ pipeline {
                 libraries.tools.dockerCleanupVolumes()
             }
 
-            junit testResults: '*.xml', healthScaleFactor: 1.0, allowEmptyResults: true
             archiveArtifacts artifacts: '*.xml,*.txt', allowEmptyArchive: true
             deleteDir()
         }

--- a/cloud/jenkins/pgo_rancher.groovy
+++ b/cloud/jenkins/pgo_rancher.groovy
@@ -199,7 +199,7 @@ pipeline {
                         .replace(']]', ']')
                         .replaceFirst('\\[', '')
 
-                libraries.tests.makeReport(testVariables.tests, testVariables)
+                libraries.tests.makeReportJUnit(testVariables.tests, testVariables)
 
                 try {
                     def sendJobSlack = load('cloud/common/sendJobSlackNotification.groovy')
@@ -238,6 +238,7 @@ pipeline {
                 libraries.tools.dockerCleanupVolumes()
             }
 
+            junit testResults: 'TestsReport.xml', healthScaleFactor: 1.0, allowEmptyResults: true
             archiveArtifacts artifacts: '*.xml,*.txt', allowEmptyArchive: true
             deleteDir()
         }

--- a/cloud/jenkins/pgo_rancher.groovy
+++ b/cloud/jenkins/pgo_rancher.groovy
@@ -1,13 +1,12 @@
 import groovy.transform.Field
 
-@Field Integer numClusters = 8
+@Field Integer numClusters = 4
 @Field List clusters = []
 
 @Field Map libraries = [:]
 @Field Map testVariables = [:]
-@Field String clusterType = "rancher"
-@Field String sourceRepo = 'https://github.com/percona/percona-server-mongodb-operator'
-@Field String operatorImage = 'docker.io/perconalab/percona-server-mongodb-operator'
+@Field String sourceRepo = 'https://github.com/percona/percona-postgresql-operator'
+@Field String operatorImage = 'docker.io/perconalab/percona-postgresql-operator'
 
 def getLibraries() {
     def loader = load('cloud/common/libraries.groovy')
@@ -15,36 +14,30 @@ def getLibraries() {
 }
 
 pipeline {
-    environment {
-        CLEAN_NAMESPACE = 1
-        DB_TAG = sh(
-            script: '''[[ "$IMAGE_MONGOD" ]] && echo "$IMAGE_MONGOD" | awk -F':' '{print $2}' || echo main''',
-            returnStdout: true
-        ).trim()
-    }
-
     parameters {
-        choice(name: 'TEST_SUITE', choices: ['run-release.csv', 'run-distro.csv', 'run-backups.csv'], description: 'Choose test suite from file')
+        choice(name: 'TEST_SUITE', choices: ['run-release.csv', 'run-distro.csv'], description: 'Choose test suite from file')
         text(name: 'TEST_LIST', defaultValue: '', description: 'List of tests to run separated by new line')
         choice(name: 'IGNORE_PREVIOUS_RUN', choices: ['NO', 'YES'], description: 'Ignore passed tests in previous run')
-        choice(name: 'PILLAR_VERSION', choices: ['none', '80', '83', '70', '60'], description: 'Set to 60/70/80/83 for a release run. Release runs force PLATFORM_CHANNEL=stable and load images from source/e2e-tests/release_versions.')
+        choice(name: 'PILLAR_VERSION', choices: ['none', '14', '14-postgis', '15', '15-postgis', '16', '16-postgis', '17', '17-postgis', '18', '18-postgis'], description: 'Set PG version for a release run. Release runs force PLATFORM_CHANNEL=stable and load images from source/e2e-tests/release_versions.')
         string(name: 'GIT_BRANCH', defaultValue: 'main', description: 'Tag/Branch')
         choice(name: 'PLATFORM_CHANNEL', choices: ['stable', 'latest', 'testing'], description: 'Used when PLATFORM_VERSION=latest. Release runs override this to stable.')
-        string(name: 'PLATFORM_VERSION', defaultValue: 'latest', description:  'RKE2/Kubernetes version. Use latest to resolve from PLATFORM_CHANNEL, min to use RKE2_MIN from release_versions, max to use RKE2_MAX from release_versions, or pass an explicit version.')
-        string(name: 'PLATFORM_ARCH', defaultValue: 'amd64', description: 'Platform architecture used to select the machine type, for example amd64 or arm64.')
+        string(name: 'PLATFORM_VERSION', defaultValue: 'latest', description: 'RKE2/Kubernetes version. Use latest to resolve from PLATFORM_CHANNEL, min to use RKE2_MIN from release_versions, max to use RKE2_MAX from release_versions, or pass an explicit version.')
+        choice(name: 'PLATFORM_ARCH', choices: ['amd64', 'arm64'], description: 'Platform architecture used to select the machine type.')
         string(name: 'RANCHER_VERSION', defaultValue: 'latest', description: 'Rancher chart version. In release runs, latest or empty is replaced with RANCHER from source/e2e-tests/release_versions.')
         string(name: 'RANCHER_ZONE', defaultValue: 'us-central1-a', description: 'Google zone to schedule Rancher instances')
+        string(name: 'PG_VERSION', defaultValue: '', description: 'PostgreSQL version used to generate DB_TAG and select release image keys, for example 14, 15, 16, 17, or 18.')
         choice(name: 'CLUSTER_WIDE', choices: ['YES', 'NO'], description: 'Run tests in cluster-wide mode')
+        choice(name: 'SKIP_TEST_WARNINGS', choices: ['false', 'true'], description: 'Skip test warnings that require release documentation')
 
-        string(name: 'IMAGE_OPERATOR', defaultValue: '', description: 'ex: perconalab/percona-server-mongodb-operator:main')
-        string(name: 'IMAGE_MONGOD', defaultValue: '', description: 'ex: perconalab/percona-server-mongodb-operator:main-mongod8.0')
-        string(name: 'IMAGE_BACKUP', defaultValue: '', description: 'ex: perconalab/percona-server-mongodb-operator:main-backup')
-        string(name: 'IMAGE_PMM_CLIENT', defaultValue: '', description: 'ex: perconalab/pmm-client:dev-latest')
-        string(name: 'IMAGE_PMM_SERVER', defaultValue: '', description: 'ex: perconalab/pmm-server:dev-latest')
-        string(name: 'IMAGE_PMM3_CLIENT', defaultValue: '', description: 'ex: perconalab/pmm-client:3-dev-latest')
-        string(name: 'IMAGE_PMM3_SERVER', defaultValue: '', description: 'ex: perconalab/pmm-server:3-dev-latest')
-        string(name: 'IMAGE_LOGCOLLECTOR', defaultValue: '', description: 'ex: perconalab/fluentbit:main-logcollector')
-        string(name: 'IMAGE_SEARCH', defaultValue: '', description: 'ex: perconalab/percona-server-mongodb-operator:main-mongot')
+        string(name: 'IMAGE_OPERATOR', defaultValue: '', description: 'Example: perconalab/percona-postgresql-operator:main')
+        string(name: 'IMAGE_POSTGRESQL', defaultValue: '', description: 'Example: perconalab/percona-postgresql-operator:main-ppg18-postgres')
+        string(name: 'IMAGE_PGBOUNCER', defaultValue: '', description: 'Example: perconalab/percona-postgresql-operator:main-pgbouncer18')
+        string(name: 'IMAGE_BACKREST', defaultValue: '', description: 'Example: perconalab/percona-postgresql-operator:main-pgbackrest18')
+        string(name: 'IMAGE_PMM_CLIENT', defaultValue: '', description: 'Example: perconalab/pmm-client:dev-latest')
+        string(name: 'IMAGE_PMM_SERVER', defaultValue: '', description: 'Example: perconalab/pmm-server:dev-latest')
+        string(name: 'IMAGE_PMM3_CLIENT', defaultValue: '', description: 'Example: perconalab/pmm-client:3-dev-latest')
+        string(name: 'IMAGE_PMM3_SERVER', defaultValue: '', description: 'Example: perconalab/pmm-server:3-dev-latest')
+        string(name: 'IMAGE_UPGRADE', defaultValue: '', description: 'Example: perconalab/percona-postgresql-operator:main-upgrade')
 
         choice(name: 'DEBUG_TESTS', choices: ['NO', 'YES'], description: 'Enable debug mode for tests')
         choice(name: 'JENKINS_AGENT', choices: ['Hetzner', 'AWS'], description: 'Jenkins agent provider')
@@ -64,11 +57,10 @@ pipeline {
         skipDefaultCheckout()
         disableConcurrentBuilds()
         timeout(time: 6, unit: 'HOURS')
-        copyArtifactPermission('psmdb-operator-latest-scheduler');
     }
 
     stages {
-        stage ('Init Workspace') {
+        stage('Init Workspace') {
             steps {
                 script {
                     deleteDir()
@@ -87,8 +79,8 @@ pipeline {
                 script {
                     libraries.dependencies.prepareNode(
                         libraries,
-                        'make',
-                        'psmdb-operator',
+                        'kuttl',
+                        'pg-operator',
                         'rancher'
                     )
                 }
@@ -101,7 +93,7 @@ pipeline {
                     libraries.tools.dockerBuildAndPush(
                         operatorImage: operatorImage,
                         branch: GIT_BRANCH,
-                        platform: 'linux/amd64,linux/arm64'
+                        operator: 'pg-operator'
                     )
                 }
             }
@@ -110,12 +102,15 @@ pipeline {
         stage('Prepare Test Variables') {
             steps {
                 script {
-                    // rke2 is the Kubernetes version used in Rancher clusters, so we set it as platform version for proper test selection
-                    // Rancher version used to define Rancher chart version for test, the chart contains Kubernetes manifests for Rancher management and downstream clusters
+                    def extraEnvs = [
+                        SKIP_TEST_WARNINGS: SKIP_TEST_WARNINGS,
+                        PG_VER: PG_VERSION
+                    ]
+
                     testVariables = libraries.tests.prepareVersions([
                         libraries             : libraries,
                         release_versions      : 'source/e2e-tests/release_versions',
-                        operator              : 'psmdb-operator',
+                        operator              : 'pg-operator',
 
                         platform              : 'rke2',
                         platform_provider     : 'rancher',
@@ -125,29 +120,32 @@ pipeline {
                         rancher_version       : RANCHER_VERSION,
                         worker_count          : 4,
                         zone                  : RANCHER_ZONE,
-                        
+
                         cluster_wide          : CLUSTER_WIDE,
                         pillar_version        : PILLAR_VERSION,
 
                         git_branch            : GIT_BRANCH,
+                        source_repo           : sourceRepo,
                         job_name              : JOB_NAME,
-                        db_tag                : DB_TAG,
+                        db_version            : PG_VERSION,
                         debug_tests           : DEBUG_TESTS,
-                        test_executor_type    : 'make',
+                        test_executor_type    : 'kuttl',
 
                         default_operator_image: "${operatorImage}:${GIT_BRANCH}",
 
                         images: [
                             IMAGE_OPERATOR    : IMAGE_OPERATOR,
-                            IMAGE_MONGOD      : IMAGE_MONGOD,
-                            IMAGE_BACKUP      : IMAGE_BACKUP,
+                            IMAGE_POSTGRESQL  : IMAGE_POSTGRESQL,
+                            IMAGE_PGBOUNCER   : IMAGE_PGBOUNCER,
+                            IMAGE_BACKREST    : IMAGE_BACKREST,
                             IMAGE_PMM_CLIENT  : IMAGE_PMM_CLIENT,
                             IMAGE_PMM_SERVER  : IMAGE_PMM_SERVER,
                             IMAGE_PMM3_CLIENT : IMAGE_PMM3_CLIENT,
                             IMAGE_PMM3_SERVER : IMAGE_PMM3_SERVER,
-                            IMAGE_LOGCOLLECTOR: IMAGE_LOGCOLLECTOR,
-                            IMAGE_SEARCH      : IMAGE_SEARCH
-                        ]
+                            IMAGE_UPGRADE     : IMAGE_UPGRADE
+                        ],
+
+                        extra_envs: extraEnvs
                     ])
 
                     currentBuild.displayName = "#${currentBuild.number} ${GIT_BRANCH}"
@@ -168,7 +166,10 @@ pipeline {
                         echo 'All tests will be re-run, ignoring previous execution results!'
                     }
 
-                    libraries.tests.loadCloudSecret('psmdb')
+                    libraries.tests.loadCloudSecret(testVariables.operator)
+
+                    stash includes: 'cloud/**', name: 'pipelineFILES'
+                    stash includes: 'source/**', name: 'sourceFILES', useDefaultExcludes: false
                 }
             }
         }
@@ -180,6 +181,7 @@ pipeline {
                     testVariables.numClusters = numClusters
                     testVariables.kubeconfigPath = '/tmp'
                     testVariables.retries = 1
+                    testVariables.jenkins_agent_label = params.JENKINS_AGENT == 'Hetzner' ? 'docker-x64-min' : 'min-al2023-x64'
 
                     // Creates clusters in parallel and runs tests in parallel on each cluster
                     parallel libraries.tests.buildParallelClusterStages(testVariables)
@@ -209,7 +211,7 @@ pipeline {
                         platformChannel: testVariables.platform_channel,
                         platformArch   : testVariables.platform_arch,
                         clusterWide    : testVariables.cluster_wide,
-                        image          : testVariables.images.IMAGE_MONGOD,
+                        image          : testVariables.images.IMAGE_POSTGRESQL,
                         operatorImage  : testVariables.images.IMAGE_OPERATOR
                     )
                 } catch (err) {
@@ -236,6 +238,8 @@ pipeline {
                 libraries.tools.dockerCleanupVolumes()
             }
 
+            junit testResults: '*.xml', healthScaleFactor: 1.0, allowEmptyResults: true
+            archiveArtifacts artifacts: '*.xml,*.txt', allowEmptyArchive: true
             deleteDir()
         }
     }


### PR DESCRIPTION
Add support for running KUTTL tests across multiple nodes using parallel stages:

  - Introduce stash and unstash to ensure the same source code is available across all Jenkins agents.
  - Add a prepareNode function to centralize and standardize dependency installation based on the operator, test executor, and cloud provider.