### PR TITLE
Add FORCE_RELEASE_RUN var

### DIFF
--- a/cloud/jenkins/pgo_aks.groovy
+++ b/cloud/jenkins/pgo_aks.groovy
@@ -286,6 +286,7 @@ void runTest(Integer TEST_ID) {
                     export KUBECONFIG=/tmp/$CLUSTER_NAME-$clusterSuffix
                     export PATH="\${KREW_ROOT:-\$HOME/.krew}/bin:\$PATH"
                     export SKIP_TEST_WARNINGS=$SKIP_TEST_WARNINGS
+                    [[ "$PILLAR_VERSION" != "none" ]] && export FORCE_RELEASE_RUN=1
 
                     kubectl kuttl test --config e2e-tests/kuttl.yaml --test "^$testName\$"
                 """

--- a/cloud/jenkins/pgo_doks.groovy
+++ b/cloud/jenkins/pgo_doks.groovy
@@ -271,6 +271,7 @@ void runTest(Integer TEST_ID) {
                         export KUBECONFIG=/tmp/$CLUSTER_NAME-$clusterSuffix
                         export PATH="\${KREW_ROOT:-\$HOME/.krew}/bin:\$PATH"
                         export SKIP_TEST_WARNINGS=$SKIP_TEST_WARNINGS
+                        [[ "$PILLAR_VERSION" != "none" ]] && export FORCE_RELEASE_RUN=1
 
                         kubectl kuttl test --config e2e-tests/kuttl.yaml --test "^$testName\$"
                     """

--- a/cloud/jenkins/pgo_eks.groovy
+++ b/cloud/jenkins/pgo_eks.groovy
@@ -332,6 +332,7 @@ void runTest(Integer TEST_ID) {
                         export KUBECONFIG=/tmp/$CLUSTER_NAME-$clusterSuffix
                         export PATH="\${KREW_ROOT:-\$HOME/.krew}/bin:\$PATH"
                         export SKIP_TEST_WARNINGS=$SKIP_TEST_WARNINGS
+                        [[ "$PILLAR_VERSION" != "none" ]] && export FORCE_RELEASE_RUN=1
 
                         kubectl kuttl test --config e2e-tests/kuttl.yaml --test "^$testName\$"
                     """

--- a/cloud/jenkins/pgo_gke.groovy
+++ b/cloud/jenkins/pgo_gke.groovy
@@ -294,6 +294,7 @@ void runTest(Integer TEST_ID) {
                     export KUBECONFIG=/tmp/$CLUSTER_NAME-$clusterSuffix
                     export PATH="\${KREW_ROOT:-\$HOME/.krew}/bin:\$PATH"
                     export SKIP_TEST_WARNINGS=$SKIP_TEST_WARNINGS
+                    [[ "$PILLAR_VERSION" != "none" ]] && export FORCE_RELEASE_RUN=1
 
                     kubectl kuttl test --config e2e-tests/kuttl.yaml --test "^$testName\$"
                 """

--- a/cloud/jenkins/pgo_minikube.groovy
+++ b/cloud/jenkins/pgo_minikube.groovy
@@ -209,6 +209,7 @@ void runTest(Integer TEST_ID) {
                     export IMAGE_LOGCOLLECTOR=$IMAGE_LOGCOLLECTOR
                     export PATH="\${KREW_ROOT:-\$HOME/.krew}/bin:\$PATH"
                     export SKIP_TEST_WARNINGS=$SKIP_TEST_WARNINGS
+                    [[ "$PILLAR_VERSION" != "none" ]] && export FORCE_RELEASE_RUN=1
 
                     kubectl kuttl test --config e2e-tests/kuttl.yaml --test "^$testName\$"
                 """

--- a/cloud/jenkins/pgo_openshift.groovy
+++ b/cloud/jenkins/pgo_openshift.groovy
@@ -348,6 +348,7 @@ void runTest(Integer TEST_ID) {
                     export KUBECONFIG=$WORKSPACE/openshift/$clusterSuffix/auth/kubeconfig
                     export PATH="\${KREW_ROOT:-\$HOME/.krew}/bin:\$PATH"
                     export SKIP_TEST_WARNINGS=$SKIP_TEST_WARNINGS
+                    [[ "$PILLAR_VERSION" != "none" ]] && export FORCE_RELEASE_RUN=1
 
                     kubectl kuttl test --config e2e-tests/kuttl.yaml --test "^$testName\$"
                 """

--- a/cloud/jenkins/pgo_rancher.groovy
+++ b/cloud/jenkins/pgo_rancher.groovy
@@ -107,6 +107,9 @@ pipeline {
                         SKIP_TEST_WARNINGS: SKIP_TEST_WARNINGS,
                         PG_VER: PG_VERSION
                     ]
+                    if ("${PILLAR_VERSION}" != "none") {
+                        extraEnvs.FORCE_RELEASE_RUN = '1'
+                    }
 
                     testVariables = libraries.tests.prepareVersions([
                         libraries             : libraries,


### PR DESCRIPTION
We have FORCE_RELEASE_RUN  variable in Functions. It is used to force using the images from release_versions for major upgrade tests. Export it in jenkins job for release runs (when PILLAR_VERSION is NOT empty).
