### PR TITLE
Auto-update OL/Rocky molecule AMI IDs weekly instead of resolving at test time

### DIFF
--- a/.github/workflows/ppg-ami-factory.yml
+++ b/.github/workflows/ppg-ami-factory.yml
@@ -180,6 +180,48 @@ jobs:
           done
           echo "- promote: $pr" >> "$GITHUB_STEP_SUMMARY"
 
+  update-molecule-env:
+    name: Update moleculeEnvPPG.groovy (OL/Rocky AMI IDs)
+    needs: bake
+    # Only after a real weekly rebake — never on manual/PR/push runs, where a
+    # partial or test-env combo list must not overwrite the pinned AMI IDs.
+    if: success() && github.event_name == 'schedule'
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: write
+      id-token: write
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          ref: master
+
+      - name: Configure AWS credentials (OIDC)
+        uses: aws-actions/configure-aws-credentials@7474bc4690e29a8392af63c5b98e7449536d5c3a # v4.3.1
+        with:
+          role-to-assume: ${{ secrets.PPG_AMI_FACTORY_ROLE_ARN || 'arn:aws:iam::119175775298:role/percona-ci-platform-gha-ppg-ami-factory' }}
+          role-session-name: ppg-ami-factory-update-env-${{ github.run_id }}-${{ github.run_attempt }}
+          aws-region: ${{ env.AWS_REGION }}
+
+      - name: Resolve latest OL/Rocky AMIs and rewrite moleculeEnvPPG.groovy
+        run: |
+          set -euo pipefail
+          python3 -m pip install --quiet boto3
+          python3 ppg/packer/scripts/update_molecule_env.py
+
+      - name: Commit and push if changed
+        run: |
+          set -euo pipefail
+          if git diff --quiet -- vars/moleculeEnvPPG.groovy; then
+            echo "no AMI ID changes; nothing to commit"
+            exit 0
+          fi
+          git config user.name "ppg-ami-factory-bot"
+          git config user.email "actions@github.com"
+          git add vars/moleculeEnvPPG.groovy
+          git commit -m "Auto-update OL/Rocky molecule AMI IDs (weekly ppg-ami-factory refresh)"
+          git push origin HEAD:master
+
   notify:
     needs: bake
     # failure() is true when ANY ancestor failed, including a check failure on a

--- a/.github/workflows/ppg-ami-factory.yml
+++ b/.github/workflows/ppg-ami-factory.yml
@@ -1,8 +1,9 @@
 # EL package-test AMI factory: Oracle Linux + Rocky Linux.
 # Bakes OL and Rocky 8/9/10 x86_64+arm64 AMIs with Packer over AWS Session
 # Manager (no inbound SSH), authenticated via GitHub OIDC (no static keys), and
-# promotes each via a fresh-boot smoke test. Consumer: pg.cd molecule jobs select
-# the newest role=ppg-package-test AMI by tag (vars/moleculeEnvPPG.groovy).
+# promotes each via a fresh-boot smoke test. Consumer: pg.cd molecule jobs use
+# the static AMI pins in vars/moleculeEnvPPG.groovy, refreshed weekly by the
+# update-molecule-env job through an auto-opened PR.
 # Rocky lineage roots are seeded once per combo via dispatch (just ci-seed-rocky).
 #
 # Triggers: PR validate-only (pull_request -> check job, no AWS), recipe change
@@ -183,13 +184,16 @@ jobs:
   update-molecule-env:
     name: Update moleculeEnvPPG.groovy (OL/Rocky AMI IDs)
     needs: bake
-    # Only after a real weekly rebake — never on manual/PR/push runs, where a
-    # partial or test-env combo list must not overwrite the pinned AMI IDs.
-    if: success() && github.event_name == 'schedule'
+    # Weekly runs only, never manual/PR/push, where a partial or test-env combo
+    # list must not drive the pins. !cancelled() rather than success(): a partial
+    # bake still refreshes the pins, because the script resolves from the promote
+    # tags, so a failed combo simply keeps last week's AMI while the rest advance.
+    if: github.event_name == 'schedule' && !cancelled() && needs.bake.result != 'skipped'
     runs-on: ubuntu-latest
     timeout-minutes: 10
     permissions:
       contents: write
+      pull-requests: write
       id-token: write
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
@@ -206,24 +210,50 @@ jobs:
       - name: Resolve latest OL/Rocky AMIs and rewrite moleculeEnvPPG.groovy
         run: |
           set -euo pipefail
-          python3 -m pip install --quiet boto3
+          python3 -m pip install --quiet 'boto3==1.43.74' 'botocore==1.43.74'
           python3 ppg/packer/scripts/update_molecule_env.py
 
-      - name: Commit and push if changed
+      - name: Commit and open a PR if changed
+        # master rejects direct pushes (protected branch, changes must go through
+        # a pull request), so the refresh is published as a PR on one fixed rolling
+        # branch. Force-push keeps that branch current; an already-open PR is
+        # reused. Needs pull-requests: write plus the repo setting "Allow GitHub
+        # Actions to create and approve pull requests".
+        env:
+          GH_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail
           if git diff --quiet -- vars/moleculeEnvPPG.groovy; then
             echo "no AMI ID changes; nothing to commit"
             exit 0
           fi
+          branch=ppg-ami-refresh
           git config user.name "ppg-ami-factory-bot"
           git config user.email "actions@github.com"
+          git checkout -B "$branch"
           git add vars/moleculeEnvPPG.groovy
           git commit -m "Auto-update OL/Rocky molecule AMI IDs (weekly ppg-ami-factory refresh)"
-          git push origin HEAD:master
+          # The rolling branch is bot-owned and rebuilt from master every week;
+          # manual commits on it do not survive the next refresh.
+          git push --force origin "HEAD:$branch"
+          # Count only same-repo PRs: an unqualified --head also matches a fork
+          # PR whose head branch happens to share the name, which would skip
+          # creation here and silently leave the refresh unpublished.
+          open_prs=$(gh pr list --head "$branch" --base master --state open \
+            --json number,headRepositoryOwner \
+            --jq '[.[] | select(.headRepositoryOwner.login == "'"${GITHUB_REPOSITORY_OWNER}"'")] | length')
+          if [ "$open_prs" = "0" ]; then
+            gh pr create --head "$branch" --base master \
+              --title "Auto-update OL/Rocky molecule AMI IDs (weekly refresh)" \
+              --body "Weekly ppg-ami-factory refresh: OL/Rocky pins in vars/moleculeEnvPPG.groovy updated to the newest promoted AMIs (tag role=ppg-package-test). Opened automatically by the update-molecule-env job."
+          else
+            echo "open PR for $branch already exists; branch force-updated"
+          fi
 
   notify:
-    needs: bake
+    # update-molecule-env is listed so its failures (AMI resolution, PR creation)
+    # alert too; with needs: bake alone they would stay Slack-silent.
+    needs: [bake, update-molecule-env]
     # failure() is true when ANY ancestor failed, including a check failure on a
     # pull_request run where bake was skipped. Never ping the webhook for PR lint.
     if: failure() && github.event_name != 'pull_request'

--- a/ppg/packer/README.md
+++ b/ppg/packer/README.md
@@ -73,8 +73,8 @@ template ONLY validates; **promotion to `role=ppg-package-test` is a separate,
 retried step** in the `justfile`/workflow that runs after a passing smoke, so a
 transient tag-API failure can never deregister a smoke-passed AMI. A real
 boot/install failure deregisters the candidate + its snapshots.
-The jobs and the next build's source filter select only `role=ppg-package-test`,
-so a non-booting image is never selectable and AMI IDs are never pinned.
+The pin refresh and the next build's source filter select only
+`role=ppg-package-test`, so a non-booting image is never selectable.
 Login user: `ec2-user` on OL, `rocky` on Rocky (the images keep their distro's
 cloud-init default user, matching what the molecule scenarios already use). "Latest"
 is the newest `role=ppg-package-test` AMI by `CreationDate` (no SSM parameter).
@@ -96,19 +96,17 @@ just ci-validate         # trigger the GHA workflow matrix (env=test)
 just ci-seed-rocky       # dispatch all six Rocky seeds (env=prod; every combo must be seeded once)
 ```
 
-## Job AMI lookup (replaces hardcoded IDs)
+## Job AMI lookup (static pins, refreshed weekly)
 
-`vars/moleculeEnvPPG.groovy` resolves each Oracle target at pipeline time
-(fail-closed: the job aborts if no base AMI is found). A follow-up PR switches
-the pg.cd jobs' Rocky targets to the same lookup with `Name=tag:os,Values=rocky`:
-
-```bash
-ami_ol9_x86_64=$(aws ec2 describe-images --region eu-central-1 --owners self \
-  --filters Name=tag:role,Values=ppg-package-test Name=tag:os,Values=oraclelinux \
-            Name=tag:os_major,Values=9 Name=tag:arch,Values=x86_64 \
-            Name=state,Values=available \
-  --query 'sort_by(Images,&CreationDate)[-1].ImageId' --output text)
-```
+`vars/moleculeEnvPPG.groovy` carries static `export ami_*` pins for the OL and
+Rocky targets, same as the RHEL/Debian/Ubuntu entries. The `update-molecule-env`
+job in `ppg-ami-factory.yml` re-resolves the newest promoted AMI per
+os+major+arch (tag `role=ppg-package-test`, via
+`scripts/update_molecule_env.py`) after the weekly bake and publishes the new
+pins on the rolling `ppg-ami-refresh` branch, opening a PR when one is not
+already open. Resolution no longer happens at pipeline time: 30 parallel molecule
+stages each firing 12 `DescribeImages` calls tripped the account-wide EC2 rate
+limit.
 
 ## Validation gates (fail-closed)
 

--- a/ppg/packer/scripts/update_molecule_env.py
+++ b/ppg/packer/scripts/update_molecule_env.py
@@ -1,0 +1,126 @@
+#!/usr/bin/env python3
+"""Resolve the newest role=ppg-package-test AMI for every OL/Rocky
+os+major+arch combo and rewrite vars/moleculeEnvPPG.groovy's static
+export lines to match.
+
+Run weekly by the update-molecule-env job in ppg-ami-factory.yml,
+after a fully successful bake — this replaces the dynamic
+DescribeImages-at-test-time resolution (which every parallel molecule
+job used to do independently, and which could trip the account-wide
+DescribeImages rate limit under load) with a single resolution done
+once here, matching how RHEL/Ubuntu/Debian are already hand-pinned.
+
+Fails closed: if any combo fails to resolve, exits non-zero without
+writing anything, so a partial factory failure (or a transient API
+error) never corrupts the file — last week's still-valid AMI IDs are
+left in place untouched, and this job simply tries again next week.
+"""
+import re
+import sys
+
+REGION = "eu-central-1"
+# (tag:os value, moleculeEnvPPG.groovy var prefix, tag:os_major value)
+COMBOS = [
+    ("oraclelinux", "ol", "8"),
+    ("oraclelinux", "ol", "9"),
+    ("oraclelinux", "ol", "10"),
+    ("rocky", "rocky", "8"),
+    ("rocky", "rocky", "9"),
+    ("rocky", "rocky", "10"),
+]
+ARCHES = ["x86_64", "arm64"]
+
+# Matches the whole comment block explaining the old dynamic-resolution
+# design, plus the _ppg_ami() helper definition itself — both dead once
+# every combo below is a static export. Only matches when the comment
+# block is immediately followed by the helper definition, so it can
+# never eat an unrelated comment elsewhere in the file. A no-op (no
+# match) on every run after the first, once this has already been removed.
+_HELPER_BLOCK_RE = re.compile(
+    r"(?:^ {8}#[^\n]*\n)+^ {8}_ppg_ami\(\)[^\n]*\n",
+    re.MULTILINE,
+)
+
+
+def resolve_all(client):
+    """Query AWS once per combo; return {var_name: ami_id}. Raises/exits
+    via caller on any missing resolution — see fail-closed note above."""
+    resolved = {}
+    missing = []
+    for os_name, var_prefix, major in COMBOS:
+        for arch in ARCHES:
+            var = f"ami_{var_prefix}{major}_{arch}"
+            images = client.describe_images(
+                Owners=["self"],
+                Filters=[
+                    {"Name": "tag:role", "Values": ["ppg-package-test"]},
+                    {"Name": "tag:os", "Values": [os_name]},
+                    {"Name": "tag:os_major", "Values": [major]},
+                    {"Name": "tag:arch", "Values": [arch]},
+                    {"Name": "state", "Values": ["available"]},
+                ],
+            )["Images"]
+            if not images:
+                missing.append(var)
+                continue
+            newest = sorted(images, key=lambda x: x["CreationDate"])[-1]
+            resolved[var] = newest["ImageId"]
+            print(f"resolved {var} = {newest['ImageId']}")
+    if missing:
+        raise RuntimeError(f"no available AMI found for: {', '.join(missing)}")
+    return resolved
+
+
+def rewrite_file(content, resolved):
+    """Pure text transform: given the current file content and a dict of
+    {var_name: ami_id}, return the new content. Raises ValueError if any
+    var's line can't be found/replaced exactly once, or if the helper
+    block removal is ambiguous — never silently do a partial rewrite."""
+    content = _HELPER_BLOCK_RE.sub("", content, count=1)
+
+    for var, ami in resolved.items():
+        pattern = re.compile(r"^( *)(?:export )?" + re.escape(var) + r"=.*$", re.MULTILINE)
+        new_content, n = pattern.subn(r"\1export " + var + "=" + ami, content)
+        if n != 1:
+            raise ValueError(f"expected exactly 1 line for {var}, found {n}")
+        content = new_content
+
+    return content
+
+
+def main():
+    import boto3
+    import botocore.config as C
+
+    client = boto3.client(
+        "ec2",
+        region_name=REGION,
+        config=C.Config(retries={"max_attempts": 10, "mode": "adaptive"}),
+    )
+    try:
+        resolved = resolve_all(client)
+    except RuntimeError as e:
+        print(f"FAIL: {e}", file=sys.stderr)
+        sys.exit(1)
+
+    path = "vars/moleculeEnvPPG.groovy"
+    with open(path) as f:
+        content = f.read()
+
+    try:
+        new_content = rewrite_file(content, resolved)
+    except ValueError as e:
+        print(f"FAIL: {e}", file=sys.stderr)
+        sys.exit(1)
+
+    if new_content == content:
+        print("no changes (all AMI IDs already up to date)")
+        return
+
+    with open(path, "w") as f:
+        f.write(new_content)
+    print(f"updated {path}")
+
+
+if __name__ == "__main__":
+    main()

--- a/ppg/packer/scripts/update_molecule_env.py
+++ b/ppg/packer/scripts/update_molecule_env.py
@@ -3,17 +3,19 @@
 os+major+arch combo and rewrite vars/moleculeEnvPPG.groovy's static
 export lines to match.
 
-Run weekly by the update-molecule-env job in ppg-ami-factory.yml,
-after a fully successful bake — this replaces the dynamic
-DescribeImages-at-test-time resolution (which every parallel molecule
-job used to do independently, and which could trip the account-wide
-DescribeImages rate limit under load) with a single resolution done
-once here, matching how RHEL/Ubuntu/Debian are already hand-pinned.
+Run weekly by the update-molecule-env job in ppg-ami-factory.yml.
+This replaces the dynamic DescribeImages-at-test-time resolution
+(which every parallel molecule job used to do independently, and
+which could trip the account-wide DescribeImages rate limit under
+load) with a single resolution done once here, matching how
+RHEL/Ubuntu/Debian are already hand-pinned. It runs even after a
+partial bake: each combo resolves to its newest promoted AMI, so a
+failed combo keeps last week's image while the others advance.
 
 Fails closed: if any combo fails to resolve, exits non-zero without
-writing anything, so a partial factory failure (or a transient API
-error) never corrupts the file — last week's still-valid AMI IDs are
-left in place untouched, and this job simply tries again next week.
+writing anything, so a wiped-out factory (or a transient API error)
+never corrupts the file: last week's still-valid AMI IDs are left in
+place untouched, and this job simply tries again next week.
 """
 import re
 import sys
@@ -74,8 +76,8 @@ def resolve_all(client):
 def rewrite_file(content, resolved):
     """Pure text transform: given the current file content and a dict of
     {var_name: ami_id}, return the new content. Raises ValueError if any
-    var's line can't be found/replaced exactly once, or if the helper
-    block removal is ambiguous — never silently do a partial rewrite."""
+    var's line can't be found/replaced exactly once, so a partial rewrite
+    is never written. Helper-block removal is a no-op once already gone."""
     content = _HELPER_BLOCK_RE.sub("", content, count=1)
 
     for var, ami in resolved.items():

--- a/vars/moleculeEnvPPG.groovy
+++ b/vars/moleculeEnvPPG.groovy
@@ -3,38 +3,30 @@ def call() {
         export ami_debian11_x86_64=ami-06687054858616b40
         export ami_debian12_x86_64=ami-0fe0ff90aca4c9a3d
         export ami_debian13_x86_64=ami-00baf448a290e0604
-        # Oracle Linux + Rocky Linux AMIs: resolved dynamically to the newest
-        # factory-built base per os+major+arch (tag role=ppg-package-test) so they
-        # auto-update on each rebake instead of being hand-pinned. boto3 (not the aws CLI):
-        # the molecule agent has boto3 (installMoleculePython39) but not always the CLI.
-        # Fail-closed: assign on its own line (a bare assignment propagates the
-        # helper's non-zero exit; an inline 'export VAR=...' masks it as export's
-        # status), then '|| exit 1' aborts the step rather than launch an empty image.
-        _ppg_ami() { python3 -c "import sys,boto3,botocore.config as C; m,a,o=sys.argv[1],sys.argv[2],sys.argv[3]; i=sorted(boto3.client('ec2',region_name='eu-central-1',config=C.Config(retries={'max_attempts':8,'mode':'standard'})).describe_images(Owners=['self'],Filters=[{'Name':'tag:role','Values':['ppg-package-test']},{'Name':'tag:os','Values':[o]},{'Name':'tag:os_major','Values':[m]},{'Name':'tag:arch','Values':[a]},{'Name':'state','Values':['available']}])['Images'],key=lambda x:x['CreationDate']); sys.stdout.write(i[-1]['ImageId'] if i else ''); sys.exit(0 if i else 1)" "\$1" "\$2" "\$3"; }
-        ami_ol8_x86_64=\$(_ppg_ami 8 x86_64 oraclelinux) || exit 1; export ami_ol8_x86_64
-        ami_ol9_x86_64=\$(_ppg_ami 9 x86_64 oraclelinux) || exit 1; export ami_ol9_x86_64
-        ami_ol10_x86_64=\$(_ppg_ami 10 x86_64 oraclelinux) || exit 1; export ami_ol10_x86_64
+        export ami_ol8_x86_64=ami-0e0e998c65a976999
+        export ami_ol9_x86_64=ami-0ff577495b12a61d0
+        export ami_ol10_x86_64=ami-02dfdbeca8fff8b2c
         export ami_rhel8_x86_64=ami-07a95227ea69ac5a7
         export ami_rhel9_x86_64=ami-035f430eefe0c383c
         export ami_rhel10_x86_64=ami-0ef84e5fc5f7d6606
-        ami_rocky8_x86_64=\$(_ppg_ami 8 x86_64 rocky) || exit 1; export ami_rocky8_x86_64
-        ami_rocky9_x86_64=\$(_ppg_ami 9 x86_64 rocky) || exit 1; export ami_rocky9_x86_64
-        ami_rocky10_x86_64=\$(_ppg_ami 10 x86_64 rocky) || exit 1; export ami_rocky10_x86_64
+        export ami_rocky8_x86_64=ami-01ec023360d049e24
+        export ami_rocky9_x86_64=ami-0e06b7199317035de
+        export ami_rocky10_x86_64=ami-02a4dd3a5a286b9be
         export ami_ubuntu22_x86_64=ami-0ae88d5843aab690d
         export ami_ubuntu24_x86_64=ami-04bc554a9635a77c8
         export ami_ubuntu26_x86_64=ami-0f60f7b735e5e576c
         export ami_debian11_arm64=ami-08e24dd64c14e3365
         export ami_debian12_arm64=ami-03737899470c20c63
         export ami_debian13_arm64=ami-009aa536d30f23947
-        ami_ol8_arm64=\$(_ppg_ami 8 arm64 oraclelinux) || exit 1; export ami_ol8_arm64
-        ami_ol9_arm64=\$(_ppg_ami 9 arm64 oraclelinux) || exit 1; export ami_ol9_arm64
-        ami_ol10_arm64=\$(_ppg_ami 10 arm64 oraclelinux) || exit 1; export ami_ol10_arm64
+        export ami_ol8_arm64=ami-071bae27d870de243
+        export ami_ol9_arm64=ami-0515e1daa5133a795
+        export ami_ol10_arm64=ami-06e30caa5194c5376
         export ami_rhel8_arm64=ami-04621017594ba750b
         export ami_rhel9_arm64=ami-094c0b306a78f3e3a
         export ami_rhel10_arm64=ami-05d5565696a1fbcc5
-        ami_rocky8_arm64=\$(_ppg_ami 8 arm64 rocky) || exit 1; export ami_rocky8_arm64
-        ami_rocky9_arm64=\$(_ppg_ami 9 arm64 rocky) || exit 1; export ami_rocky9_arm64
-        ami_rocky10_arm64=\$(_ppg_ami 10 arm64 rocky) || exit 1; export ami_rocky10_arm64
+        export ami_rocky8_arm64=ami-0070049a80bb9feeb
+        export ami_rocky9_arm64=ami-02b7184cdfa7cad8c
+        export ami_rocky10_arm64=ami-0790a371ac070a029
         export ami_ubuntu22_arm64=ami-002da4b711811778d
         export ami_ubuntu24_arm64=ami-0c355ec49d386672d
         export ami_ubuntu26_arm64=ami-0f89bfe113307ab25


### PR DESCRIPTION
Adds an update-molecule-env job that runs after a successful weekly bake and rewrites vars/moleculeEnvPPG.groovy with the newest AMI per os+major+arch, replacing the dynamic DescribeImages call every parallel molecule job used to make independently (source of the RequestLimitExceeded errors) with a single resolution done once here, matching how RHEL/Ubuntu/Debian are already hand-pinned.