### PR TITLE
DISTMYSQL-638: Let pxb previews test fork changes to build scripts

### DIFF
--- a/pxb/v2/jenkins/percona-xtrabackup-2.4-compile-pipeline.groovy
+++ b/pxb/v2/jenkins/percona-xtrabackup-2.4-compile-pipeline.groovy
@@ -69,7 +69,7 @@ pipeline {
                         fi
                         rm -f ${WORKSPACE}/XB_VERSION-${BUILD_NUMBER}
                     '''
-                    git branch: 'master', url: 'https://github.com/Percona-Lab/jenkins-pipelines'
+                    checkout scm
                     withCredentials([[$class: 'AmazonWebServicesCredentialsBinding', accessKeyVariable: 'AWS_ACCESS_KEY_ID', credentialsId: '24e68886-c552-4033-8503-ed85bbaa31f3', secretKeyVariable: 'AWS_SECRET_ACCESS_KEY']]) {
                         sh '''
                             # sudo is needed for better node recovery after compilation failure

--- a/pxb/v2/jenkins/percona-xtrabackup-2.4-test-pipeline.groovy
+++ b/pxb/v2/jenkins/percona-xtrabackup-2.4-test-pipeline.groovy
@@ -61,7 +61,7 @@ pipeline {
                         currentBuild.displayName = "${BUILD_NUMBER} ${CMAKE_BUILD_TYPE}/${DOCKER_OS}"
                     }
                     sh 'echo Prepare: \$(date -u "+%s")'
-                    git branch: 'master', url: 'https://github.com/Percona-Lab/jenkins-pipelines'
+                    checkout scm
                     sh '''
                         # sudo is needed for better node recovery after compilation failure
                         # if building failed on compilation stage directory will have files owned by docker user

--- a/pxb/v2/jenkins/percona-xtrabackup-8.0-compile-pipeline.groovy
+++ b/pxb/v2/jenkins/percona-xtrabackup-8.0-compile-pipeline.groovy
@@ -74,7 +74,7 @@ pipeline {
                         fi
                         rm -f ${WORKSPACE}/XB_VERSION-${BUILD_NUMBER}
                     '''
-                    git branch: 'master', url: 'https://github.com/Percona-Lab/jenkins-pipelines'
+                    checkout scm
                     withCredentials([[$class: 'AmazonWebServicesCredentialsBinding', accessKeyVariable: 'AWS_ACCESS_KEY_ID', credentialsId: '24e68886-c552-4033-8503-ed85bbaa31f3', secretKeyVariable: 'AWS_SECRET_ACCESS_KEY']]) {
                         sh '''#!/bin/bash
                             # sudo is needed for better node recovery after compilation failure

--- a/pxb/v2/jenkins/percona-xtrabackup-8.0-test-cloud-pipeline.groovy
+++ b/pxb/v2/jenkins/percona-xtrabackup-8.0-test-cloud-pipeline.groovy
@@ -67,7 +67,7 @@ pipeline {
                         currentBuild.displayName = "${BUILD_NUMBER} ${CMAKE_BUILD_TYPE}/${DOCKER_OS}"
                     }
                     sh 'echo Prepare: \$(date -u "+%s")'
-                    git branch: 'master', url: 'https://github.com/Percona-Lab/jenkins-pipelines'
+                    checkout scm
                     sh '''
                         # sudo is needed for better node recovery after compilation failure
                         # if building failed on compilation stage directory will have files owned by docker user

--- a/pxb/v2/jenkins/percona-xtrabackup-8.0-test-pipeline.groovy
+++ b/pxb/v2/jenkins/percona-xtrabackup-8.0-test-pipeline.groovy
@@ -77,7 +77,7 @@ pipeline {
                         currentBuild.displayName = "${BUILD_NUMBER} ${CMAKE_BUILD_TYPE}/${DOCKER_OS}"
                     }
                     sh 'echo Prepare: \$(date -u "+%s")'
-                    git branch: 'master', url: 'https://github.com/Percona-Lab/jenkins-pipelines'
+                    checkout scm
                     sh '''#!/bin/bash
                         # sudo is needed for better node recovery after compilation failure
                         # if building failed on compilation stage directory will have files owned by docker user

--- a/pxb/v2/jenkins/percona-xtrabackup-8.1-compile-pipeline.groovy
+++ b/pxb/v2/jenkins/percona-xtrabackup-8.1-compile-pipeline.groovy
@@ -73,7 +73,7 @@ pipeline {
                         fi
                         rm -f ${WORKSPACE}/XB_VERSION-${BUILD_NUMBER}
                     '''
-                    git branch: 'master', url: 'https://github.com/Percona-Lab/jenkins-pipelines'
+                    checkout scm
                     withCredentials([[$class: 'AmazonWebServicesCredentialsBinding', accessKeyVariable: 'AWS_ACCESS_KEY_ID', credentialsId: '24e68886-c552-4033-8503-ed85bbaa31f3', secretKeyVariable: 'AWS_SECRET_ACCESS_KEY']]) {
                         sh '''#!/bin/bash
                             # sudo is needed for better node recovery after compilation failure

--- a/pxb/v2/jenkins/percona-xtrabackup-8.1-test-cloud-pipeline.groovy
+++ b/pxb/v2/jenkins/percona-xtrabackup-8.1-test-cloud-pipeline.groovy
@@ -67,7 +67,7 @@ pipeline {
                         currentBuild.displayName = "${BUILD_NUMBER} ${CMAKE_BUILD_TYPE}/${DOCKER_OS}"
                     }
                     sh 'echo Prepare: \$(date -u "+%s")'
-                    git branch: 'master', url: 'https://github.com/Percona-Lab/jenkins-pipelines'
+                    checkout scm
                     sh '''
                         # sudo is needed for better node recovery after compilation failure
                         # if building failed on compilation stage directory will have files owned by docker user

--- a/pxb/v2/jenkins/percona-xtrabackup-8.1-test-pipeline.groovy
+++ b/pxb/v2/jenkins/percona-xtrabackup-8.1-test-pipeline.groovy
@@ -76,7 +76,7 @@ pipeline {
                         currentBuild.displayName = "${BUILD_NUMBER} ${CMAKE_BUILD_TYPE}/${DOCKER_OS}"
                     }
                     sh 'echo Prepare: \$(date -u "+%s")'
-                    git branch: 'master', url: 'https://github.com/Percona-Lab/jenkins-pipelines'
+                    checkout scm
                     sh '''#!/bin/bash
                         # sudo is needed for better node recovery after compilation failure
                         # if building failed on compilation stage directory will have files owned by docker user

--- a/pxb/v2/jenkins/percona-xtrabackup-9.x-compile-pipeline.groovy
+++ b/pxb/v2/jenkins/percona-xtrabackup-9.x-compile-pipeline.groovy
@@ -73,7 +73,7 @@ pipeline {
                         fi
                         rm -f ${WORKSPACE}/XB_VERSION-${BUILD_NUMBER}
                     '''
-                    git branch: 'master', url: 'https://github.com/Percona-Lab/jenkins-pipelines'
+                    checkout scm
                     withCredentials([[$class: 'AmazonWebServicesCredentialsBinding', accessKeyVariable: 'AWS_ACCESS_KEY_ID', credentialsId: '24e68886-c552-4033-8503-ed85bbaa31f3', secretKeyVariable: 'AWS_SECRET_ACCESS_KEY']]) {
                         sh '''#!/bin/bash
                             # sudo is needed for better node recovery after compilation failure

--- a/pxb/v2/jenkins/percona-xtrabackup-9.x-single-platform.groovy
+++ b/pxb/v2/jenkins/percona-xtrabackup-9.x-single-platform.groovy
@@ -108,7 +108,7 @@ pipeline {
                         fi
                         rm -f ${WORKSPACE}/XB_VERSION-${BUILD_NUMBER}
                     '''
-                    git branch: 'master', url: 'https://github.com/Percona-Lab/jenkins-pipelines'
+                    checkout scm
                     withCredentials([[$class: 'AmazonWebServicesCredentialsBinding', accessKeyVariable: 'AWS_ACCESS_KEY_ID', credentialsId: '24e68886-c552-4033-8503-ed85bbaa31f3', secretKeyVariable: 'AWS_SECRET_ACCESS_KEY']]) {
                         sh '''#!/bin/bash
                             sudo git reset --hard
@@ -143,7 +143,7 @@ pipeline {
             agent { label LABEL }
             steps {
                 timeout(time: 480, unit: 'MINUTES') {
-                    git branch: 'master', url: 'https://github.com/Percona-Lab/jenkins-pipelines'
+                    checkout scm
                     withCredentials([[$class: 'AmazonWebServicesCredentialsBinding', accessKeyVariable: 'AWS_ACCESS_KEY_ID', credentialsId: '24e68886-c552-4033-8503-ed85bbaa31f3', secretKeyVariable: 'AWS_SECRET_ACCESS_KEY']]) {
                         sh '''#!/bin/bash
                             sudo git reset --hard

--- a/pxb/v2/jenkins/percona-xtrabackup-9.x-test-pipeline.groovy
+++ b/pxb/v2/jenkins/percona-xtrabackup-9.x-test-pipeline.groovy
@@ -76,7 +76,7 @@ pipeline {
                         currentBuild.displayName = "${BUILD_NUMBER} ${CMAKE_BUILD_TYPE}/${DOCKER_OS}"
                     }
                     sh 'echo Prepare: \$(date -u "+%s")'
-                    git branch: 'master', url: 'https://github.com/Percona-Lab/jenkins-pipelines'
+                    checkout scm
                     sh '''#!/bin/bash
                         # sudo is needed for better node recovery after compilation failure
                         # if building failed on compilation stage directory will have files owned by docker user


### PR DESCRIPTION
**Feature**
- pxb v2 pipelines check out sources via `checkout scm`, so a build uses the repository and revision the job's SCM points at

**Why**
- The hardcoded git step always fetched build scripts from canonical master, so fork previews could not test changes to files like `pxb/v2/docker/run-test`
- Contributors resorted to overwriting production jobs to test
- Production jobs keep identical behavior, their SCM already points at canonical master

**Tickets**
- [DISTMYSQL-638](https://perconadev.atlassian.net/browse/DISTMYSQL-638) (this)

[DISTMYSQL-638]: https://perconadev.atlassian.net/browse/DISTMYSQL-638?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ