### PR TITLE
PMM-7 Set explicit helm timeout for the pmm-ha install

### DIFF
--- a/pmm/v3/pmm3-ha-rosa.groovy
+++ b/pmm/v3/pmm3-ha-rosa.groovy
@@ -727,6 +727,7 @@ EOF
                         # Install pmm-ha chart (creates component service accounts)
                         # Resource requests reduced for test clusters (defaults are higher for production)
                         helm upgrade --install pmm-ha helm-charts/charts/pmm-ha -n pmm \
+                            --timeout 20m \
                             --set secret.create=false \
                             --set secret.name=pmm-secret \
                             ${PMM_IMAGE_REPOSITORY:+--set image.repository=${PMM_IMAGE_REPOSITORY}} \


### PR DESCRIPTION
PMM-7 set explicit helm timeout for the pmm-ha install. Helm's default 5m timeout is too tight for a cold pull-through.