### PR TITLE
DISTMYSQL-632: Survive spot reclaim in innodb-cluster package tests

### DIFF
--- a/ps/jenkins/test-ps-innodb-cluster.groovy
+++ b/ps/jenkins/test-ps-innodb-cluster.groovy
@@ -157,6 +157,7 @@ pipeline {
 
     options {
         skipDefaultCheckout()
+        retry(count: 2, conditions: [agent()])
     }
 
     environment {


### PR DESCRIPTION
**Bug**
- Spot reclaim of a branch worker aborts the whole `test-ps-innodb-cluster` run and skips molecule cleanup; one reclaim wave killed all 22 branches of a run

**Fix**
- `retry(count: 2, conditions: [agent()])` on the child pipeline: the branch re-runs on a fresh agent only when the agent is lost, genuine test failures never retry
- The parallel parent stays retry-free: interrupting its build steps cancels running children, and a parent retry would re-trigger the whole fan-out

**Tickets**
- [DISTMYSQL-632](https://perconadev.atlassian.net/browse/DISTMYSQL-632) (this), [PS-11265](https://perconadev.atlassian.net/browse/PS-11265) (pattern validated on parallel-mtr)

[DISTMYSQL-632]: https://perconadev.atlassian.net/browse/DISTMYSQL-632?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[PS-11265]: https://perconadev.atlassian.net/browse/PS-11265?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ