### PR TITLE
DISTMYSQL-630: Molecule subnet vars cover all three eu-central-1 zones

### DIFF
--- a/vars/moleculeEnvPPG.groovy
+++ b/vars/moleculeEnvPPG.groovy
@@ -41,7 +41,7 @@ def call() {
         export region=eu-central-1
         export vpc_subnet_id_aws1=subnet-0775d65ad1e9703bc
         export vpc_subnet_id_aws2=subnet-09947b46d69590c50
-        export vpc_subnet_id_aws3=subnet-0fad4db6fdd8025b6
+        export vpc_subnet_id_aws3=subnet-0c72f5b07120e4805
         export driver=ec2
     """
 }


### PR DESCRIPTION
**Feature**
- `vpc_subnet_id_aws3` now points at the new eu-central-1a subnet, so the PPG molecule subnet vars cover one zone each (`aws1`=1b, `aws2`=1c, `aws3`=1a)

**Why**
- A single-zone on-demand capacity shortage stalled PPG package tests; every heavy scenario pins the 1c subnet and the VPC had no 1a leg to escape to
- `aws3` duplicated `aws1`'s zone and has zero consumers in ppg-testing, so the repoint changes no running scenario
- The subnet exists and is verified live (public route table, public IPs on launch), applied via the platform repo

**Tickets**
- [DISTMYSQL-630](https://perconadev.atlassian.net/browse/DISTMYSQL-630) (this), companion [percona-cd-platform PR 411](https://github.com/percona/percona-cd-platform/pull/411) (merged)

[DISTMYSQL-630]: https://perconadev.atlassian.net/browse/DISTMYSQL-630?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ