### PR TITLE
PMM-15319 Remove unused test_db seeding step

### DIFF
--- a/pmm/v3/pmm3-api-tests.groovy
+++ b/pmm/v3/pmm3-api-tests.groovy
@@ -70,7 +70,6 @@ pipeline {
                     -v ${PWD}/managed/testdata/checks:/srv/checks \
                     ${DOCKER_VERSION}
 
-                    docker compose -f api-tests/docker-compose.yml up test_db
                     DOCKER_IMAGE=local/pmm-api-tests make -C api-tests docker-build-image
                 '''
                 script {


### PR DESCRIPTION
## What

Drops the `docker compose -f api-tests/docker-compose.yml up test_db` step from the `API Tests Setup` stage of `pmm/v3/pmm3-api-tests.groovy`.

## Why

The step seeds sample databases that nothing in this pipeline consumes.

`aleksi/test_db:1.1.0` is a data-only image (its command is `sh`). Running it populates the named volumes `test_db_mysql` and `test_db_postgres` from the image content, so that the `mysql` and `postgres` compose services can mount them as entrypoint init scripts and boot with the `world` sample schema.

This pipeline never starts those services. It runs a bare `pmm-server` container and then the API test image — that `docker compose up test_db` is its only compose invocation. The seeded volumes have no reader.

Nor do the tests need them. Nothing under `api-tests/` in percona/pmm references `test_db`, `world`, or the compose DB hostnames; management tests register services against placeholder addresses like `10.10.10.10` and pass `SkipConnectionCheck` at 195 call sites across 25 files, so pmm-managed never dials the target. The only tests that would need a live database are skipped, or target the pmm-server node itself.

So every run of this job pulls a 219 MB image from Docker Hub and fills two volumes nobody reads.

## Sequencing

This is step 1 of 3, tracked in [PMM-15319](https://perconadev.atlassian.net/browse/PMM-15319). Follow-ups in percona/pmm remove the same step from `.github/workflows/api-tests.yml` and then the `test_db` service from `api-tests/docker-compose.yml`. This PR has to land first: the pipeline references the compose service by name, and removing the compose entry ahead of it would fail the job with "no such service".

The `hub.docker.com` login stays — `${DOCKER_VERSION}` is still pulled from Docker Hub.

## Test plan

Run `pmm3-api-tests` on this branch and confirm the same test count as a recent `master` run, with no `aleksi/test_db` pull in the log.

[PMM-15319]: https://perconadev.atlassian.net/browse/PMM-15319?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

Tests passed: ✅ https://pmm.cd.percona.com/job/pmm3-api-tests/6973/console