### PR TITLE
PKG-1444: Stop rescue kernels from filling /boot on Rocky test AMIs

### DIFF
--- a/ppg/packer/scripts/provision.sh
+++ b/ppg/packer/scripts/provision.sh
@@ -6,6 +6,39 @@
 # cloud-init + machine-id below so a launched instance re-initialises.
 set -euxo pipefail
 
+# /boot hygiene, before the update so the kernel transaction has room. Rocky
+# images ship dracut-config-rescue, and the machine-id reset below gives every
+# chained bake a fresh machine id, so each kernel-installing bake added one
+# more ~90MB rescue pair (dracut's rescue hook keys its state by machine id
+# and never cleans other ids'). Five pairs filled the fixed 936MB /boot and
+# kernel updates started failing mid-transaction. CI images never boot the
+# rescue entry: stop generating it, drop accumulated pairs, and purge loader
+# entries that point at removed kernels. Every step no-ops on images without
+# the rescue package or without a separate /boot (Oracle Linux).
+if rpm -q dracut-config-rescue >/dev/null 2>&1; then
+  dnf -y remove dracut-config-rescue
+fi
+
+rm -f /boot/vmlinuz-0-rescue-* /boot/initramfs-0-rescue-* /boot/.vmlinuz-0-rescue-*.hmac
+rm -f /boot/loader/entries/*-0-rescue*.conf
+
+for entry in /boot/loader/entries/*.conf; do
+  [[ -e "${entry}" ]] || continue
+  image="$(sed -n 's/^linux //p' "${entry}")"
+  if [[ -n "${image}" && ! -e "/boot${image}" ]]; then
+    rm -f "${entry}"
+  fi
+done
+
+# The update needs old+new kernel on /boot at once, plus the ~80MB initramfs
+# dracut writes after rpm's disk check. Fail here, with a clear message,
+# rather than mid-transaction.
+boot_free_mb="$(df -BM --output=avail /boot | tail -1 | tr -dc '0-9')"
+if (( boot_free_mb < 200 )); then
+  echo "PROVISION FAIL: /boot has ${boot_free_mb}MB free, need >= 200MB for a kernel update" >&2
+  exit 1
+fi
+
 # Core refresh: this is what the manual process did by hand.
 dnf -y update
 

--- a/ppg/packer/scripts/validate.sh
+++ b/ppg/packer/scripts/validate.sh
@@ -78,6 +78,17 @@ else
   printf '%s\n' "${pending}"
 fi
 
+# 8. /boot keeps headroom for the next chained bake and for consumer-side
+#    kernel updates (rescue-pair creep filled it once, provision.sh now cleans
+#    it; images whose /boot lives on the root filesystem pass trivially).
+boot_free_mb="$(df -BM --output=avail /boot | tail -1 | tr -dc '0-9')"
+
+if (( boot_free_mb < 260 )); then
+  fail "/boot has only ${boot_free_mb}MB free (need >= 260MB)"
+fi
+
+echo "  /boot ok: ${boot_free_mb}MB free"
+
 echo "VALIDATE OK: ${OS} ${OS_MAJOR} ${UNAME_ARCH}"
 # De-instancing is native now: packer `ssh_clear_authorized_keys` strips the temp
 # key, and cloud-init's default `ssh_deletekeys: true` regenerates host keys on


### PR DESCRIPTION
**Bug**
- Rocky 9/10 molecule converges fail with `installing package kernel-core-... needs 28-45MB more space on the /boot filesystem`: each kernel-installing weekly bake left one more ~90MB rescue kernel pair on the fixed 936MB `/boot` (machine-id reset + dracut rescue hook), and the newest generation shipped with 10MB free
- The next scheduled bake runs the same failing transaction, so the Rocky lineages would stop producing AMIs

**Fix**
- provision.sh: before the update, remove `dracut-config-rescue`, accumulated rescue pairs, and loader entries pointing at removed kernels, then fail closed if `/boot` has under 200MB free
- validate.sh: fail the bake when the finished image keeps under 260MB free on `/boot`
- No-ops on Oracle Linux (no rescue package, `/boot` on the root filesystem)

**Tickets**
- [PKG-1444](https://perconadev.atlassian.net/browse/PKG-1444) (this)

[PKG-1444]: https://perconadev.atlassian.net/browse/PKG-1444?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ