### PR TITLE
DISTMYSQL-639: Keep check-mysql-repo reports for 30 days

### DIFF
--- a/ps/jenkins/check_mysql_repo.groovy
+++ b/ps/jenkins/check_mysql_repo.groovy
@@ -56,7 +56,7 @@ pipeline {
     }
     options {
         disableConcurrentBuilds()
-        buildDiscarder(logRotator(numToKeepStr: '10', artifactNumToKeepStr: '10'))
+        buildDiscarder(logRotator(daysToKeepStr: '30', artifactDaysToKeepStr: '30'))
         timestamps()
     }
     stages {


### PR DESCRIPTION
**Bug**
- `check-mysql-repo` runs hourly but keeps only the last 10 builds, so a build survives about 10 hours and report artifact links shared in new-tag alerts return 404 by the time the team opens them (seen with the `mysql-cluster-8.0.48` report).

**Fix**
- Switch the build discarder to days-based retention, 30 days for builds and artifacts.

**Tickets**
- [DISTMYSQL-639](https://perconadev.atlassian.net/browse/DISTMYSQL-639) (this)

[DISTMYSQL-639]: https://perconadev.atlassian.net/browse/DISTMYSQL-639?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ