### PR TITLE
Bump Trivy to 0.74.0 in installTrivy shared library

### DIFF
--- a/vars/installTrivy.groovy
+++ b/vars/installTrivy.groovy
@@ -11,9 +11,9 @@
 //   installTrivy(htmlTpl: true)                      // also download html.tpl
 
 def call(Map args = [:]) {
-    def TRIVY_VERSION    = "0.71.0"
-    def CHECKSUM_AMD64   = "30a3d22b23f88c233f1658f562fb477cae3b3e8b4761109d515b7698daf85814"
-    def CHECKSUM_ARM64   = "2561be394a3199c911f82fced606cbc05e1cb23eb6ce1da6935540adb76f4252"
+    def TRIVY_VERSION    = "0.74.0"
+    def CHECKSUM_AMD64   = "2ae6fe3ee734b7fdf11335663e18c75ea12dccc76062f09f164a3b0f8be4371a"
+    def CHECKSUM_ARM64   = "b94ce1976bbf3c15b514b605ee88be7c6d94a29be2302847ff01cb794d47aad5"
     def CHECKSUM_HTMLTPL = "d36b637cc77bc1a49b1f9a2358173756cd27a5d3385fab6365c0bab09abe5f0a"
 
     def method    = args.get('method', 'auto')


### PR DESCRIPTION
Update TRIVY_VERSION and the AMD64/ARM64 binary checksums, verified live against the official v0.74.0 release; html.tpl checksum is unchanged since that file is identical across versions.